### PR TITLE
Remove the dns name component of this test.

### DIFF
--- a/examples/aci-volume-mount/index.ts
+++ b/examples/aci-volume-mount/index.ts
@@ -24,7 +24,6 @@ const containerGroup = new azure.containerservice.Group("containergroup", {
     resourceGroupName: resourceGroup.name,
     ipAddressType: "public",
     osType: "linux",
-    dnsNameLabel: "pulumicontainergroup",
     containers: [
         {
             name: "webserver",


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-azure-serverless/issues/19

The test doesn't really need this property set.  And setting it causes tests to have issues in parallel since two simultaneous runs of this test will both try to take the same dns-name-label which Azure doesn't allow.