### PR TITLE
Override tfbridge dependency versions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -432,7 +432,7 @@
 [[projects]]
   name = "github.com/mitchellh/copystructure"
   packages = ["."]
-  revision = "5af94aef99f597e6a9e1f6ac6be6ce0f3c96b49d"
+  revision = "d23ffcb85de31694d6ccaa23ccb4a03e55c1303f"
 
 [[projects]]
   name = "github.com/mitchellh/go-homedir"
@@ -468,7 +468,7 @@
 [[projects]]
   name = "github.com/mitchellh/reflectwalk"
   packages = ["."]
-  revision = "92573fe8d000a145bfebc03a16bc22b34945867f"
+  revision = "63d60e9d0dbc60cf9164e6510889b0db6683d98c"
 
 [[projects]]
   name = "github.com/opentracing/opentracing-go"
@@ -882,6 +882,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7e255e27f0e7aa7a761b08da8053f2b719b7b3d304d90cd37b38faae055a1795"
+  inputs-digest = "8ce8ca854848b35ff0cbe6dedbcfea8d84edda0b3b10ddc3b6596c88182c357a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -6,6 +6,15 @@
   branch = "master"
   name = "github.com/pulumi/pulumi-terraform"
 
+# DO NOT REMOVE THESE [pulumi/pulumi-terraform#229]
+# These versions are required by tfbridge - we must build against them even if the provider requests an older version.
+[[override]]
+  name = "github.com/mitchellh/copystructure"
+  revision = "d23ffcb85de31694d6ccaa23ccb4a03e55c1303f"
+[[override]]
+  name = "github.com/mitchellh/reflectwalk"
+  revision = "63d60e9d0dbc60cf9164e6510889b0db6683d98c"
+
 [[constraint]]
   branch = "pulumi-master"
   name = "github.com/terraform-providers/terraform-provider-azurerm"
@@ -227,12 +236,6 @@
     govendor-overriden=true
 
 [[override]]
-  name = "github.com/mitchellh/copystructure"
-  revision = "5af94aef99f597e6a9e1f6ac6be6ce0f3c96b49d"
-  [override.metadata]
-    govendor-overriden=true
-
-[[override]]
   name = "github.com/mitchellh/go-homedir"
   revision = "58046073cbffe2f25d425fe1331102f55cf719de"
   [override.metadata]
@@ -259,12 +262,6 @@
 [[override]]
   name = "github.com/mitchellh/mapstructure"
   revision = "53818660ed4955e899c0bcafa97299a388bd7c8e"
-  [override.metadata]
-    govendor-overriden=true
-
-[[override]]
-  name = "github.com/mitchellh/reflectwalk"
-  revision = "92573fe8d000a145bfebc03a16bc22b34945867f"
   [override.metadata]
     govendor-overriden=true
 


### PR DESCRIPTION
`tfbridge` requires recent versions of `copystructre` and `reflectwalk`, or else can hit panics seen in .

We used to lock these in our lock file, but had not recorded these dependencies in the toml.

When we moved to `govendor-override`, we moved to a model where we pick up the exact versions of dependencies requested by the provider.  However, the provider asks for an older version of these dependencies which will trigger this bug in tfbridge.  

As a result, we have to make an exception here and pick version different from what the provider requests to ensure that tfbridge can operate correctly.  This is unfortunately still somewhat brittle, and the only real hope is that we can either:
1. Move to a single dependency management system for both tfbridge abnd providers (maybe Go 1.11 modules)
2. Split the provider out of process so that it doesn't have to build against the same version of the package as tfbridge uses.

Fixes pulumi/pulumi-terraform#229 (again).