### PR TITLE
Publish sdist Python packages

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -481,6 +481,7 @@
     "pkg/util/cmdutil",
     "pkg/util/contract",
     "pkg/util/fsutil",
+    "pkg/util/httputil",
     "pkg/util/mapper",
     "pkg/util/retry",
     "pkg/util/rpcutil",
@@ -489,7 +490,7 @@
     "pkg/workspace",
     "sdk/proto/go"
   ]
-  revision = "479a2e6ad511fc818b234f32031bb2e9985cfb9d"
+  revision = "9ba6584bbfbda7c54e116b0e04c93c8480a5ed28"
 
 [[projects]]
   name = "github.com/pulumi/pulumi-terraform"
@@ -497,7 +498,7 @@
     "pkg/tfbridge",
     "pkg/tfgen"
   ]
-  revision = "06100dcb730d85c58d8c94da85a35e7baa7f3372"
+  revision = "28cef72de7316f1f42aa79d11c76c0cea9123bf8"
 
 [[projects]]
   branch = "master"
@@ -709,6 +710,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6f44cc9453fdb6cd5b25fa8c1570b4a07f1e02053b07872b0bc719b79dc9b073"
+  inputs-digest = "7f750932aa880dabef04e2a5443b35a338bafa95baa76df0511cebacebb5d3e6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,15 +1,15 @@
 [[override]]
   name = "github.com/pulumi/pulumi"
-  revision = "479a2e6ad511fc818b234f32031bb2e9985cfb9d"
+  revision = "9ba6584bbfbda7c54e116b0e04c93c8480a5ed28"
 
 [[override]]
   name = "github.com/pulumi/pulumi-terraform"
-  revision = "06100dcb730d85c58d8c94da85a35e7baa7f3372"
+  revision = "28cef72de7316f1f42aa79d11c76c0cea9123bf8"
 
 [[constraint]]
   name = "github.com/terraform-providers/terraform-provider-azurerm"
   version = "=1.3.1"
-  
+
 [[override]]
   name = "github.com/pulumi/terraform"
   branch = "pulumi-master"

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ build::
 		python setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
 		sed -i.bak "s/\$${VERSION}/$(VERSION)/g" ./bin/setup.py && rm ./bin/setup.py.bak && \
-		cd ./bin && python setup.py build bdist_wheel --universal
+		cd ./bin && python setup.py build sdist
 
 lint::
 	$(GOMETALINTER) ./cmd/... resources.go | sort ; exit "$${PIPESTATUS[0]}"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -65,5 +65,5 @@ if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
     twine upload \
         --repository-url https://pypi.pulumi.com?token=${PULUMI_API_TOKEN} \
         -u pulumi -p pulumi \
-        ${ROOT}/pack/python/bin/dist/*.whl
+        ${ROOT}/pack/python/bin/dist/*.tar.gz
 fi


### PR DESCRIPTION
This changes over to sdists, rather than bdist_wheels, to ensure that
our custom plugin script actually takes effect during installation.

Fixes pulumi/pulumi#1086 for the Azure provider package only.