### PR TITLE
Swithch to the 'dev' version of our dependencies.

### DIFF
--- a/examples/aci-multi/package.json
+++ b/examples/aci-multi/package.json
@@ -7,7 +7,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "@types/node": "^8.0.26",

--- a/examples/aci-volume-mount/package.json
+++ b/examples/aci-volume-mount/package.json
@@ -7,7 +7,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "@types/node": "^8.0.26",

--- a/examples/aks/package.json
+++ b/examples/aks/package.json
@@ -6,13 +6,15 @@
     "scripts": {
         "build": "tsc"
     },
+    "dependencies": {
+        "@pulumi/pulumi": "dev"
+    },
     "devDependencies": {
         "@types/node": "^8.0.26",
         "typescript": "^3.0.3"
     },
     "peerDependencies": {
-        "@pulumi/azure": "latest",
-        "@pulumi/pulumi": "^0.15.1"
+        "@pulumi/azure": "latest"
     },
     "license": "Apache 2.0"
 }

--- a/examples/loadbalancer/package.json
+++ b/examples/loadbalancer/package.json
@@ -7,7 +7,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "@types/node": "^8.0.26",

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -7,7 +7,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "typescript": "^3.0.3"

--- a/examples/webserver/package.json
+++ b/examples/webserver/package.json
@@ -7,7 +7,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.1"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "@types/node": "^8.0.26",

--- a/resources.go
+++ b/resources.go
@@ -581,7 +581,7 @@ func Provider() tfbridge.ProviderInfo {
 				"@types/node": "^8.0.25", // so we can access strongly typed node definitions.
 			},
 			Dependencies: map[string]string{
-				"@pulumi/pulumi": "^0.15.3-dev",
+				"@pulumi/pulumi": "dev",
 			},
 			Overlay: &tfbridge.OverlayInfo{
 				Files:   []string{},

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -13,7 +13,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.3-dev"
+        "@pulumi/pulumi": "dev"
     },
     "devDependencies": {
         "@types/node": "^8.0.25",

--- a/sdk/nodejs/yarn.lock
+++ b/sdk/nodejs/yarn.lock
@@ -45,9 +45,9 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@pulumi/pulumi@^0.15.3-dev":
-  version "0.15.3"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.3.tgz#2a4ee8f1270384b722fc6b18e5f98a3fa82a5619"
+"@pulumi/pulumi@dev":
+  version "0.15.4-dev-1537898302-g5d34e380"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.4-dev-1537898302-g5d34e380.tgz#73e5507aa352d15602f3269c60aa1894f1d690e9"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"


### PR DESCRIPTION
This prevents us from having to continually update these version numbers everywhere as we update upstream libs. We will still need to replace these with the right non-dev values when we publish official versins. But we had to do that anyways even when we were saying things like ~0.15.4-dev.