### PR TITLE
Don't auto-name when 'name' is optional

### DIFF
--- a/resources.go
+++ b/resources.go
@@ -209,7 +209,7 @@ func Provider() tfbridge.ProviderInfo {
 			"azurerm_autoscale_setting": {Tok: azureResource(azureAutoscale, "Setting")},
 
 			// Authorization
-			"azurerm_role_assignment": {Tok: azureResource(azureRole, "assignment")},
+			"azurerm_role_assignment": {Tok: azureResource(azureRole, "Assignment")},
 			"azurerm_role_definition": {Tok: azureResource(azureRole, "Definition")},
 
 			// Azure Container Service
@@ -618,8 +618,8 @@ func Provider() tfbridge.ProviderInfo {
 	// already have a name mapping entry, since those may have custom overrides set above (e.g., for length).
 	for resname, res := range prov.Resources {
 		if schema := p.ResourcesMap[resname]; schema != nil {
-			// Only apply auto-name to input properties (Optional || Required) named `name`
-			if tfs, has := schema.Schema[azureName]; has && (tfs.Optional || tfs.Required) {
+			// Only apply auto-name to Required input properties named `name`.
+			if tfs, has := schema.Schema[azureName]; has && tfs.Required {
 				if _, hasfield := res.Fields[azureName]; !hasfield {
 					if res.Fields == nil {
 						res.Fields = make(map[string]*tfbridge.SchemaInfo)

--- a/sdk/go/azure/role/assignment.go
+++ b/sdk/go/azure/role/assignment.go
@@ -9,13 +9,13 @@ import (
 )
 
 // Assigns a given Principal (User or Application) to a given Role.
-type assignment struct {
+type Assignment struct {
 	s *pulumi.ResourceState
 }
 
-// Newassignment registers a new resource with the given unique name, arguments, and options.
-func Newassignment(ctx *pulumi.Context,
-	name string, args *assignmentArgs, opts ...pulumi.ResourceOpt) (*assignment, error) {
+// NewAssignment registers a new resource with the given unique name, arguments, and options.
+func NewAssignment(ctx *pulumi.Context,
+	name string, args *AssignmentArgs, opts ...pulumi.ResourceOpt) (*Assignment, error) {
 	if args == nil || args.PrincipalId == nil {
 		return nil, errors.New("missing required argument 'PrincipalId'")
 	}
@@ -36,17 +36,17 @@ func Newassignment(ctx *pulumi.Context,
 		inputs["roleDefinitionName"] = args.RoleDefinitionName
 		inputs["scope"] = args.Scope
 	}
-	s, err := ctx.RegisterResource("azure:role/assignment:assignment", name, true, inputs, opts...)
+	s, err := ctx.RegisterResource("azure:role/assignment:Assignment", name, true, inputs, opts...)
 	if err != nil {
 		return nil, err
 	}
-	return &assignment{s: s}, nil
+	return &Assignment{s: s}, nil
 }
 
-// Getassignment gets an existing assignment resource's state with the given name, ID, and optional
+// GetAssignment gets an existing Assignment resource's state with the given name, ID, and optional
 // state properties that are used to uniquely qualify the lookup (nil if not required).
-func Getassignment(ctx *pulumi.Context,
-	name string, id pulumi.ID, state *assignmentState, opts ...pulumi.ResourceOpt) (*assignment, error) {
+func GetAssignment(ctx *pulumi.Context,
+	name string, id pulumi.ID, state *AssignmentState, opts ...pulumi.ResourceOpt) (*Assignment, error) {
 	inputs := make(map[string]interface{})
 	if state != nil {
 		inputs["name"] = state.Name
@@ -55,50 +55,50 @@ func Getassignment(ctx *pulumi.Context,
 		inputs["roleDefinitionName"] = state.RoleDefinitionName
 		inputs["scope"] = state.Scope
 	}
-	s, err := ctx.ReadResource("azure:role/assignment:assignment", name, id, inputs, opts...)
+	s, err := ctx.ReadResource("azure:role/assignment:Assignment", name, id, inputs, opts...)
 	if err != nil {
 		return nil, err
 	}
-	return &assignment{s: s}, nil
+	return &Assignment{s: s}, nil
 }
 
 // URN is this resource's unique name assigned by Pulumi.
-func (r *assignment) URN() *pulumi.URNOutput {
+func (r *Assignment) URN() *pulumi.URNOutput {
 	return r.s.URN
 }
 
 // ID is this resource's unique identifier assigned by its provider.
-func (r *assignment) ID() *pulumi.IDOutput {
+func (r *Assignment) ID() *pulumi.IDOutput {
 	return r.s.ID
 }
 
 // A unique UUID/GUID for this Role Assignment - one will be generated if not specified. Changing this forces a new resource to be created.
-func (r *assignment) Name() *pulumi.StringOutput {
+func (r *Assignment) Name() *pulumi.StringOutput {
 	return (*pulumi.StringOutput)(r.s.State["name"])
 }
 
 // The ID of the Principal (User or Application) to assign the Role Definition to. Changing this forces a new resource to be created.
-func (r *assignment) PrincipalId() *pulumi.StringOutput {
+func (r *Assignment) PrincipalId() *pulumi.StringOutput {
 	return (*pulumi.StringOutput)(r.s.State["principalId"])
 }
 
 // The Scoped-ID of the Role Definition. Changing this forces a new resource to be created. Conflicts with `role_definition_name`.
-func (r *assignment) RoleDefinitionId() *pulumi.StringOutput {
+func (r *Assignment) RoleDefinitionId() *pulumi.StringOutput {
 	return (*pulumi.StringOutput)(r.s.State["roleDefinitionId"])
 }
 
 // The name of a built-in Role. Changing this forces a new resource to be created. Conflicts with `role_definition_id`.
-func (r *assignment) RoleDefinitionName() *pulumi.StringOutput {
+func (r *Assignment) RoleDefinitionName() *pulumi.StringOutput {
 	return (*pulumi.StringOutput)(r.s.State["roleDefinitionName"])
 }
 
 // The scope at which the Role Assignment applies too, such as `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333`, `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup`, or `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM`. Changing this forces a new resource to be created.
-func (r *assignment) Scope() *pulumi.StringOutput {
+func (r *Assignment) Scope() *pulumi.StringOutput {
 	return (*pulumi.StringOutput)(r.s.State["scope"])
 }
 
-// Input properties used for looking up and filtering assignment resources.
-type assignmentState struct {
+// Input properties used for looking up and filtering Assignment resources.
+type AssignmentState struct {
 	// A unique UUID/GUID for this Role Assignment - one will be generated if not specified. Changing this forces a new resource to be created.
 	Name interface{}
 	// The ID of the Principal (User or Application) to assign the Role Definition to. Changing this forces a new resource to be created.
@@ -111,8 +111,8 @@ type assignmentState struct {
 	Scope interface{}
 }
 
-// The set of arguments for constructing a assignment resource.
-type assignmentArgs struct {
+// The set of arguments for constructing a Assignment resource.
+type AssignmentArgs struct {
 	// A unique UUID/GUID for this Role Assignment - one will be generated if not specified. Changing this forces a new resource to be created.
 	Name interface{}
 	// The ID of the Principal (User or Application) to assign the Role Definition to. Changing this forces a new resource to be created.

--- a/sdk/nodejs/role/assignment.ts
+++ b/sdk/nodejs/role/assignment.ts
@@ -7,17 +7,17 @@ import * as utilities from "../utilities";
 /**
  * Assigns a given Principal (User or Application) to a given Role.
  */
-export class assignment extends pulumi.CustomResource {
+export class Assignment extends pulumi.CustomResource {
     /**
-     * Get an existing assignment resource's state with the given name, ID, and optional extra
+     * Get an existing Assignment resource's state with the given name, ID, and optional extra
      * properties used to qualify the lookup.
      *
      * @param name The _unique_ name of the resulting resource.
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: assignmentState): assignment {
-        return new assignment(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: AssignmentState): Assignment {
+        return new Assignment(name, <any>state, { id });
     }
 
     /**
@@ -42,24 +42,24 @@ export class assignment extends pulumi.CustomResource {
     public readonly scope: pulumi.Output<string>;
 
     /**
-     * Create a assignment resource with the given unique name, arguments, and options.
+     * Create a Assignment resource with the given unique name, arguments, and options.
      *
      * @param name The _unique_ name of the resource.
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args: assignmentArgs, opts?: pulumi.CustomResourceOptions)
-    constructor(name: string, argsOrState?: assignmentArgs | assignmentState, opts?: pulumi.CustomResourceOptions) {
+    constructor(name: string, args: AssignmentArgs, opts?: pulumi.CustomResourceOptions)
+    constructor(name: string, argsOrState?: AssignmentArgs | AssignmentState, opts?: pulumi.CustomResourceOptions) {
         let inputs: pulumi.Inputs = {};
         if (opts && opts.id) {
-            const state: assignmentState = argsOrState as assignmentState | undefined;
+            const state: AssignmentState = argsOrState as AssignmentState | undefined;
             inputs["name"] = state ? state.name : undefined;
             inputs["principalId"] = state ? state.principalId : undefined;
             inputs["roleDefinitionId"] = state ? state.roleDefinitionId : undefined;
             inputs["roleDefinitionName"] = state ? state.roleDefinitionName : undefined;
             inputs["scope"] = state ? state.scope : undefined;
         } else {
-            const args = argsOrState as assignmentArgs | undefined;
+            const args = argsOrState as AssignmentArgs | undefined;
             if (!args || args.principalId === undefined) {
                 throw new Error("Missing required property 'principalId'");
             }
@@ -72,14 +72,14 @@ export class assignment extends pulumi.CustomResource {
             inputs["roleDefinitionName"] = args ? args.roleDefinitionName : undefined;
             inputs["scope"] = args ? args.scope : undefined;
         }
-        super("azure:role/assignment:assignment", name, inputs, opts);
+        super("azure:role/assignment:Assignment", name, inputs, opts);
     }
 }
 
 /**
- * Input properties used for looking up and filtering assignment resources.
+ * Input properties used for looking up and filtering Assignment resources.
  */
-export interface assignmentState {
+export interface AssignmentState {
     /**
      * A unique UUID/GUID for this Role Assignment - one will be generated if not specified. Changing this forces a new resource to be created.
      */
@@ -103,9 +103,9 @@ export interface assignmentState {
 }
 
 /**
- * The set of arguments for constructing a assignment resource.
+ * The set of arguments for constructing a Assignment resource.
  */
-export interface assignmentArgs {
+export interface AssignmentArgs {
     /**
      * A unique UUID/GUID for this Role Assignment - one will be generated if not specified. Changing this forces a new resource to be created.
      */

--- a/sdk/python/pulumi_azure/role/assignment.py
+++ b/sdk/python/pulumi_azure/role/assignment.py
@@ -6,12 +6,12 @@ import pulumi
 import pulumi.runtime
 from .. import utilities
 
-class assignment(pulumi.CustomResource):
+class Assignment(pulumi.CustomResource):
     """
     Assigns a given Principal (User or Application) to a given Role.
     """
     def __init__(__self__, __name__, __opts__=None, name=None, principal_id=None, role_definition_id=None, role_definition_name=None, scope=None):
-        """Create a assignment resource with the given unique name, props, and options."""
+        """Create a Assignment resource with the given unique name, props, and options."""
         if not __name__:
             raise TypeError('Missing resource name argument (for URN creation)')
         if not isinstance(__name__, basestring):
@@ -65,8 +65,8 @@ class assignment(pulumi.CustomResource):
         """
         __props__['scope'] = scope
 
-        super(assignment, __self__).__init__(
-            'azure:role/assignment:assignment',
+        super(Assignment, __self__).__init__(
+            'azure:role/assignment:Assignment',
             __name__,
             __props__,
             __opts__)


### PR DESCRIPTION
We have been applying auto-naming to all input properties, even if they were already Optional.  In that case, the provider already understands how to provide a default name - or one is truly not required at all.  So we should avoid overwriting this with a Pulumi autoname.

Also fixes the casing of `azure.role.assignment` - this is a breaking change.

Fixes #121.