### PR TITLE
Ingest newer pulumi-terraform

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -412,7 +412,7 @@
 [[projects]]
   name = "github.com/mitchellh/copystructure"
   packages = ["."]
-  revision = "5af94aef99f597e6a9e1f6ac6be6ce0f3c96b49d"
+  revision = "d23ffcb85de31694d6ccaa23ccb4a03e55c1303f"
 
 [[projects]]
   branch = "master"
@@ -451,7 +451,7 @@
 [[projects]]
   name = "github.com/mitchellh/reflectwalk"
   packages = ["."]
-  revision = "92573fe8d000a145bfebc03a16bc22b34945867f"
+  revision = "63d60e9d0dbc60cf9164e6510889b0db6683d98c"
 
 [[projects]]
   name = "github.com/opentracing/opentracing-go"


### PR DESCRIPTION
This ingests up to commit
https://github.com/pulumi/pulumi-terraform/commit/cbcc964376d13cb90f3bf60519b5bb0509eb6935
from the pulumi-terraform repo.

I tried to go beyond this, but there seem to be some changes to code-gen
that require more effort around depending on new types in @pulumi/pulumi.