### PR TITLE
Ensure published binaries have the correct version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ GOMETALINTER=${GOMETALINTERBIN} --config=Gometalinter.json
 TESTPARALLELISM := 10
 
 build::
-	go install -ldflags "-X github.com/pulumi/pulumi-aws/pkg/version.Version=${VERSION}" ${PROJECT}/cmd/${TFGEN}
-	go install -ldflags "-X github.com/pulumi/pulumi-aws/pkg/version.Version=${VERSION}" ${PROJECT}/cmd/${PROVIDER}
+	go install -ldflags "-X github.com/pulumi/pulumi-azure/pkg/version.Version=${VERSION}" ${PROJECT}/cmd/${TFGEN}
+	go install -ldflags "-X github.com/pulumi/pulumi-azure/pkg/version.Version=${VERSION}" ${PROJECT}/cmd/${PROVIDER}
 	$(TFGEN) --out pack/
 	cd pack/ && yarn install
 	cd ${PACKDIR} && yarn link pulumi # ensure we resolve to Pulumi's stdlibs.

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -6,11 +6,12 @@ ROOT=$(dirname $0)/..
 PUBDIR=$(mktemp -du)
 GITVER=$(git rev-parse HEAD)
 PUBFILE=$(dirname ${PUBDIR})/${GITVER}.tgz
+VERSION=$(git describe --tags --dirty 2>/dev/null)
 
 # Figure out which branch we're on. Prefer $TRAVIS_BRANCH, if set, since
 # Travis leaves us at detached HEAD and `git rev-parse` just returns "HEAD".
 BRANCH=${TRAVIS_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}
-declare -a PUBTARGETS=(${GITVER} $(git describe --tags 2>/dev/null) ${BRANCH})
+declare -a PUBTARGETS=(${GITVER} ${VERSION} ${BRANCH})
 
 # usage: run_go_build <path-to-package-to-build>
 function run_go_build() {
@@ -21,7 +22,10 @@ function run_go_build() {
     fi
 
     mkdir -p "${PUBDIR}/bin"
-    go build -o "${PUBDIR}/bin/${output_name}${bin_suffix}" "$1"
+    go build \
+       -ldflags "-X github.com/pulumi/pulumi-azure/pkg/version.Version=${VERSION}" \
+       -o "${PUBDIR}/bin/${output_name}${bin_suffix}" \
+       "$1"
 }
 
 # usage: copy_package <path-to-module> <module-name>
@@ -30,7 +34,6 @@ copy_package() {
 
     mkdir -p "${module_root}"
     cp -R "$1" "${module_root}/"
-    cp "$1/../package.json" "${module_root}/"
     if [ -e "${module_root}/node_modules" ]; then
         rm -rf "${module_root}/node_modules"
     fi


### PR DESCRIPTION
Ideally we would just use `make build` and `make install` in favor of
having yet another way to build the product, but before we can do that
in general we need to come up with a better story for cross
building. For now, just ensure we pass the correct version string to
go build when building.