### PR TITLE
Update to latest version of pulumi-terraform

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -496,7 +496,7 @@
     "pkg/tfbridge",
     "pkg/tfgen"
   ]
-  revision = "3c809d5b5a993ede15ff4f393237086582aff855"
+  revision = "ea783305995aa83b79d503187d446bbd0c55505e"
 
 [[projects]]
   branch = "master"
@@ -702,6 +702,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "78538680dbff690f5a9814b8c4a6c6fabc2eaaeb7d5bc305bb383b37a0abf7ff"
+  inputs-digest = "aa9668f2bc42ff31e2e8e5223bfc32ee28d14ae2203aeb2b5fd896561e2b3b0a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,7 +4,7 @@
 
 [[override]]
   name = "github.com/pulumi/pulumi-terraform"
-  revision = "3c809d5b5a993ede15ff4f393237086582aff855"
+  revision = "ea783305995aa83b79d503187d446bbd0c55505e"
 
 [[constraint]]
   name = "github.com/terraform-providers/terraform-provider-azurerm"


### PR DESCRIPTION
Adopt changes to hide the private resource constructor.