### PR TITLE
Ingest latest Terraform code-gen

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -594,7 +594,7 @@
     "pkg/tfbridge",
     "pkg/tfgen"
   ]
-  revision = "2c187fb6f5e33adbc3c54c4dff4c86f7c9af7379"
+  revision = "7a44de90bda793310b6ff4ef4100136b26e69e95"
 
 [[projects]]
   branch = "master"

--- a/sdk/go/azure/compute/dataDiskAttachment.go
+++ b/sdk/go/azure/compute/dataDiskAttachment.go
@@ -10,7 +10,7 @@ import (
 
 // Manages attaching a Disk to a Virtual Machine.
 // 
-// ~> **NOTE:** Data Disks can be attached either directly on the `azurerm_virtual_machine` resource, or using the `azurerm_virtual_machine_data_disk_attachment` resource - but the two cannot be used together. If both are used against the same Virtual Machine, spurious changes will occur.
+// > **NOTE:** Data Disks can be attached either directly on the `azurerm_virtual_machine` resource, or using the `azurerm_virtual_machine_data_disk_attachment` resource - but the two cannot be used together. If both are used against the same Virtual Machine, spurious changes will occur.
 // 
 // -> **Please Note:** only Managed Disks are supported via this separate resource, Unmanaged Disks can be attached using the `storage_data_disk` block in the `azurerm_virtual_machine` resource.
 type DataDiskAttachment struct {

--- a/sdk/go/azure/compute/extension.go
+++ b/sdk/go/azure/compute/extension.go
@@ -11,7 +11,7 @@ import (
 // Manages a Virtual Machine Extension to provide post deployment configuration
 // and run automated tasks.
 // 
-// ~> **NOTE:** Custom Script Extensions for Linux & Windows require that the `commandToExecute` returns a `0` exit code to be classified as successfully deployed. You can achieve this by appending `exit 0` to the end of your `commandToExecute`.
+// > **NOTE:** Custom Script Extensions for Linux & Windows require that the `commandToExecute` returns a `0` exit code to be classified as successfully deployed. You can achieve this by appending `exit 0` to the end of your `commandToExecute`.
 // 
 // -> **NOTE:** Custom Script Extensions require that the Azure Virtual Machine Guest Agent is running on the Virtual Machine.
 type Extension struct {

--- a/sdk/go/azure/compute/scaleSet.go
+++ b/sdk/go/azure/compute/scaleSet.go
@@ -10,7 +10,7 @@ import (
 
 // Manage a virtual machine scale set.
 // 
-// ~> **Note:** All arguments including the administrator login and password will be stored in the raw state as plain-text.
+// > **Note:** All arguments including the administrator login and password will be stored in the raw state as plain-text.
 // [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 type ScaleSet struct {
 	s *pulumi.ResourceState

--- a/sdk/go/azure/compute/virtualMachine.go
+++ b/sdk/go/azure/compute/virtualMachine.go
@@ -10,7 +10,7 @@ import (
 
 // Manages a Virtual Machine.
 // 
-// ~> **NOTE:** Data Disks can be attached either directly on the `azurerm_virtual_machine` resource, or using the `azurerm_virtual_machine_data_disk_attachment` resource - but the two cannot be used together. If both are used against the same Virtual Machine, spurious changes will occur.
+// > **NOTE:** Data Disks can be attached either directly on the `azurerm_virtual_machine` resource, or using the `azurerm_virtual_machine_data_disk_attachment` resource - but the two cannot be used together. If both are used against the same Virtual Machine, spurious changes will occur.
 type VirtualMachine struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/azure/containerservice/getKubernetesCluster.go
+++ b/sdk/go/azure/containerservice/getKubernetesCluster.go
@@ -9,7 +9,7 @@ import (
 
 // Use this data source to access information about an existing Managed Kubernetes Cluster (AKS).
 // 
-// ~> **Note:** All arguments including the client secret will be stored in the raw state as plain-text.
+// > **Note:** All arguments including the client secret will be stored in the raw state as plain-text.
 // [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 func LookupKubernetesCluster(ctx *pulumi.Context, args *GetKubernetesClusterArgs) (*GetKubernetesClusterResult, error) {
 	inputs := make(map[string]interface{})

--- a/sdk/go/azure/containerservice/kubernetesCluster.go
+++ b/sdk/go/azure/containerservice/kubernetesCluster.go
@@ -10,7 +10,7 @@ import (
 
 // Manages a Managed Kubernetes Cluster (also known as AKS / Azure Kubernetes Service)
 // 
-// ~> **Note:** All arguments including the client secret will be stored in the raw state as plain-text. [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
+// > **Note:** All arguments including the client secret will be stored in the raw state as plain-text. [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 type KubernetesCluster struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/azure/containerservice/registry.go
+++ b/sdk/go/azure/containerservice/registry.go
@@ -10,7 +10,7 @@ import (
 
 // Manages an Azure Container Registry.
 // 
-// ~> **Note:** All arguments including the access key will be stored in the raw state as plain-text.
+// > **Note:** All arguments including the access key will be stored in the raw state as plain-text.
 // [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 type Registry struct {
 	s *pulumi.ResourceState

--- a/sdk/go/azure/containerservice/service.go
+++ b/sdk/go/azure/containerservice/service.go
@@ -10,10 +10,10 @@ import (
 
 // Manages an Azure Container Service Instance
 // 
-// ~> **NOTE:** All arguments including the client secret will be stored in the raw state as plain-text.
+// > **NOTE:** All arguments including the client secret will be stored in the raw state as plain-text.
 // [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 // 
-// ~> **DEPRECATED:** [Azure Container Service (ACS) has been deprecated by Azure in favour of Azure (Managed) Kubernetes Service (AKS)](https://azure.microsoft.com/en-us/updates/azure-container-service-will-retire-on-january-31-2020/). Support for ACS will be removed in the next major version of the AzureRM Provider (2.0) - and we **strongly recommend** you consider using Azure Kubernetes Service (AKS) for new deployments.
+// > **DEPRECATED:** [Azure Container Service (ACS) has been deprecated by Azure in favour of Azure (Managed) Kubernetes Service (AKS)](https://azure.microsoft.com/en-us/updates/azure-container-service-will-retire-on-january-31-2020/). Support for ACS will be removed in the next major version of the AzureRM Provider (2.0) - and we **strongly recommend** you consider using Azure Kubernetes Service (AKS) for new deployments.
 // 
 // ## Example Usage (DCOS)
 // 

--- a/sdk/go/azure/core/templateDeployment.go
+++ b/sdk/go/azure/core/templateDeployment.go
@@ -10,7 +10,7 @@ import (
 
 // Manage a template deployment of resources
 // 
-// ~> **Note on ARM Template Deployments:** Due to the way the underlying Azure API is designed, Terraform can only manage the deployment of the ARM Template - and not any resources which are created by it.
+// > **Note on ARM Template Deployments:** Due to the way the underlying Azure API is designed, Terraform can only manage the deployment of the ARM Template - and not any resources which are created by it.
 // This means that when deleting the `azurerm_template_deployment` resource, Terraform will only remove the reference to the deployment, whilst leaving any resources created by that ARM Template Deployment.
 // One workaround for this is to use a unique Resource Group for each ARM Template Deployment, which means deleting the Resource Group would contain any resources created within it - however this isn't ideal. [More information](https://docs.microsoft.com/en-us/rest/api/resources/deployments#Deployments_Delete).
 type TemplateDeployment struct {

--- a/sdk/go/azure/datalake/storeFile.go
+++ b/sdk/go/azure/datalake/storeFile.go
@@ -10,7 +10,7 @@ import (
 
 // Manage a Azure Data Lake Store File.
 // 
-// ~> **Note:** If you want to change the data in the remote file without changing the `local_file_path`, then 
+// > **Note:** If you want to change the data in the remote file without changing the `local_file_path`, then 
 // taint the resource so the `azurerm_data_lake_store_file` gets recreated with the new data.
 type StoreFile struct {
 	s *pulumi.ResourceState

--- a/sdk/go/azure/eventhub/eventGridTopic.go
+++ b/sdk/go/azure/eventhub/eventGridTopic.go
@@ -10,7 +10,7 @@ import (
 
 // Manages an EventGrid Topic
 // 
-// ~> **Note:** at this time EventGrid Topic's are only available in a limited number of regions.
+// > **Note:** at this time EventGrid Topic's are only available in a limited number of regions.
 type EventGridTopic struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/azure/keyvault/accessPolicy.go
+++ b/sdk/go/azure/keyvault/accessPolicy.go
@@ -10,7 +10,7 @@ import (
 
 // Manages a Key Vault Access Policy.
 // 
-// ~> **NOTE:** It's possible to define Key Vault Access Policies both within the `azurerm_key_vault` resource via the `access_policy` block and by using the `azurerm_key_vault_access_policy` resource. However it's not possible to use both methods to manage Access Policies within a KeyVault, since there'll be conflicts.
+// > **NOTE:** It's possible to define Key Vault Access Policies both within the `azurerm_key_vault` resource via the `access_policy` block and by using the `azurerm_key_vault_access_policy` resource. However it's not possible to use both methods to manage Access Policies within a KeyVault, since there'll be conflicts.
 // 
 // -> **NOTE:** Azure permits a maximum of 16 Access Policies per Key Vault - [more information can be found in this document](https://docs.microsoft.com/en-us/azure/key-vault/key-vault-secure-your-key-vault#data-plane-access-control).
 type AccessPolicy struct {

--- a/sdk/go/azure/keyvault/getKey.go
+++ b/sdk/go/azure/keyvault/getKey.go
@@ -9,7 +9,7 @@ import (
 
 // Use this data source to access information about an existing Key Vault Key.
 // 
-// ~> **Note:** All arguments including the secret value will be stored in the raw state as plain-text.
+// > **Note:** All arguments including the secret value will be stored in the raw state as plain-text.
 // [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 func LookupKey(ctx *pulumi.Context, args *GetKeyArgs) (*GetKeyResult, error) {
 	inputs := make(map[string]interface{})

--- a/sdk/go/azure/keyvault/getSecret.go
+++ b/sdk/go/azure/keyvault/getSecret.go
@@ -9,7 +9,7 @@ import (
 
 // Use this data source to access information about an existing Key Vault Secret.
 // 
-// ~> **Note:** All arguments including the secret value will be stored in the raw state as plain-text.
+// > **Note:** All arguments including the secret value will be stored in the raw state as plain-text.
 // [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 func LookupSecret(ctx *pulumi.Context, args *GetSecretArgs) (*GetSecretResult, error) {
 	inputs := make(map[string]interface{})

--- a/sdk/go/azure/keyvault/keyVault.go
+++ b/sdk/go/azure/keyvault/keyVault.go
@@ -10,7 +10,7 @@ import (
 
 // Manages a Key Vault.
 // 
-// ~> **NOTE:** It's possible to define Key Vault Access Policies both within the `azurerm_key_vault` resource via the `access_policy` block and by using the `azurerm_key_vault_access_policy` resource. However it's not possible to use both methods to manage Access Policies within a KeyVault, since there'll be conflicts.
+// > **NOTE:** It's possible to define Key Vault Access Policies both within the `azurerm_key_vault` resource via the `access_policy` block and by using the `azurerm_key_vault_access_policy` resource. However it's not possible to use both methods to manage Access Policies within a KeyVault, since there'll be conflicts.
 type KeyVault struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/azure/keyvault/secret.go
+++ b/sdk/go/azure/keyvault/secret.go
@@ -10,7 +10,7 @@ import (
 
 // Manages a Key Vault Secret.
 // 
-// ~> **Note:** All arguments including the secret value will be stored in the raw state as plain-text.
+// > **Note:** All arguments including the secret value will be stored in the raw state as plain-text.
 // [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 type Secret struct {
 	s *pulumi.ResourceState

--- a/sdk/go/azure/lb/backendAddressPool.go
+++ b/sdk/go/azure/lb/backendAddressPool.go
@@ -10,7 +10,7 @@ import (
 
 // Manage a Load Balancer Backend Address Pool.
 // 
-// ~> **NOTE:** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
+// > **NOTE:** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
 type BackendAddressPool struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/azure/lb/natPool.go
+++ b/sdk/go/azure/lb/natPool.go
@@ -10,7 +10,7 @@ import (
 
 // Manages a Load Balancer NAT pool.
 // 
-// ~> **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
+// > **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
 type NatPool struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/azure/lb/natRule.go
+++ b/sdk/go/azure/lb/natRule.go
@@ -10,7 +10,7 @@ import (
 
 // Manages a Load Balancer NAT Rule.
 // 
-// ~> **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
+// > **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
 type NatRule struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/azure/lb/probe.go
+++ b/sdk/go/azure/lb/probe.go
@@ -10,7 +10,7 @@ import (
 
 // Manages a LoadBalancer Probe Resource.
 // 
-// ~> **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
+// > **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
 type Probe struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/azure/lb/rule.go
+++ b/sdk/go/azure/lb/rule.go
@@ -10,7 +10,7 @@ import (
 
 // Manages a Load Balancer Rule.
 // 
-// ~> **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
+// > **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
 type Rule struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/azure/network/networkSecurityGroup.go
+++ b/sdk/go/azure/network/networkSecurityGroup.go
@@ -10,7 +10,7 @@ import (
 
 // Manages a network security group that contains a list of network security rules.  Network security groups enable inbound or outbound traffic to be enabled or denied.
 // 
-// ~> **NOTE on Network Security Groups and Network Security Rules:** Terraform currently
+// > **NOTE on Network Security Groups and Network Security Rules:** Terraform currently
 // provides both a standalone Network Security Rule resource, and allows for Network Security Rules to be defined in-line within the Network Security Group resource.
 // At this time you cannot use a Network Security Group with in-line Network Security Rules in conjunction with any Network Security Rule resources. Doing so will cause a conflict of rule settings and will overwrite rules.
 type NetworkSecurityGroup struct {

--- a/sdk/go/azure/network/networkSecurityRule.go
+++ b/sdk/go/azure/network/networkSecurityRule.go
@@ -10,7 +10,7 @@ import (
 
 // Manages a Network Security Rule.
 // 
-// ~> **NOTE on Network Security Groups and Network Security Rules:** Terraform currently
+// > **NOTE on Network Security Groups and Network Security Rules:** Terraform currently
 // provides both a standalone Network Security Rule resource, and allows for Network Security Rules to be defined in-line within the Network Security Group resource.
 // At this time you cannot use a Network Security Group with in-line Network Security Rules in conjunction with any Network Security Rule resources. Doing so will cause a conflict of rule settings and will overwrite rules.
 type NetworkSecurityRule struct {

--- a/sdk/go/azure/network/subnet.go
+++ b/sdk/go/azure/network/subnet.go
@@ -10,7 +10,7 @@ import (
 
 // Manages a subnet. Subnets represent network segments within the IP space defined by the virtual network.
 // 
-// ~> **NOTE on Virtual Networks and Subnet's:** Terraform currently
+// > **NOTE on Virtual Networks and Subnet's:** Terraform currently
 // provides both a standalone Subnet resource, and allows for Subnets to be defined in-line within the Virtual Network resource.
 // At this time you cannot use a Virtual Network with in-line Subnets in conjunction with any Subnet resources. Doing so will cause a conflict of Subnet configurations and will overwrite Subnet's.
 type Subnet struct {

--- a/sdk/go/azure/network/virtualNetwork.go
+++ b/sdk/go/azure/network/virtualNetwork.go
@@ -11,7 +11,7 @@ import (
 // Manages a virtual network including any configured subnets. Each subnet can
 // optionally be configured with a security group to be associated with the subnet.
 // 
-// ~> **NOTE on Virtual Networks and Subnet's:** Terraform currently
+// > **NOTE on Virtual Networks and Subnet's:** Terraform currently
 // provides both a standalone Subnet resource, and allows for Subnets to be defined in-line within the Virtual Network resource.
 // At this time you cannot use a Virtual Network with in-line Subnets in conjunction with any Subnet resources. Doing so will cause a conflict of Subnet configurations and will overwrite Subnet's.
 type VirtualNetwork struct {

--- a/sdk/go/azure/scheduler/getJobCollection.go
+++ b/sdk/go/azure/scheduler/getJobCollection.go
@@ -9,7 +9,7 @@ import (
 
 // Use this data source to access information about an existing Scheduler Job Collection.
 // 
-// ~> **NOTE:** Support for Scheduler Job Collections has been deprecated by Microsoft in favour of Logic Apps ([more information can be found at this link](https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps)) - as such we plan to remove support for this data source as a part of version 2.0 of the AzureRM Provider.
+// > **NOTE:** Support for Scheduler Job Collections has been deprecated by Microsoft in favour of Logic Apps ([more information can be found at this link](https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps)) - as such we plan to remove support for this data source as a part of version 2.0 of the AzureRM Provider.
 func LookupJobCollection(ctx *pulumi.Context, args *GetJobCollectionArgs) (*GetJobCollectionResult, error) {
 	inputs := make(map[string]interface{})
 	if args != nil {

--- a/sdk/go/azure/scheduler/job.go
+++ b/sdk/go/azure/scheduler/job.go
@@ -10,7 +10,7 @@ import (
 
 // Manages a Scheduler Job.
 // 
-// ~> **NOTE:** Support for Scheduler Job has been deprecated by Microsoft in favour of Logic Apps ([more information can be found at this link](https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps)) - as such we plan to remove support for this resource as a part of version 2.0 of the AzureRM Provider.
+// > **NOTE:** Support for Scheduler Job has been deprecated by Microsoft in favour of Logic Apps ([more information can be found at this link](https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps)) - as such we plan to remove support for this resource as a part of version 2.0 of the AzureRM Provider.
 type Job struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/azure/scheduler/jobCollection.go
+++ b/sdk/go/azure/scheduler/jobCollection.go
@@ -10,7 +10,7 @@ import (
 
 // Manages a Scheduler Job Collection.
 // 
-// ~> **NOTE:** Support for Scheduler Job Collections has been deprecated by Microsoft in favour of Logic Apps ([more information can be found at this link](https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps)) - as such we plan to remove support for this resource as a part of version 2.0 of the AzureRM Provider.
+// > **NOTE:** Support for Scheduler Job Collections has been deprecated by Microsoft in favour of Logic Apps ([more information can be found at this link](https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps)) - as such we plan to remove support for this resource as a part of version 2.0 of the AzureRM Provider.
 type JobCollection struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/azure/securitycenter/contact.go
+++ b/sdk/go/azure/securitycenter/contact.go
@@ -10,7 +10,7 @@ import (
 
 // Manages the subscription's Security Center Contact.
 // 
-// ~> **NOTE:** Owner access permission is required. 
+// > **NOTE:** Owner access permission is required. 
 type Contact struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/azure/securitycenter/subscriptionPricing.go
+++ b/sdk/go/azure/securitycenter/subscriptionPricing.go
@@ -10,9 +10,9 @@ import (
 
 // Manages the Pricing Tier for Azure Security Center in the current subscription.
 // 
-// ~> **NOTE:** This resource requires the `Owner` permission on the Subscription.
+// > **NOTE:** This resource requires the `Owner` permission on the Subscription.
 // 
-// ~> **NOTE:** Deletion of this resource does not change or reset the pricing tier to `Free`
+// > **NOTE:** Deletion of this resource does not change or reset the pricing tier to `Free`
 type SubscriptionPricing struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/azure/securitycenter/workspace.go
+++ b/sdk/go/azure/securitycenter/workspace.go
@@ -10,9 +10,9 @@ import (
 
 // Manages the subscription's Security Center Workspace.
 // 
-// ~> **NOTE:** Owner access permission is required.
+// > **NOTE:** Owner access permission is required.
 // 
-// ~> **NOTE:** The subscription's pricing model can not be `Free` for this to have any affect.
+// > **NOTE:** The subscription's pricing model can not be `Free` for this to have any affect.
 type Workspace struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/azure/sql/elasticPool.go
+++ b/sdk/go/azure/sql/elasticPool.go
@@ -10,7 +10,7 @@ import (
 
 // Allows you to manage an Azure SQL Elastic Pool.
 // 
-// ~> **NOTE:** -  This version of the `Elasticpool` resource is being **deprecated** and should no longer be used. Please use the azurerm_mssql_elasticpool version instead.
+// > **NOTE:** -  This version of the `Elasticpool` resource is being **deprecated** and should no longer be used. Please use the azurerm_mssql_elasticpool version instead.
 type ElasticPool struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/azure/sql/sqlServer.go
+++ b/sdk/go/azure/sql/sqlServer.go
@@ -10,7 +10,7 @@ import (
 
 // Manages a SQL Azure Database Server.
 // 
-// ~> **Note:** All arguments including the administrator login and password will be stored in the raw state as plain-text.
+// > **Note:** All arguments including the administrator login and password will be stored in the raw state as plain-text.
 // [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 type SqlServer struct {
 	s *pulumi.ResourceState

--- a/sdk/nodejs/ad/application.ts
+++ b/sdk/nodejs/ad/application.ts
@@ -8,6 +8,22 @@ import * as utilities from "../utilities";
  * Manages an Application within Azure Active Directory.
  * 
  * -> **NOTE:** If you're authenticating using a Service Principal then it must have permissions to both `Read and write all applications` and `Sign in and read user profile` within the `Windows Azure Active Directory` API.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_azuread_application_test = new azure.ad.Application("test", {
+ *     availableToOtherTenants: false,
+ *     homepage: "https://homepage",
+ *     identifierUris: ["https://uri"],
+ *     name: "example",
+ *     oauth2AllowImplicitFlow: true,
+ *     replyUrls: ["https://replyurl"],
+ * });
+ * ```
  */
 export class Application extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/ad/getApplication.ts
+++ b/sdk/nodejs/ad/getApplication.ts
@@ -8,6 +8,19 @@ import * as utilities from "../utilities";
  * Use this data source to access information about an existing Application within Azure Active Directory.
  * 
  * -> **NOTE:** If you're authenticating using a Service Principal then it must have permissions to both `Read and write all applications` and `Sign in and read user profile` within the `Windows Azure Active Directory` API.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_azuread_application_test = pulumi.output(azure.ad.getApplication({
+ *     name: "My First AzureAD Application",
+ * }));
+ * 
+ * export const azureActiveDirectoryObjectId = azurerm_azuread_application_test.apply(__arg0 => __arg0.id);
+ * ```
  */
 export function getApplication(args?: GetApplicationArgs, opts?: pulumi.InvokeOptions): Promise<GetApplicationResult> {
     args = args || {};

--- a/sdk/nodejs/ad/getServicePrincipal.ts
+++ b/sdk/nodejs/ad/getServicePrincipal.ts
@@ -8,6 +8,39 @@ import * as utilities from "../utilities";
  * Gets information about an existing Service Principal associated with an Application within Azure Active Directory.
  * 
  * -> **NOTE:** If you're authenticating using a Service Principal then it must have permissions to both `Read and write all applications` and `Sign in and read user profile` within the `Windows Azure Active Directory` API.
+ * 
+ * ## Example Usage (by Application Display Name)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_azuread_service_principal_test = pulumi.output(azure.ad.getServicePrincipal({
+ *     displayName: "my-awesome-application",
+ * }));
+ * ```
+ * 
+ * ## Example Usage (by Application ID)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_azuread_service_principal_test = pulumi.output(azure.ad.getServicePrincipal({
+ *     applicationId: "00000000-0000-0000-0000-000000000000",
+ * }));
+ * ```
+ * 
+ * ## Example Usage (by Object ID)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_azuread_service_principal_test = pulumi.output(azure.ad.getServicePrincipal({
+ *     objectId: "00000000-0000-0000-0000-000000000000",
+ * }));
+ * ```
  */
 export function getServicePrincipal(args?: GetServicePrincipalArgs, opts?: pulumi.InvokeOptions): Promise<GetServicePrincipalResult> {
     args = args || {};

--- a/sdk/nodejs/ad/servicePrincipal.ts
+++ b/sdk/nodejs/ad/servicePrincipal.ts
@@ -8,6 +8,25 @@ import * as utilities from "../utilities";
  * Manages a Service Principal associated with an Application within Azure Active Directory.
  * 
  * -> **NOTE:** If you're authenticating using a Service Principal then it must have permissions to both `Read and write all applications` and `Sign in and read user profile` within the `Windows Azure Active Directory` API.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_azuread_application_test = new azure.ad.Application("test", {
+ *     availableToOtherTenants: false,
+ *     homepage: "http://homepage",
+ *     identifierUris: ["http://uri"],
+ *     name: "example",
+ *     oauth2AllowImplicitFlow: true,
+ *     replyUrls: ["http://replyurl"],
+ * });
+ * const azurerm_azuread_service_principal_test = new azure.ad.ServicePrincipal("test", {
+ *     applicationId: azurerm_azuread_application_test.applicationId,
+ * });
+ * ```
  */
 export class ServicePrincipal extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/ad/servicePrincipalPassword.ts
+++ b/sdk/nodejs/ad/servicePrincipalPassword.ts
@@ -8,6 +8,30 @@ import * as utilities from "../utilities";
  * Manages a Password associated with a Service Principal within Azure Active Directory.
  * 
  * -> **NOTE:** If you're authenticating using a Service Principal then it must have permissions to both `Read and write all applications` and `Sign in and read user profile` within the `Windows Azure Active Directory` API.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_azuread_application_test = new azure.ad.Application("test", {
+ *     availableToOtherTenants: false,
+ *     homepage: "http://homepage",
+ *     identifierUris: ["http://uri"],
+ *     name: "example",
+ *     oauth2AllowImplicitFlow: true,
+ *     replyUrls: ["http://replyurl"],
+ * });
+ * const azurerm_azuread_service_principal_test = new azure.ad.ServicePrincipal("test", {
+ *     applicationId: azurerm_azuread_application_test.applicationId,
+ * });
+ * const azurerm_azuread_service_principal_password_test = new azure.ad.ServicePrincipalPassword("test", {
+ *     endDate: "2020-01-01T01:02:03Z",
+ *     servicePrincipalId: azurerm_azuread_service_principal_test.id,
+ *     value: "VT=uSgbTanZhyz@%nL9Hpd+Tfay_MRV#",
+ * });
+ * ```
  */
 export class ServicePrincipalPassword extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/apimanagement/aPI.ts
+++ b/sdk/nodejs/apimanagement/aPI.ts
@@ -6,6 +6,29 @@ import * as utilities from "../utilities";
 
 /**
  * Manages an API Management Service.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "example-resources",
+ * });
+ * const azurerm_api_management_test = new azure.apimanagement.API("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-apim",
+ *     publisherEmail: "company@terraform.io",
+ *     publisherName: "My Company",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         capacity: 1,
+ *         name: "Developer",
+ *     },
+ * });
+ * ```
  */
 export class API extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/apimanagement/getAPI.ts
+++ b/sdk/nodejs/apimanagement/getAPI.ts
@@ -6,6 +6,20 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing API Management Service.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_api_management_test = pulumi.output(azure.apimanagement.getAPI({
+ *     name: "search-api",
+ *     resourceGroupName: "search-service",
+ * }));
+ * 
+ * export const apiManagementId = azurerm_api_management_test.apply(__arg0 => __arg0.id);
+ * ```
  */
 export function getAPI(args: GetAPIArgs, opts?: pulumi.InvokeOptions): Promise<GetAPIResult> {
     return pulumi.runtime.invoke("azure:apimanagement/getAPI:getAPI", {

--- a/sdk/nodejs/appinsights/insights.ts
+++ b/sdk/nodejs/appinsights/insights.ts
@@ -6,6 +6,27 @@ import * as utilities from "../utilities";
 
 /**
  * Manage an Application Insights component.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "tf-test",
+ * });
+ * const azurerm_application_insights_test = new azure.appinsights.Insights("test", {
+ *     applicationType: "Web",
+ *     location: "West Europe",
+ *     name: "tf-test-appinsights",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * 
+ * export const appId = azurerm_application_insights_test.appId;
+ * export const instrumentationKey = azurerm_application_insights_test.instrumentationKey;
+ * ```
  */
 export class Insights extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/appservice/activeSlot.ts
+++ b/sdk/nodejs/appservice/activeSlot.ts
@@ -8,6 +8,25 @@ import * as utilities from "../utilities";
  * Promotes an App Service Slot to Production within an App Service.
  * 
  * -> **Note:** When using Slots - the `app_settings`, `connection_string` and `site_config` blocks on the `azurerm_app_service` resource will be overwritten when promoting a Slot using the `azurerm_app_service_active_slot` resource.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * import * as random from "@pulumi/random";
+ * 
+ * const azurerm_app_service_test = new azure.appservice.AppService("test", {});
+ * const azurerm_app_service_plan_test = new azure.appservice.Plan("test", {});
+ * const azurerm_app_service_slot_test = new azure.appservice.Slot("test", {});
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {});
+ * const random_id_server = new random.RandomId("server", {});
+ * const azurerm_app_service_active_slot_test = new azure.appservice.ActiveSlot("test", {
+ *     appServiceName: azurerm_app_service_test.name,
+ *     appServiceSlotName: azurerm_app_service_slot_test.name,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * ```
  */
 export class ActiveSlot extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/appservice/appService.ts
+++ b/sdk/nodejs/appservice/appService.ts
@@ -8,6 +8,92 @@ import * as utilities from "../utilities";
  * Manages an App Service (within an App Service Plan).
  * 
  * -> **Note:** When using Slots - the `app_settings`, `connection_string` and `site_config` blocks on the `azurerm_app_service` resource will be overwritten when promoting a Slot using the `azurerm_app_service_active_slot` resource.
+ * 
+ * ## Example Usage (.net 4.x)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as random from "@pulumi/random";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "some-resource-group",
+ * });
+ * const random_id_server = new random.RandomId("server", {
+ *     byteLength: 8,
+ *     keepers: {
+ *         azi_id: 1,
+ *     },
+ * });
+ * const azurerm_app_service_plan_test = new azure.appservice.Plan("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "some-app-service-plan",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         size: "S1",
+ *         tier: "Standard",
+ *     },
+ * });
+ * const azurerm_app_service_test = new azure.appservice.AppService("test", {
+ *     appServicePlanId: azurerm_app_service_plan_test.id,
+ *     appSettings: {
+ *         SOME_KEY: "some-value",
+ *     },
+ *     connectionStrings: [{
+ *         name: "Database",
+ *         type: "SQLServer",
+ *         value: "Server=some-server.mydomain.com;Integrated Security=SSPI",
+ *     }],
+ *     location: azurerm_resource_group_test.location,
+ *     name: random_id_server.hex,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     siteConfig: {
+ *         dotnetFrameworkVersion: "v4.0",
+ *         scmType: "LocalGit",
+ *     },
+ * });
+ * ```
+ * 
+ * ## Example Usage (Java 1.8)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as random from "@pulumi/random";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "some-resource-group",
+ * });
+ * const random_id_server = new random.RandomId("server", {
+ *     byteLength: 8,
+ *     keepers: {
+ *         azi_id: 1,
+ *     },
+ * });
+ * const azurerm_app_service_plan_test = new azure.appservice.Plan("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "some-app-service-plan",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         size: "S1",
+ *         tier: "Standard",
+ *     },
+ * });
+ * const azurerm_app_service_test = new azure.appservice.AppService("test", {
+ *     appServicePlanId: azurerm_app_service_plan_test.id,
+ *     location: azurerm_resource_group_test.location,
+ *     name: random_id_server.hex,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     siteConfig: {
+ *         javaContainer: "JETTY",
+ *         javaContainerVersion: "9.3",
+ *         javaVersion: "1.8",
+ *         scmType: "LocalGit",
+ *     },
+ * });
+ * ```
  */
 export class AppService extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/appservice/customHostnameBinding.ts
+++ b/sdk/nodejs/appservice/customHostnameBinding.ts
@@ -6,6 +6,45 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Hostname Binding within an App Service.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * import * as random from "@pulumi/random";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "some-resource-group",
+ * });
+ * const random_id_server = new random.RandomId("server", {
+ *     byteLength: 8,
+ *     keepers: {
+ *         azi_id: 1,
+ *     },
+ * });
+ * const azurerm_app_service_plan_test = new azure.appservice.Plan("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "some-app-service-plan",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         size: "S1",
+ *         tier: "Standard",
+ *     },
+ * });
+ * const azurerm_app_service_test = new azure.appservice.AppService("test", {
+ *     appServicePlanId: azurerm_app_service_plan_test.id,
+ *     location: azurerm_resource_group_test.location,
+ *     name: random_id_server.hex,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_app_service_custom_hostname_binding_test = new azure.appservice.CustomHostnameBinding("test", {
+ *     appServiceName: azurerm_app_service_test.name,
+ *     hostname: "www.mywebsite.com",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * ```
  */
 export class CustomHostnameBinding extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/appservice/functionApp.ts
+++ b/sdk/nodejs/appservice/functionApp.ts
@@ -6,6 +6,77 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Function App.
+ * 
+ * ## Example Usage (with App Service Plan)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "westus2",
+ *     name: "azure-functions-test-rg",
+ * });
+ * const azurerm_app_service_plan_test = new azure.appservice.Plan("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "azure-functions-test-service-plan",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         size: "S1",
+ *         tier: "Standard",
+ *     },
+ * });
+ * const azurerm_storage_account_test = new azure.storage.Account("test", {
+ *     accountReplicationType: "LRS",
+ *     accountTier: "Standard",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "functionsapptestsa",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_function_app_test = new azure.appservice.FunctionApp("test", {
+ *     appServicePlanId: azurerm_app_service_plan_test.id,
+ *     location: azurerm_resource_group_test.location,
+ *     name: "test-azure-functions",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     storageConnectionString: azurerm_storage_account_test.primaryConnectionString,
+ * });
+ * ```
+ * 
+ * ## Example Usage (in a Consumption Plan)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "westus2",
+ *     name: "azure-functions-cptest-rg",
+ * });
+ * const azurerm_app_service_plan_test = new azure.appservice.Plan("test", {
+ *     kind: "FunctionApp",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "azure-functions-test-service-plan",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         size: "Y1",
+ *         tier: "Dynamic",
+ *     },
+ * });
+ * const azurerm_storage_account_test = new azure.storage.Account("test", {
+ *     accountReplicationType: "LRS",
+ *     accountTier: "Standard",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "functionsapptestsa",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_function_app_test = new azure.appservice.FunctionApp("test", {
+ *     appServicePlanId: azurerm_app_service_plan_test.id,
+ *     location: azurerm_resource_group_test.location,
+ *     name: "test-azure-functions",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     storageConnectionString: azurerm_storage_account_test.primaryConnectionString,
+ * });
+ * ```
  */
 export class FunctionApp extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/appservice/getAppService.ts
+++ b/sdk/nodejs/appservice/getAppService.ts
@@ -6,6 +6,20 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing App Service.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_app_service_test = pulumi.output(azure.appservice.getAppService({
+ *     name: "search-app-service",
+ *     resourceGroupName: "search-service",
+ * }));
+ * 
+ * export const appServiceId = azurerm_app_service_test.apply(__arg0 => __arg0.id);
+ * ```
  */
 export function getAppService(args: GetAppServiceArgs, opts?: pulumi.InvokeOptions): Promise<GetAppServiceResult> {
     return pulumi.runtime.invoke("azure:appservice/getAppService:getAppService", {

--- a/sdk/nodejs/appservice/getAppServicePlan.ts
+++ b/sdk/nodejs/appservice/getAppServicePlan.ts
@@ -6,6 +6,20 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing App Service Plan (formerly known as a `Server Farm`).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_app_service_plan_test = pulumi.output(azure.appservice.getAppServicePlan({
+ *     name: "search-app-service-plan",
+ *     resourceGroupName: "search-service",
+ * }));
+ * 
+ * export const appServicePlanId = azurerm_app_service_plan_test.apply(__arg0 => __arg0.id);
+ * ```
  */
 export function getAppServicePlan(args: GetAppServicePlanArgs, opts?: pulumi.InvokeOptions): Promise<GetAppServicePlanResult> {
     return pulumi.runtime.invoke("azure:appservice/getAppServicePlan:getAppServicePlan", {

--- a/sdk/nodejs/appservice/plan.ts
+++ b/sdk/nodejs/appservice/plan.ts
@@ -6,6 +6,74 @@ import * as utilities from "../utilities";
 
 /**
  * Manage an App Service Plan component.
+ * 
+ * ## Example Usage (Dedicated)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "api-rg-pro",
+ * });
+ * const azurerm_app_service_plan_test = new azure.appservice.Plan("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "api-appserviceplan-pro",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         size: "S1",
+ *         tier: "Standard",
+ *     },
+ * });
+ * ```
+ * 
+ * ## Example Usage (Shared / Consumption Plan)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "api-rg-pro",
+ * });
+ * const azurerm_app_service_plan_test = new azure.appservice.Plan("test", {
+ *     kind: "FunctionApp",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "api-appserviceplan-pro",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         size: "Y1",
+ *         tier: "Dynamic",
+ *     },
+ * });
+ * ```
+ * 
+ * ## Example Usage (Linux)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "api-rg-pro",
+ * });
+ * const azurerm_app_service_plan_test = new azure.appservice.Plan("test", {
+ *     kind: "Linux",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "api-appserviceplan-pro",
+ *     properties: {
+ *         reserved: true,
+ *     },
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         size: "S1",
+ *         tier: "Standard",
+ *     },
+ * });
+ * ```
  */
 export class Plan extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/appservice/slot.ts
+++ b/sdk/nodejs/appservice/slot.ts
@@ -9,6 +9,120 @@ import * as utilities from "../utilities";
  * 
  * -> **Note:** When using Slots - the `app_settings`, `connection_string` and `site_config` blocks on the `azurerm_app_service` resource will be overwritten when promoting a Slot using the `azurerm_app_service_active_slot` resource.
  * 
+ * 
+ * ## Example Usage (.net 4.x)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * import * as random from "@pulumi/random";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "some-resource-group",
+ * });
+ * const random_id_server = new random.RandomId("server", {
+ *     byteLength: 8,
+ *     keepers: {
+ *         azi_id: 1,
+ *     },
+ * });
+ * const azurerm_app_service_plan_test = new azure.appservice.Plan("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "some-app-service-plan",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         size: "S1",
+ *         tier: "Standard",
+ *     },
+ * });
+ * const azurerm_app_service_test = new azure.appservice.AppService("test", {
+ *     appServicePlanId: azurerm_app_service_plan_test.id,
+ *     appSettings: {
+ *         SOME_KEY: "some-value",
+ *     },
+ *     connectionStrings: [{
+ *         name: "Database",
+ *         type: "SQLServer",
+ *         value: "Server=some-server.mydomain.com;Integrated Security=SSPI",
+ *     }],
+ *     location: azurerm_resource_group_test.location,
+ *     name: random_id_server.hex,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     siteConfig: {
+ *         dotnetFrameworkVersion: "v4.0",
+ *     },
+ * });
+ * const azurerm_app_service_slot_test = new azure.appservice.Slot("test", {
+ *     appServiceName: azurerm_app_service_test.name,
+ *     appServicePlanId: azurerm_app_service_plan_test.id,
+ *     appSettings: {
+ *         SOME_KEY: "some-value",
+ *     },
+ *     connectionStrings: [{
+ *         name: "Database",
+ *         type: "SQLServer",
+ *         value: "Server=some-server.mydomain.com;Integrated Security=SSPI",
+ *     }],
+ *     location: azurerm_resource_group_test.location,
+ *     name: random_id_server.hex,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     siteConfig: {
+ *         dotnetFrameworkVersion: "v4.0",
+ *     },
+ * });
+ * ```
+ * 
+ * ## Example Usage (Java 1.8)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as random from "@pulumi/random";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "some-resource-group",
+ * });
+ * const random_id_server = new random.RandomId("server", {
+ *     byteLength: 8,
+ *     keepers: {
+ *         azi_id: 1,
+ *     },
+ * });
+ * const azurerm_app_service_plan_test = new azure.appservice.Plan("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "some-app-service-plan",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         size: "S1",
+ *         tier: "Standard",
+ *     },
+ * });
+ * const azurerm_app_service_test = new azure.appservice.AppService("test", {
+ *     appServicePlanId: azurerm_app_service_plan_test.id,
+ *     location: azurerm_resource_group_test.location,
+ *     name: random_id_server.hex,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     siteConfig: {
+ *         javaContainer: "JETTY",
+ *         javaContainerVersion: "9.3",
+ *         javaVersion: "1.8",
+ *     },
+ * });
+ * const azurerm_app_service_slot_test = new azure.appservice.Slot("test", {
+ *     appServiceName: azurerm_app_service_test.name,
+ *     appServicePlanId: azurerm_app_service_plan_test.id,
+ *     location: azurerm_resource_group_test.location,
+ *     name: random_id_server.hex,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     siteConfig: {
+ *         javaContainer: "JETTY",
+ *         javaContainerVersion: "9.3",
+ *         javaVersion: "1.8",
+ *     },
+ * });
+ * ```
  */
 export class Slot extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/automation/account.ts
+++ b/sdk/nodejs/automation/account.ts
@@ -6,6 +6,29 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Automation Account.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_example = new azure.core.ResourceGroup("example", {
+ *     location: "West Europe",
+ *     name: "resourceGroup1",
+ * });
+ * const azurerm_automation_account_example = new azure.automation.Account("example", {
+ *     location: azurerm_resource_group_example.location,
+ *     name: "automationAccount1",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     sku: {
+ *         name: "Basic",
+ *     },
+ *     tags: {
+ *         environment: "development",
+ *     },
+ * });
+ * ```
  */
 export class Account extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/automation/credential.ts
+++ b/sdk/nodejs/automation/credential.ts
@@ -6,6 +6,34 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Automation Credential.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_example = new azure.core.ResourceGroup("example", {
+ *     location: "West Europe",
+ *     name: "resourceGroup1",
+ * });
+ * const azurerm_automation_account_example = new azure.automation.Account("example", {
+ *     location: azurerm_resource_group_example.location,
+ *     name: "account1",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     sku: {
+ *         name: "Basic",
+ *     },
+ * });
+ * const azurerm_automation_credential_example = new azure.automation.Credential("example", {
+ *     accountName: azurerm_automation_account_example.name,
+ *     description: "This is an example credential",
+ *     name: "credential1",
+ *     password: "example_pwd",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     username: "example_user",
+ * });
+ * ```
  */
 export class Credential extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/automation/dscConfiguration.ts
+++ b/sdk/nodejs/automation/dscConfiguration.ts
@@ -6,6 +6,33 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Automation DSC Configuration.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_example = new azure.core.ResourceGroup("example", {
+ *     location: "West Europe",
+ *     name: "resourceGroup1",
+ * });
+ * const azurerm_automation_account_example = new azure.automation.Account("example", {
+ *     location: azurerm_resource_group_example.location,
+ *     name: "account1",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     sku: {
+ *         name: "Basic",
+ *     },
+ * });
+ * const azurerm_automation_dsc_configuration_example = new azure.automation.DscConfiguration("example", {
+ *     automationAccountName: azurerm_automation_account_example.name,
+ *     contentEmbedded: "configuration test {}",
+ *     location: azurerm_resource_group_example.location,
+ *     name: "test",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ * });
+ * ```
  */
 export class DscConfiguration extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/automation/dscNodeConfiguration.ts
+++ b/sdk/nodejs/automation/dscNodeConfiguration.ts
@@ -6,6 +6,39 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Automation DSC Node Configuration.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_example = new azure.core.ResourceGroup("example", {
+ *     location: "West Europe",
+ *     name: "resourceGroup1",
+ * });
+ * const azurerm_automation_account_example = new azure.automation.Account("example", {
+ *     location: azurerm_resource_group_example.location,
+ *     name: "account1",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     sku: {
+ *         name: "Basic",
+ *     },
+ * });
+ * const azurerm_automation_dsc_configuration_example = new azure.automation.DscConfiguration("example", {
+ *     automationAccountName: azurerm_automation_account_example.name,
+ *     contentEmbedded: "configuration test {}",
+ *     location: azurerm_resource_group_example.location,
+ *     name: "test",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ * });
+ * const azurerm_automation_dsc_nodeconfiguration_example = new azure.automation.DscNodeConfiguration("example", {
+ *     automationAccountName: azurerm_automation_account_example.name,
+ *     contentEmbedded: "instance of MSFT_FileDirectoryConfiguration as $MSFT_FileDirectoryConfiguration1ref\n{\n  ResourceID = \"[File]bla\";\n  Ensure = \"Present\";\n  Contents = \"bogus Content\";\n  DestinationPath = \"c:\\\\bogus.txt\";\n  ModuleName = \"PSDesiredStateConfiguration\";\n  SourceInfo = \"::3::9::file\";\n  ModuleVersion = \"1.0\";\n  ConfigurationName = \"bla\";\n};\ninstance of OMI_ConfigurationDocument\n{\n  Version=\"2.0.0\";\n  MinimumCompatibleVersion = \"1.0.0\";\n  CompatibleVersionAdditionalProperties= {\"Omi_BaseResource:ConfigurationName\"};\n  Author=\"bogusAuthor\";\n  GenerationDate=\"06/15/2018 14:06:24\";\n  GenerationHost=\"bogusComputer\";\n  Name=\"test\";\n};\n",
+ *     name: "test.localhost",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ * }, {dependsOn: [azurerm_automation_dsc_configuration_example]});
+ * ```
  */
 export class DscNodeConfiguration extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/automation/module.ts
+++ b/sdk/nodejs/automation/module.ts
@@ -6,6 +6,34 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Automation Module.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_example = new azure.core.ResourceGroup("example", {
+ *     location: "West Europe",
+ *     name: "resourceGroup1",
+ * });
+ * const azurerm_automation_account_example = new azure.automation.Account("example", {
+ *     location: azurerm_resource_group_example.location,
+ *     name: "account1",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     sku: {
+ *         name: "Basic",
+ *     },
+ * });
+ * const azurerm_automation_module_example = new azure.automation.Module("example", {
+ *     automationAccountName: azurerm_automation_account_example.name,
+ *     moduleLink: {
+ *         uri: "https://devopsgallerystorage.blob.core.windows.net/packages/xactivedirectory.2.19.0.nupkg",
+ *     },
+ *     name: "xActiveDirectory",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ * });
+ * ```
  */
 export class Module extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/automation/runBook.ts
+++ b/sdk/nodejs/automation/runBook.ts
@@ -6,6 +6,39 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Automation Runbook.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_example = new azure.core.ResourceGroup("example", {
+ *     location: "West Europe",
+ *     name: "resourceGroup1",
+ * });
+ * const azurerm_automation_account_example = new azure.automation.Account("example", {
+ *     location: azurerm_resource_group_example.location,
+ *     name: "account1",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     sku: {
+ *         name: "Basic",
+ *     },
+ * });
+ * const azurerm_automation_runbook_example = new azure.automation.RunBook("example", {
+ *     accountName: azurerm_automation_account_example.name,
+ *     description: "This is an example runbook",
+ *     location: azurerm_resource_group_example.location,
+ *     logProgress: true,
+ *     logVerbose: true,
+ *     name: "Get-AzureVMTutorial",
+ *     publishContentLink: {
+ *         uri: "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/101-automation-runbook-getvms/Runbooks/Get-AzureVMTutorial.ps1",
+ *     },
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     runbookType: "PowerShellWorkflow",
+ * });
+ * ```
  */
 export class RunBook extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/automation/schedule.ts
+++ b/sdk/nodejs/automation/schedule.ts
@@ -6,6 +6,39 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Automation Schedule.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_example = new azure.core.ResourceGroup("example", {
+ *     location: "West Europe",
+ *     name: "tfex-automation-account",
+ * });
+ * const azurerm_automation_account_example = new azure.automation.Account("example", {
+ *     location: azurerm_resource_group_example.location,
+ *     name: "tfex-automation-account",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     sku: {
+ *         name: "Basic",
+ *     },
+ * });
+ * const azurerm_automation_schedule_example = new azure.automation.Schedule("example", {
+ *     advancedSchedule: [{
+ *         weekDays: ["Friday"],
+ *     }],
+ *     automationAccountName: azurerm_automation_account_example.name,
+ *     description: "This is an example schedule",
+ *     frequency: "Week",
+ *     interval: 1,
+ *     name: "tfex-automation-schedule",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     startTime: "2014-04-15T18:00:15+02:00",
+ *     timezone: "Central Europe Standard Time",
+ * });
+ * ```
  */
 export class Schedule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/cdn/endpoint.ts
+++ b/sdk/nodejs/cdn/endpoint.ts
@@ -6,6 +6,41 @@ import * as utilities from "../utilities";
 
 /**
  * A CDN Endpoint is the entity within a CDN Profile containing configuration information regarding caching behaviors and origins. The CDN Endpoint is exposed using the URL format <endpointname>.azureedge.net.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as random from "@pulumi/random";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acceptanceTestResourceGroup1",
+ * });
+ * const random_id_server = new random.RandomId("server", {
+ *     byteLength: 8,
+ *     keepers: {
+ *         azi_id: 1,
+ *     },
+ * });
+ * const azurerm_cdn_profile_test = new azure.cdn.Profile("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "exampleCdnProfile",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: "Standard_Verizon",
+ * });
+ * const azurerm_cdn_endpoint_test = new azure.cdn.Endpoint("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: random_id_server.hex,
+ *     origins: [{
+ *         hostName: "www.example.com",
+ *         name: "exampleCdnOrigin",
+ *     }],
+ *     profileName: azurerm_cdn_profile_test.name,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * ```
  */
 export class Endpoint extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/cdn/getProfile.ts
+++ b/sdk/nodejs/cdn/getProfile.ts
@@ -6,6 +6,20 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing CDN Profile.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_cdn_profile_test = pulumi.output(azure.cdn.getProfile({
+ *     name: "myfirstcdnprofile",
+ *     resourceGroupName: "example-resources",
+ * }));
+ * 
+ * export const cdnProfileId = azurerm_cdn_profile_test.apply(__arg0 => __arg0.id);
+ * ```
  */
 export function getProfile(args: GetProfileArgs, opts?: pulumi.InvokeOptions): Promise<GetProfileResult> {
     return pulumi.runtime.invoke("azure:cdn/getProfile:getProfile", {

--- a/sdk/nodejs/cdn/profile.ts
+++ b/sdk/nodejs/cdn/profile.ts
@@ -6,6 +6,28 @@ import * as utilities from "../utilities";
 
 /**
  * Manage a CDN Profile to create a collection of CDN Endpoints.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "resourceGroup1",
+ * });
+ * const azurerm_cdn_profile_test = new azure.cdn.Profile("test", {
+ *     location: "West US",
+ *     name: "exampleCdnProfile",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: "Standard_Verizon",
+ *     tags: {
+ *         cost_center: "MSFT",
+ *         environment: "Production",
+ *     },
+ * });
+ * ```
  */
 export class Profile extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/cognitive/account.ts
+++ b/sdk/nodejs/cognitive/account.ts
@@ -6,6 +6,31 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Cognitive Services Account.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "example-resources",
+ * });
+ * const azurerm_cognitive_account_test = new azure.cognitive.Account("test", {
+ *     kind: "Face",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-account",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         name: "S0",
+ *         tier: "Standard",
+ *     },
+ *     tags: {
+ *         Acceptance: "Test",
+ *     },
+ * });
+ * ```
  */
 export class Account extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/compute/availabilitySet.ts
+++ b/sdk/nodejs/compute/availabilitySet.ts
@@ -6,6 +6,26 @@ import * as utilities from "../utilities";
 
 /**
  * Manages an availability set for virtual machines.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "resourceGroup1",
+ * });
+ * const azurerm_availability_set_test = new azure.compute.AvailabilitySet("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "acceptanceTestAvailabilitySet1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         environment: "Production",
+ *     },
+ * });
+ * ```
  */
 export class AvailabilitySet extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/compute/dataDiskAttachment.ts
+++ b/sdk/nodejs/compute/dataDiskAttachment.ts
@@ -7,7 +7,7 @@ import * as utilities from "../utilities";
 /**
  * Manages attaching a Disk to a Virtual Machine.
  * 
- * ~> **NOTE:** Data Disks can be attached either directly on the `azurerm_virtual_machine` resource, or using the `azurerm_virtual_machine_data_disk_attachment` resource - but the two cannot be used together. If both are used against the same Virtual Machine, spurious changes will occur.
+ * > **NOTE:** Data Disks can be attached either directly on the `azurerm_virtual_machine` resource, or using the `azurerm_virtual_machine_data_disk_attachment` resource - but the two cannot be used together. If both are used against the same Virtual Machine, spurious changes will occur.
  * 
  * -> **Please Note:** only Managed Disks are supported via this separate resource, Unmanaged Disks can be attached using the `storage_data_disk` block in the `azurerm_virtual_machine` resource.
  */

--- a/sdk/nodejs/compute/extension.ts
+++ b/sdk/nodejs/compute/extension.ts
@@ -8,9 +8,102 @@ import * as utilities from "../utilities";
  * Manages a Virtual Machine Extension to provide post deployment configuration
  * and run automated tasks.
  * 
- * ~> **NOTE:** Custom Script Extensions for Linux & Windows require that the `commandToExecute` returns a `0` exit code to be classified as successfully deployed. You can achieve this by appending `exit 0` to the end of your `commandToExecute`.
+ * > **NOTE:** Custom Script Extensions for Linux & Windows require that the `commandToExecute` returns a `0` exit code to be classified as successfully deployed. You can achieve this by appending `exit 0` to the end of your `commandToExecute`.
  * 
  * -> **NOTE:** Custom Script Extensions require that the Azure Virtual Machine Guest Agent is running on the Virtual Machine.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acctestRG",
+ * });
+ * const azurerm_virtual_network_test = new azure.network.VirtualNetwork("test", {
+ *     addressSpaces: ["10.0.0.0/16"],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "acctvn",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_subnet_test = new azure.network.Subnet("test", {
+ *     addressPrefix: "10.0.2.0/24",
+ *     name: "acctsub",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     virtualNetworkName: azurerm_virtual_network_test.name,
+ * });
+ * const azurerm_network_interface_test = new azure.network.NetworkInterface("test", {
+ *     ipConfigurations: [{
+ *         name: "testconfiguration1",
+ *         privateIpAddressAllocation: "dynamic",
+ *         subnetId: azurerm_subnet_test.id,
+ *     }],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "acctni",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_storage_account_test = new azure.storage.Account("test", {
+ *     accountReplicationType: "LRS",
+ *     accountTier: "Standard",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "accsa",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         environment: "staging",
+ *     },
+ * });
+ * const azurerm_storage_container_test = new azure.storage.Container("test", {
+ *     containerAccessType: "private",
+ *     name: "vhds",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     storageAccountName: azurerm_storage_account_test.name,
+ * });
+ * const azurerm_virtual_machine_test = new azure.compute.VirtualMachine("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "acctvm",
+ *     networkInterfaceIds: [azurerm_network_interface_test.id],
+ *     osProfile: {
+ *         adminPassword: "Password1234!",
+ *         adminUsername: "testadmin",
+ *         computerName: "hostname",
+ *     },
+ *     osProfileLinuxConfig: {
+ *         disablePasswordAuthentication: false,
+ *     },
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     storageImageReference: {
+ *         offer: "UbuntuServer",
+ *         publisher: "Canonical",
+ *         sku: "16.04-LTS",
+ *         version: "latest",
+ *     },
+ *     storageOsDisk: {
+ *         caching: "ReadWrite",
+ *         createOption: "FromImage",
+ *         name: "myosdisk1",
+ *         vhdUri: pulumi.all([azurerm_storage_account_test.primaryBlobEndpoint, azurerm_storage_container_test.name]).apply(([__arg0, __arg1]) => `${__arg0}${__arg1}/myosdisk1.vhd`),
+ *     },
+ *     tags: {
+ *         environment: "staging",
+ *     },
+ *     vmSize: "Standard_F2",
+ * });
+ * const azurerm_virtual_machine_extension_test = new azure.compute.Extension("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "hostname",
+ *     publisher: "Microsoft.Azure.Extensions",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     settings: "\t{\n\t\t\"commandToExecute\": \"hostname && uptime\"\n\t}\n",
+ *     tags: {
+ *         environment: "Production",
+ *     },
+ *     type: "CustomScript",
+ *     typeHandlerVersion: "2.0",
+ *     virtualMachineName: azurerm_virtual_machine_test.name,
+ * });
+ * ```
  */
 export class Extension extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/compute/getImage.ts
+++ b/sdk/nodejs/compute/getImage.ts
@@ -6,6 +6,20 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing Image.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_image_search = pulumi.output(azure.compute.getImage({
+ *     name: "search-api",
+ *     resourceGroupName: "packerimages",
+ * }));
+ * 
+ * export const imageId = azurerm_image_search.apply(__arg0 => __arg0.id);
+ * ```
  */
 export function getImage(args: GetImageArgs, opts?: pulumi.InvokeOptions): Promise<GetImageResult> {
     return pulumi.runtime.invoke("azure:compute/getImage:getImage", {

--- a/sdk/nodejs/compute/getManagedDisk.ts
+++ b/sdk/nodejs/compute/getManagedDisk.ts
@@ -6,6 +6,86 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing Managed Disk.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_virtual_network_test = new azure.network.VirtualNetwork("test", {
+ *     addressSpaces: ["10.0.0.0/16"],
+ *     location: "West US 2",
+ *     name: "acctvn",
+ *     resourceGroupName: "acctestRG",
+ * });
+ * const azurerm_managed_disk_datasourcemd = pulumi.output(azure.compute.getManagedDisk({
+ *     name: "testManagedDisk",
+ *     resourceGroupName: "acctestRG",
+ * }));
+ * const azurerm_subnet_test = new azure.network.Subnet("test", {
+ *     addressPrefix: "10.0.2.0/24",
+ *     name: "acctsub",
+ *     resourceGroupName: "acctestRG",
+ *     virtualNetworkName: azurerm_virtual_network_test.name,
+ * });
+ * const azurerm_network_interface_test = new azure.network.NetworkInterface("test", {
+ *     ipConfigurations: [{
+ *         name: "testconfiguration1",
+ *         privateIpAddressAllocation: "dynamic",
+ *         subnetId: azurerm_subnet_test.id,
+ *     }],
+ *     location: "West US 2",
+ *     name: "acctni",
+ *     resourceGroupName: "acctestRG",
+ * });
+ * const azurerm_virtual_machine_test = new azure.compute.VirtualMachine("test", {
+ *     location: "West US 2",
+ *     name: "acctvm",
+ *     networkInterfaceIds: [azurerm_network_interface_test.id],
+ *     osProfile: {
+ *         adminPassword: "Password1234!",
+ *         adminUsername: "testadmin",
+ *         computerName: "hostname",
+ *     },
+ *     osProfileLinuxConfig: {
+ *         disablePasswordAuthentication: false,
+ *     },
+ *     resourceGroupName: "acctestRG",
+ *     storageDataDisks: [
+ *         {
+ *             createOption: "Empty",
+ *             diskSizeGb: Number.parseFloat("1023"),
+ *             lun: 0,
+ *             managedDiskType: "Standard_LRS",
+ *             name: "datadisk_new",
+ *         },
+ *         {
+ *             createOption: "Attach",
+ *             diskSizeGb: azurerm_managed_disk_datasourcemd.apply(__arg0 => __arg0.diskSizeGb),
+ *             lun: 1,
+ *             managedDiskId: azurerm_managed_disk_datasourcemd.apply(__arg0 => __arg0.id),
+ *             name: azurerm_managed_disk_datasourcemd.apply(__arg0 => __arg0.name),
+ *         },
+ *     ],
+ *     storageImageReference: {
+ *         offer: "UbuntuServer",
+ *         publisher: "Canonical",
+ *         sku: "16.04-LTS",
+ *         version: "latest",
+ *     },
+ *     storageOsDisk: {
+ *         caching: "ReadWrite",
+ *         createOption: "FromImage",
+ *         managedDiskType: "Standard_LRS",
+ *         name: "myosdisk1",
+ *     },
+ *     tags: {
+ *         environment: "staging",
+ *     },
+ *     vmSize: "Standard_DS1_v2",
+ * });
+ * ```
  */
 export function getManagedDisk(args: GetManagedDiskArgs, opts?: pulumi.InvokeOptions): Promise<GetManagedDiskResult> {
     return pulumi.runtime.invoke("azure:compute/getManagedDisk:getManagedDisk", {

--- a/sdk/nodejs/compute/getPlatformImage.ts
+++ b/sdk/nodejs/compute/getPlatformImage.ts
@@ -6,6 +6,22 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about a Platform Image.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_platform_image_test = pulumi.output(azure.compute.getPlatformImage({
+ *     location: "West Europe",
+ *     offer: "UbuntuServer",
+ *     publisher: "Canonical",
+ *     sku: "16.04-LTS",
+ * }));
+ * 
+ * export const version = azurerm_platform_image_test.apply(__arg0 => __arg0.version);
+ * ```
  */
 export function getPlatformImage(args: GetPlatformImageArgs, opts?: pulumi.InvokeOptions): Promise<GetPlatformImageResult> {
     return pulumi.runtime.invoke("azure:compute/getPlatformImage:getPlatformImage", {

--- a/sdk/nodejs/compute/getSharedImage.ts
+++ b/sdk/nodejs/compute/getSharedImage.ts
@@ -8,6 +8,19 @@ import * as utilities from "../utilities";
  * Use this data source to access information about an existing Shared Image within a Shared Image Gallery.
  * 
  * -> **NOTE** Shared Image Galleries are currently in Public Preview. You can find more information, including [how to register for the Public Preview here](https://azure.microsoft.com/en-gb/blog/announcing-the-public-preview-of-shared-image-gallery/).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_shared_image_test = pulumi.output(azure.compute.getSharedImage({
+ *     galleryName: "my-image-gallery",
+ *     name: "my-image",
+ *     resourceGroupName: "example-resources",
+ * }));
+ * ```
  */
 export function getSharedImage(args: GetSharedImageArgs, opts?: pulumi.InvokeOptions): Promise<GetSharedImageResult> {
     return pulumi.runtime.invoke("azure:compute/getSharedImage:getSharedImage", {

--- a/sdk/nodejs/compute/getSharedImageGallery.ts
+++ b/sdk/nodejs/compute/getSharedImageGallery.ts
@@ -8,6 +8,18 @@ import * as utilities from "../utilities";
  * Use this data source to access information about an existing Shared Image Gallery.
  * 
  * -> **NOTE** Shared Image Galleries are currently in Public Preview. You can find more information, including [how to register for the Public Preview here](https://azure.microsoft.com/en-gb/blog/announcing-the-public-preview-of-shared-image-gallery/).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_shared_image_gallery_test = pulumi.output(azure.compute.getSharedImageGallery({
+ *     name: "my-image-gallery",
+ *     resourceGroupName: "example-resources",
+ * }));
+ * ```
  */
 export function getSharedImageGallery(args: GetSharedImageGalleryArgs, opts?: pulumi.InvokeOptions): Promise<GetSharedImageGalleryResult> {
     return pulumi.runtime.invoke("azure:compute/getSharedImageGallery:getSharedImageGallery", {

--- a/sdk/nodejs/compute/getSharedImageVersion.ts
+++ b/sdk/nodejs/compute/getSharedImageVersion.ts
@@ -8,6 +8,20 @@ import * as utilities from "../utilities";
  * Use this data source to access information about an existing Version of a Shared Image within a Shared Image Gallery.
  * 
  * -> **NOTE** Shared Image Galleries are currently in Public Preview. You can find more information, including [how to register for the Public Preview here](https://azure.microsoft.com/en-gb/blog/announcing-the-public-preview-of-shared-image-gallery/).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_shared_image_version_test = pulumi.output(azure.compute.getSharedImageVersion({
+ *     galleryName: "my-image-gallery",
+ *     imageName: "my-image",
+ *     name: "1.0.0",
+ *     resourceGroupName: "example-resources",
+ * }));
+ * ```
  */
 export function getSharedImageVersion(args: GetSharedImageVersionArgs, opts?: pulumi.InvokeOptions): Promise<GetSharedImageVersionResult> {
     return pulumi.runtime.invoke("azure:compute/getSharedImageVersion:getSharedImageVersion", {

--- a/sdk/nodejs/compute/getSnapshot.ts
+++ b/sdk/nodejs/compute/getSnapshot.ts
@@ -6,6 +6,18 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing Snapshot.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_snapshot_test = pulumi.output(azure.compute.getSnapshot({
+ *     name: "my-snapshot",
+ *     resourceGroupName: "my-resource-group",
+ * }));
+ * ```
  */
 export function getSnapshot(args: GetSnapshotArgs, opts?: pulumi.InvokeOptions): Promise<GetSnapshotResult> {
     return pulumi.runtime.invoke("azure:compute/getSnapshot:getSnapshot", {

--- a/sdk/nodejs/compute/image.ts
+++ b/sdk/nodejs/compute/image.ts
@@ -6,6 +6,47 @@ import * as utilities from "../utilities";
 
 /**
  * Manage a custom virtual machine image that can be used to create virtual machines.
+ * 
+ * ## Example Usage Creating from VHD
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acctest",
+ * });
+ * const azurerm_image_test = new azure.compute.Image("test", {
+ *     location: "West US",
+ *     name: "acctest",
+ *     osDisk: {
+ *         blobUri: "{blob_uri}",
+ *         osState: "Generalized",
+ *         osType: "Linux",
+ *         sizeGb: 30,
+ *     },
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * ```
+ * 
+ * ## Example Usage Creating from Virtual Machine (VM must be generalized beforehand)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acctest",
+ * });
+ * const azurerm_image_test = new azure.compute.Image("test", {
+ *     location: "West US",
+ *     name: "acctest",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sourceVirtualMachineId: "{vm_id}",
+ * });
+ * ```
  */
 export class Image extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/compute/managedDisk.ts
+++ b/sdk/nodejs/compute/managedDisk.ts
@@ -6,6 +6,64 @@ import * as utilities from "../utilities";
 
 /**
  * Manage a managed disk.
+ * 
+ * ## Example Usage with Create Empty
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US 2",
+ *     name: "acctestRG",
+ * });
+ * const azurerm_managed_disk_test = new azure.compute.ManagedDisk("test", {
+ *     createOption: "Empty",
+ *     diskSizeGb: Number.parseFloat("1"),
+ *     location: "West US 2",
+ *     name: "acctestmd",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     storageAccountType: "Standard_LRS",
+ *     tags: {
+ *         environment: "staging",
+ *     },
+ * });
+ * ```
+ * 
+ * ## Example Usage with Create Copy
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US 2",
+ *     name: "acctestRG",
+ * });
+ * const azurerm_managed_disk_source = new azure.compute.ManagedDisk("source", {
+ *     createOption: "Empty",
+ *     diskSizeGb: Number.parseFloat("1"),
+ *     location: "West US 2",
+ *     name: "acctestmd1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     storageAccountType: "Standard_LRS",
+ *     tags: {
+ *         environment: "staging",
+ *     },
+ * });
+ * const azurerm_managed_disk_copy = new azure.compute.ManagedDisk("copy", {
+ *     createOption: "Copy",
+ *     diskSizeGb: Number.parseFloat("1"),
+ *     location: "West US 2",
+ *     name: "acctestmd2",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sourceResourceId: azurerm_managed_disk_source.id,
+ *     storageAccountType: "Standard_LRS",
+ *     tags: {
+ *         environment: "staging",
+ *     },
+ * });
+ * ```
  */
 export class ManagedDisk extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/compute/scaleSet.ts
+++ b/sdk/nodejs/compute/scaleSet.ts
@@ -7,8 +7,240 @@ import * as utilities from "../utilities";
 /**
  * Manage a virtual machine scale set.
  * 
- * ~> **Note:** All arguments including the administrator login and password will be stored in the raw state as plain-text.
+ * > **Note:** All arguments including the administrator login and password will be stored in the raw state as plain-text.
  * [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
+ * 
+ * ## Example Usage with Managed Disks (Recommended)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * import * as fs from "fs";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US 2",
+ *     name: "acctestRG",
+ * });
+ * const azurerm_public_ip_test = new azure.network.PublicIp("test", {
+ *     domainNameLabel: azurerm_resource_group_test.name,
+ *     location: azurerm_resource_group_test.location,
+ *     name: "test",
+ *     publicIpAddressAllocation: "static",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         environment: "staging",
+ *     },
+ * });
+ * const azurerm_lb_test = new azure.lb.LoadBalancer("test", {
+ *     frontendIpConfigurations: [{
+ *         name: "PublicIPAddress",
+ *         publicIpAddressId: azurerm_public_ip_test.id,
+ *     }],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "test",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_lb_backend_address_pool_bpepool = new azure.lb.BackendAddressPool("bpepool", {
+ *     loadbalancerId: azurerm_lb_test.id,
+ *     name: "BackEndAddressPool",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_lb_nat_pool_lbnatpool: azure.lb.NatPool[] = [];
+ * for (let i = 0; i < 3; i++) {
+ *     azurerm_lb_nat_pool_lbnatpool.push(new azure.lb.NatPool(`lbnatpool-${i}`, {
+ *         backendPort: 22,
+ *         frontendIpConfigurationName: "PublicIPAddress",
+ *         frontendPortEnd: 50119,
+ *         frontendPortStart: 50000,
+ *         loadbalancerId: azurerm_lb_test.id,
+ *         name: "ssh",
+ *         protocol: "Tcp",
+ *         resourceGroupName: azurerm_resource_group_test.name,
+ *     }));
+ * }
+ * const azurerm_lb_probe_test = new azure.lb.Probe("test", {
+ *     loadbalancerId: azurerm_lb_test.id,
+ *     name: "http-probe",
+ *     port: 8080,
+ *     requestPath: "/health",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_virtual_network_test = new azure.network.VirtualNetwork("test", {
+ *     addressSpaces: ["10.0.0.0/16"],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "acctvn",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_subnet_test = new azure.network.Subnet("test", {
+ *     addressPrefix: "10.0.2.0/24",
+ *     name: "acctsub",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     virtualNetworkName: azurerm_virtual_network_test.name,
+ * });
+ * const azurerm_virtual_machine_scale_set_test = new azure.compute.ScaleSet("test", {
+ *     automaticOsUpgrade: true,
+ *     healthProbeId: azurerm_lb_probe_test.id,
+ *     location: azurerm_resource_group_test.location,
+ *     name: "mytestscaleset-1",
+ *     networkProfiles: [{
+ *         ipConfigurations: [{
+ *             loadBalancerBackendAddressPoolIds: [azurerm_lb_backend_address_pool_bpepool.id],
+ *             loadBalancerInboundNatRulesIds: [pulumi.all(azurerm_lb_nat_pool_lbnatpool.map(v => v.id)).apply(__arg0 => __arg0.map(v => v)[1])],
+ *             name: "TestIPConfiguration",
+ *             primary: true,
+ *             subnetId: azurerm_subnet_test.id,
+ *         }],
+ *         name: "terraformnetworkprofile",
+ *         primary: true,
+ *     }],
+ *     osProfile: {
+ *         adminUsername: "myadmin",
+ *         computerNamePrefix: "testvm",
+ *     },
+ *     osProfileLinuxConfig: {
+ *         disablePasswordAuthentication: true,
+ *         sshKeys: [{
+ *             keyData: fs.readFileSync("~/.ssh/demo_key.pub", "utf-8"),
+ *             path: "/home/myadmin/.ssh/authorized_keys",
+ *         }],
+ *     },
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     rollingUpgradePolicy: {
+ *         maxBatchInstancePercent: 20,
+ *         maxUnhealthyInstancePercent: 20,
+ *         maxUnhealthyUpgradedInstancePercent: 5,
+ *         pauseTimeBetweenBatches: "PT0S",
+ *     },
+ *     sku: {
+ *         capacity: 2,
+ *         name: "Standard_F2",
+ *         tier: "Standard",
+ *     },
+ *     storageProfileDataDisks: [{
+ *         caching: "ReadWrite",
+ *         createOption: "Empty",
+ *         diskSizeGb: 10,
+ *         lun: 0,
+ *     }],
+ *     storageProfileImageReference: {
+ *         offer: "UbuntuServer",
+ *         publisher: "Canonical",
+ *         sku: "16.04-LTS",
+ *         version: "latest",
+ *     },
+ *     storageProfileOsDisk: {
+ *         caching: "ReadWrite",
+ *         createOption: "FromImage",
+ *         managedDiskType: "Standard_LRS",
+ *         name: "",
+ *     },
+ *     tags: {
+ *         environment: "staging",
+ *     },
+ *     upgradePolicyMode: "Rolling",
+ * });
+ * ```
+ * 
+ * ## Example Usage with Unmanaged Disks
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * import * as fs from "fs";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acctestRG",
+ * });
+ * const azurerm_storage_account_test = new azure.storage.Account("test", {
+ *     accountReplicationType: "LRS",
+ *     accountTier: "Standard",
+ *     location: "westus",
+ *     name: "accsa",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         environment: "staging",
+ *     },
+ * });
+ * const azurerm_storage_container_test = new azure.storage.Container("test", {
+ *     containerAccessType: "private",
+ *     name: "vhds",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     storageAccountName: azurerm_storage_account_test.name,
+ * });
+ * const azurerm_virtual_network_test = new azure.network.VirtualNetwork("test", {
+ *     addressSpaces: ["10.0.0.0/16"],
+ *     location: "West US",
+ *     name: "acctvn",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_subnet_test = new azure.network.Subnet("test", {
+ *     addressPrefix: "10.0.2.0/24",
+ *     name: "acctsub",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     virtualNetworkName: azurerm_virtual_network_test.name,
+ * });
+ * const azurerm_virtual_machine_scale_set_test = new azure.compute.ScaleSet("test", {
+ *     location: "West US",
+ *     name: "mytestscaleset-1",
+ *     networkProfiles: [{
+ *         ipConfigurations: [{
+ *             name: "TestIPConfiguration",
+ *             primary: true,
+ *             subnetId: azurerm_subnet_test.id,
+ *         }],
+ *         name: "TestNetworkProfile",
+ *         primary: true,
+ *     }],
+ *     osProfile: {
+ *         adminUsername: "myadmin",
+ *         computerNamePrefix: "testvm",
+ *     },
+ *     osProfileLinuxConfig: {
+ *         disablePasswordAuthentication: true,
+ *         sshKeys: [{
+ *             keyData: fs.readFileSync("~/.ssh/demo_key.pub", "utf-8"),
+ *             path: "/home/myadmin/.ssh/authorized_keys",
+ *         }],
+ *     },
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         capacity: 2,
+ *         name: "Standard_F2",
+ *         tier: "Standard",
+ *     },
+ *     storageProfileImageReference: {
+ *         offer: "UbuntuServer",
+ *         publisher: "Canonical",
+ *         sku: "16.04-LTS",
+ *         version: "latest",
+ *     },
+ *     storageProfileOsDisk: {
+ *         caching: "ReadWrite",
+ *         createOption: "FromImage",
+ *         name: "osDiskProfile",
+ *         vhdContainers: [pulumi.all([azurerm_storage_account_test.primaryBlobEndpoint, azurerm_storage_container_test.name]).apply(([__arg0, __arg1]) => `${__arg0}${__arg1}`)],
+ *     },
+ *     upgradePolicyMode: "Manual",
+ * });
+ * ```
+ * 
+ * ## Example of storage_profile_image_reference with id
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_image_test = new azure.compute.Image("test", {
+ *     name: "test",
+ * });
+ * const azurerm_virtual_machine_scale_set_test = new azure.compute.ScaleSet("test", {
+ *     name: "test",
+ *     storageProfileImageReference: {
+ *         id: azurerm_image_test.id,
+ *     },
+ * });
+ * ```
  */
 export class ScaleSet extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/compute/sharedImage.ts
+++ b/sdk/nodejs/compute/sharedImage.ts
@@ -8,6 +8,40 @@ import * as utilities from "../utilities";
  * Manages a Shared Image within a Shared Image Gallery.
  * 
  * -> **NOTE** Shared Image Galleries are currently in Public Preview. You can find more information, including [how to register for the Public Preview here](https://azure.microsoft.com/en-gb/blog/announcing-the-public-preview-of-shared-image-gallery/).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "example-resources",
+ * });
+ * const azurerm_shared_image_gallery_test = new azure.compute.SharedImageGallery("test", {
+ *     description: "Shared images and things.",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example_image_gallery",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         Hello: "There",
+ *         World: "Example",
+ *     },
+ * });
+ * const azurerm_shared_image_test = new azure.compute.SharedImage("test", {
+ *     galleryName: azurerm_shared_image_gallery_test.name,
+ *     identifier: {
+ *         offer: "OfferName",
+ *         publisher: "PublisherName",
+ *         sku: "ExampleSku",
+ *     },
+ *     location: azurerm_resource_group_test.location,
+ *     name: "my-image",
+ *     osType: "Linux",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * ```
  */
 export class SharedImage extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/compute/sharedImageGallery.ts
+++ b/sdk/nodejs/compute/sharedImageGallery.ts
@@ -8,6 +8,28 @@ import * as utilities from "../utilities";
  * Manages a Shared Image Gallery.
  * 
  * -> **NOTE** Shared Image Galleries are currently in Public Preview. You can find more information, including [how to register for the Public Preview here](https://azure.microsoft.com/en-gb/blog/announcing-the-public-preview-of-shared-image-gallery/).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "example-resources",
+ * });
+ * const azurerm_shared_image_gallery_test = new azure.compute.SharedImageGallery("test", {
+ *     description: "Shared images and things.",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example_image_gallery",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         Hello: "There",
+ *         World: "Example",
+ *     },
+ * });
+ * ```
  */
 export class SharedImageGallery extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/compute/sharedImageVersion.ts
+++ b/sdk/nodejs/compute/sharedImageVersion.ts
@@ -8,6 +8,35 @@ import * as utilities from "../utilities";
  * Manages a Version of a Shared Image within a Shared Image Gallery.
  * 
  * -> **NOTE** Shared Image Galleries are currently in Public Preview. You can find more information, including [how to register for the Public Preview here](https://azure.microsoft.com/en-gb/blog/announcing-the-public-preview-of-shared-image-gallery/).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_image_existing = pulumi.output(azure.compute.getImage({
+ *     name: "search-api",
+ *     resourceGroupName: "packerimages",
+ * }));
+ * const azurerm_shared_image_existing = pulumi.output(azure.compute.getSharedImage({
+ *     galleryName: "existing_gallery",
+ *     name: "existing-image",
+ *     resourceGroupName: "existing-resources",
+ * }));
+ * const azurerm_shared_image_version_test = new azure.compute.SharedImageVersion("test", {
+ *     galleryName: azurerm_shared_image_existing.apply(__arg0 => __arg0.galleryName),
+ *     imageName: azurerm_shared_image_existing.apply(__arg0 => __arg0.name),
+ *     location: azurerm_shared_image_existing.apply(__arg0 => __arg0.location),
+ *     managedImageId: azurerm_image_existing.apply(__arg0 => __arg0.id),
+ *     name: "0.0.1",
+ *     resourceGroupName: azurerm_shared_image_existing.apply(__arg0 => __arg0.resourceGroupName),
+ *     targetRegions: [{
+ *         name: azurerm_shared_image_existing.apply(__arg0 => __arg0.location),
+ *         regionalReplicaCount: Number.parseFloat("5"),
+ *     }],
+ * });
+ * ```
  */
 export class SharedImageVersion extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/compute/snapshot.ts
+++ b/sdk/nodejs/compute/snapshot.ts
@@ -6,6 +6,33 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Disk Snapshot.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "snapshot-rg",
+ * });
+ * const azurerm_managed_disk_test = new azure.compute.ManagedDisk("test", {
+ *     createOption: "Empty",
+ *     diskSizeGb: Number.parseFloat("10"),
+ *     location: azurerm_resource_group_test.location,
+ *     name: "managed-disk",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     storageAccountType: "Standard_LRS",
+ * });
+ * const azurerm_snapshot_test = new azure.compute.Snapshot("test", {
+ *     createOption: "Copy",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "snapshot",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sourceUri: azurerm_managed_disk_test.id,
+ * });
+ * ```
  */
 export class Snapshot extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/compute/virtualMachine.ts
+++ b/sdk/nodejs/compute/virtualMachine.ts
@@ -7,7 +7,76 @@ import * as utilities from "../utilities";
 /**
  * Manages a Virtual Machine.
  * 
- * ~> **NOTE:** Data Disks can be attached either directly on the `azurerm_virtual_machine` resource, or using the `azurerm_virtual_machine_data_disk_attachment` resource - but the two cannot be used together. If both are used against the same Virtual Machine, spurious changes will occur.
+ * > **NOTE:** Data Disks can be attached either directly on the `azurerm_virtual_machine` resource, or using the `azurerm_virtual_machine_data_disk_attachment` resource - but the two cannot be used together. If both are used against the same Virtual Machine, spurious changes will occur.
+ * 
+ * ## Example Usage (from an Azure Platform Image)
+ * 
+ * This example provisions a Virtual Machine with Managed Disks. Other examples of the `azurerm_virtual_machine` resource can be found in [the `./examples/virtual-machines` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/examples/virtual-machines)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const config = new pulumi.Config();
+ * const var_prefix = config.get("prefix") || "tfvmex";
+ * 
+ * const azurerm_resource_group_main = new azure.core.ResourceGroup("main", {
+ *     location: "West US 2",
+ *     name: `${var_prefix}-resources`,
+ * });
+ * const azurerm_virtual_network_main = new azure.network.VirtualNetwork("main", {
+ *     addressSpaces: ["10.0.0.0/16"],
+ *     location: azurerm_resource_group_main.location,
+ *     name: `${var_prefix}-network`,
+ *     resourceGroupName: azurerm_resource_group_main.name,
+ * });
+ * const azurerm_subnet_internal = new azure.network.Subnet("internal", {
+ *     addressPrefix: "10.0.2.0/24",
+ *     name: "internal",
+ *     resourceGroupName: azurerm_resource_group_main.name,
+ *     virtualNetworkName: azurerm_virtual_network_main.name,
+ * });
+ * const azurerm_network_interface_main = new azure.network.NetworkInterface("main", {
+ *     ipConfigurations: [{
+ *         name: "testconfiguration1",
+ *         privateIpAddressAllocation: "dynamic",
+ *         subnetId: azurerm_subnet_internal.id,
+ *     }],
+ *     location: azurerm_resource_group_main.location,
+ *     name: `${var_prefix}-nic`,
+ *     resourceGroupName: azurerm_resource_group_main.name,
+ * });
+ * const azurerm_virtual_machine_main = new azure.compute.VirtualMachine("main", {
+ *     location: azurerm_resource_group_main.location,
+ *     name: `${var_prefix}-vm`,
+ *     networkInterfaceIds: [azurerm_network_interface_main.id],
+ *     osProfile: {
+ *         adminPassword: "Password1234!",
+ *         adminUsername: "testadmin",
+ *         computerName: "hostname",
+ *     },
+ *     osProfileLinuxConfig: {
+ *         disablePasswordAuthentication: false,
+ *     },
+ *     resourceGroupName: azurerm_resource_group_main.name,
+ *     storageImageReference: {
+ *         offer: "UbuntuServer",
+ *         publisher: "Canonical",
+ *         sku: "16.04-LTS",
+ *         version: "latest",
+ *     },
+ *     storageOsDisk: {
+ *         caching: "ReadWrite",
+ *         createOption: "FromImage",
+ *         managedDiskType: "Standard_LRS",
+ *         name: "myosdisk1",
+ *     },
+ *     tags: {
+ *         environment: "staging",
+ *     },
+ *     vmSize: "Standard_DS1_v2",
+ * });
+ * ```
  */
 export class VirtualMachine extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/containerservice/getKubernetesCluster.ts
+++ b/sdk/nodejs/containerservice/getKubernetesCluster.ts
@@ -7,8 +7,20 @@ import * as utilities from "../utilities";
 /**
  * Use this data source to access information about an existing Managed Kubernetes Cluster (AKS).
  * 
- * ~> **Note:** All arguments including the client secret will be stored in the raw state as plain-text.
+ * > **Note:** All arguments including the client secret will be stored in the raw state as plain-text.
  * [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_kubernetes_cluster_test = pulumi.output(azure.containerservice.getKubernetesCluster({
+ *     name: "myakscluster",
+ *     resourceGroupName: "my-example-resource-group",
+ * }));
+ * ```
  */
 export function getKubernetesCluster(args: GetKubernetesClusterArgs, opts?: pulumi.InvokeOptions): Promise<GetKubernetesClusterResult> {
     return pulumi.runtime.invoke("azure:containerservice/getKubernetesCluster:getKubernetesCluster", {

--- a/sdk/nodejs/containerservice/getRegistry.ts
+++ b/sdk/nodejs/containerservice/getRegistry.ts
@@ -6,6 +6,20 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing Container Registry.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_container_registry_test = pulumi.output(azure.containerservice.getRegistry({
+ *     name: "testacr",
+ *     resourceGroupName: "test",
+ * }));
+ * 
+ * export const loginServer = azurerm_container_registry_test.apply(__arg0 => __arg0.loginServer);
+ * ```
  */
 export function getRegistry(args: GetRegistryArgs, opts?: pulumi.InvokeOptions): Promise<GetRegistryResult> {
     return pulumi.runtime.invoke("azure:containerservice/getRegistry:getRegistry", {

--- a/sdk/nodejs/containerservice/group.ts
+++ b/sdk/nodejs/containerservice/group.ts
@@ -6,6 +6,76 @@ import * as utilities from "../utilities";
 
 /**
  * Manage as an Azure Container Group instance.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_aci_rg = new azure.core.ResourceGroup("aci-rg", {
+ *     location: "west us",
+ *     name: "aci-test",
+ * });
+ * const azurerm_storage_account_aci_sa = new azure.storage.Account("aci-sa", {
+ *     accountReplicationType: "LRS",
+ *     accountTier: "Standard",
+ *     location: azurerm_resource_group_aci_rg.location,
+ *     name: "acistorageacct",
+ *     resourceGroupName: azurerm_resource_group_aci_rg.name,
+ * });
+ * const azurerm_storage_share_aci_share = new azure.storage.Share("aci-share", {
+ *     name: "aci-test-share",
+ *     quota: 50,
+ *     resourceGroupName: azurerm_resource_group_aci_rg.name,
+ *     storageAccountName: azurerm_storage_account_aci_sa.name,
+ * });
+ * const azurerm_container_group_aci_helloworld = new azure.containerservice.Group("aci-helloworld", {
+ *     containers: [
+ *         {
+ *             commands: [
+ *                 "/bin/bash",
+ *                 "-c",
+ *                 "'/path to/myscript.sh'",
+ *             ],
+ *             cpu: Number.parseFloat("0.5"),
+ *             environmentVariables: {
+ *                 NODE_ENV: "testing",
+ *             },
+ *             image: "seanmckenna/aci-hellofiles",
+ *             memory: Number.parseFloat("1.5"),
+ *             name: "hw",
+ *             port: Number.parseFloat("80"),
+ *             secureEnvironmentVariables: {
+ *                 ACCESS_KEY: "secure_testing",
+ *             },
+ *             volumes: [{
+ *                 mountPath: "/aci/logs",
+ *                 name: "logs",
+ *                 readOnly: false,
+ *                 shareName: azurerm_storage_share_aci_share.name,
+ *                 storageAccountKey: azurerm_storage_account_aci_sa.primaryAccessKey,
+ *                 storageAccountName: azurerm_storage_account_aci_sa.name,
+ *             }],
+ *         },
+ *         {
+ *             cpu: Number.parseFloat("0.5"),
+ *             image: "microsoft/aci-tutorial-sidecar",
+ *             memory: Number.parseFloat("1.5"),
+ *             name: "sidecar",
+ *         },
+ *     ],
+ *     dnsNameLabel: "aci-label",
+ *     ipAddressType: "public",
+ *     location: azurerm_resource_group_aci_rg.location,
+ *     name: "aci-hw",
+ *     osType: "Linux",
+ *     resourceGroupName: azurerm_resource_group_aci_rg.name,
+ *     tags: {
+ *         environment: "testing",
+ *     },
+ * });
+ * ```
  */
 export class Group extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/containerservice/kubernetesCluster.ts
+++ b/sdk/nodejs/containerservice/kubernetesCluster.ts
@@ -7,7 +7,44 @@ import * as utilities from "../utilities";
 /**
  * Manages a Managed Kubernetes Cluster (also known as AKS / Azure Kubernetes Service)
  * 
- * ~> **Note:** All arguments including the client secret will be stored in the raw state as plain-text. [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
+ * > **Note:** All arguments including the client secret will be stored in the raw state as plain-text. [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
+ * 
+ * ## Example Usage
+ * 
+ * This example provisions a basic Managed Kubernetes Cluster. Other examples of the `azurerm_kubernetes_cluster` resource can be found in [the `./examples/kubernetes` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/examples/kubernetes)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "East US",
+ *     name: "acctestRG1",
+ * });
+ * const azurerm_kubernetes_cluster_test = new azure.containerservice.KubernetesCluster("test", {
+ *     agentPoolProfile: {
+ *         count: 1,
+ *         name: "default",
+ *         osDiskSizeGb: 30,
+ *         osType: "Linux",
+ *         vmSize: "Standard_D1_v2",
+ *     },
+ *     dnsPrefix: "acctestagent1",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "acctestaks1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     servicePrincipal: {
+ *         clientId: "00000000-0000-0000-0000-000000000000",
+ *         clientSecret: "00000000000000000000000000000000",
+ *     },
+ *     tags: {
+ *         Environment: "Production",
+ *     },
+ * });
+ * 
+ * export const clientCertificate = azurerm_kubernetes_cluster_test.kubeConfig.apply(__arg0 => __arg0.clientCertificate);
+ * export const kubeConfig = azurerm_kubernetes_cluster_test.kubeConfigRaw;
+ * ```
  */
 export class KubernetesCluster extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/containerservice/registry.ts
+++ b/sdk/nodejs/containerservice/registry.ts
@@ -7,8 +7,63 @@ import * as utilities from "../utilities";
 /**
  * Manages an Azure Container Registry.
  * 
- * ~> **Note:** All arguments including the access key will be stored in the raw state as plain-text.
+ * > **Note:** All arguments including the access key will be stored in the raw state as plain-text.
  * [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
+ * 
+ * ## Example Usage
+ * 
+ * ### Classic (unmanaged) Container Registry
+ * 
+ * When using the `Classic` SKU, you need to provide the Azure storage account.
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "resourceGroup1",
+ * });
+ * const azurerm_storage_account_test = new azure.storage.Account("test", {
+ *     accountReplicationType: "GRS",
+ *     accountTier: "Standard",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "storageaccount1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_container_registry_test = new azure.containerservice.Registry("test", {
+ *     adminEnabled: true,
+ *     location: azurerm_resource_group_test.location,
+ *     name: "containerRegistry1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: "Classic",
+ *     storageAccountId: azurerm_storage_account_test.id,
+ * });
+ * ```
+ * ### Managed Container Registry
+ * 
+ * When using a SKU other than `Classic`, Azure Container Registry manages the storage account for you.
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_rg = new azure.core.ResourceGroup("rg", {
+ *     location: "West US",
+ *     name: "resourceGroup1",
+ * });
+ * const azurerm_container_registry_acr = new azure.containerservice.Registry("acr", {
+ *     adminEnabled: false,
+ *     georeplicationLocations: [
+ *         "East US",
+ *         "West Europe",
+ *     ],
+ *     location: azurerm_resource_group_rg.location,
+ *     name: "containerRegistry1",
+ *     resourceGroupName: azurerm_resource_group_rg.name,
+ *     sku: "Premium",
+ * });
+ * ```
  */
 export class Registry extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/containerservice/service.ts
+++ b/sdk/nodejs/containerservice/service.ts
@@ -7,10 +7,10 @@ import * as utilities from "../utilities";
 /**
  * Manages an Azure Container Service Instance
  * 
- * ~> **NOTE:** All arguments including the client secret will be stored in the raw state as plain-text.
+ * > **NOTE:** All arguments including the client secret will be stored in the raw state as plain-text.
  * [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
  * 
- * ~> **DEPRECATED:** [Azure Container Service (ACS) has been deprecated by Azure in favour of Azure (Managed) Kubernetes Service (AKS)](https://azure.microsoft.com/en-us/updates/azure-container-service-will-retire-on-january-31-2020/). Support for ACS will be removed in the next major version of the AzureRM Provider (2.0) - and we **strongly recommend** you consider using Azure Kubernetes Service (AKS) for new deployments.
+ * > **DEPRECATED:** [Azure Container Service (ACS) has been deprecated by Azure in favour of Azure (Managed) Kubernetes Service (AKS)](https://azure.microsoft.com/en-us/updates/azure-container-service-will-retire-on-january-31-2020/). Support for ACS will be removed in the next major version of the AzureRM Provider (2.0) - and we **strongly recommend** you consider using Azure Kubernetes Service (AKS) for new deployments.
  * 
  * ## Example Usage (DCOS)
  * 
@@ -54,6 +54,89 @@ import * as utilities from "../utilities";
  *     Environment = "Production"
  *   }
  * }
+ * ```
+ * 
+ * ## Example Usage (Kubernetes)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acctestRG1",
+ * });
+ * const azurerm_container_service_test = new azure.containerservice.Service("test", {
+ *     agentPoolProfile: {
+ *         count: 1,
+ *         dnsPrefix: "acctestagent1",
+ *         name: "default",
+ *         vmSize: "Standard_F2",
+ *     },
+ *     diagnosticsProfile: {
+ *         enabled: false,
+ *     },
+ *     linuxProfile: {
+ *         adminUsername: "acctestuser1",
+ *         sshKey: {
+ *             keyData: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld",
+ *         },
+ *     },
+ *     location: azurerm_resource_group_test.location,
+ *     masterProfile: {
+ *         count: 1,
+ *         dnsPrefix: "acctestmaster1",
+ *     },
+ *     name: "acctestcontservice1",
+ *     orchestrationPlatform: "Kubernetes",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     servicePrincipal: {
+ *         clientId: "00000000-0000-0000-0000-000000000000",
+ *         clientSecret: "00000000000000000000000000000000",
+ *     },
+ *     tags: {
+ *         Environment: "Production",
+ *     },
+ * });
+ * ```
+ * ###  Example Usage (Swarm)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acctestRG1",
+ * });
+ * const azurerm_container_service_test = new azure.containerservice.Service("test", {
+ *     agentPoolProfile: {
+ *         count: 1,
+ *         dnsPrefix: "acctestagent1",
+ *         name: "default",
+ *         vmSize: "Standard_F2",
+ *     },
+ *     diagnosticsProfile: {
+ *         enabled: false,
+ *     },
+ *     linuxProfile: {
+ *         adminUsername: "acctestuser1",
+ *         sshKey: {
+ *             keyData: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld",
+ *         },
+ *     },
+ *     location: azurerm_resource_group_test.location,
+ *     masterProfile: {
+ *         count: 1,
+ *         dnsPrefix: "acctestmaster1",
+ *     },
+ *     name: "acctestcontservice1",
+ *     orchestrationPlatform: "Swarm",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         Environment: "Production",
+ *     },
+ * });
  * ```
  */
 export class Service extends pulumi.CustomResource {

--- a/sdk/nodejs/core/getClientConfig.ts
+++ b/sdk/nodejs/core/getClientConfig.ts
@@ -6,6 +6,17 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access the configuration of the AzureRM provider.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_client_config_current = pulumi.output(azure.core.getClientConfig({}));
+ * 
+ * export const accountId = azurerm_client_config_current.apply(__arg0 => __arg0.servicePrincipalApplicationId);
+ * ```
  */
 export function getClientConfig(opts?: pulumi.InvokeOptions): Promise<GetClientConfigResult> {
     return pulumi.runtime.invoke("azure:core/getClientConfig:getClientConfig", {

--- a/sdk/nodejs/core/getResourceGroup.ts
+++ b/sdk/nodejs/core/getResourceGroup.ts
@@ -6,6 +6,25 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing Resource Group.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = pulumi.output(azure.core.getResourceGroup({
+ *     name: "dsrg_test",
+ * }));
+ * const azurerm_managed_disk_test = new azure.compute.ManagedDisk("test", {
+ *     createOption: "Empty",
+ *     diskSizeGb: Number.parseFloat("1"),
+ *     location: azurerm_resource_group_test.apply(__arg0 => __arg0.location),
+ *     name: "managed_disk_name",
+ *     resourceGroupName: azurerm_resource_group_test.apply(__arg0 => __arg0.name),
+ *     storageAccountType: "Standard_LRS",
+ * });
+ * ```
  */
 export function getResourceGroup(args: GetResourceGroupArgs, opts?: pulumi.InvokeOptions): Promise<GetResourceGroupResult> {
     return pulumi.runtime.invoke("azure:core/getResourceGroup:getResourceGroup", {

--- a/sdk/nodejs/core/getSubscription.ts
+++ b/sdk/nodejs/core/getSubscription.ts
@@ -6,6 +6,17 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing Subscription.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_subscription_current = pulumi.output(azure.core.getSubscription({}));
+ * 
+ * export const currentSubscriptionDisplayName = azurerm_subscription_current.apply(__arg0 => __arg0.displayName);
+ * ```
  */
 export function getSubscription(args?: GetSubscriptionArgs, opts?: pulumi.InvokeOptions): Promise<GetSubscriptionResult> {
     args = args || {};

--- a/sdk/nodejs/core/resourceGroup.ts
+++ b/sdk/nodejs/core/resourceGroup.ts
@@ -6,6 +6,21 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a resource group on Azure.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "testResourceGroup1",
+ *     tags: {
+ *         environment: "Production",
+ *     },
+ * });
+ * ```
  */
 export class ResourceGroup extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/core/templateDeployment.ts
+++ b/sdk/nodejs/core/templateDeployment.ts
@@ -7,9 +7,34 @@ import * as utilities from "../utilities";
 /**
  * Manage a template deployment of resources
  * 
- * ~> **Note on ARM Template Deployments:** Due to the way the underlying Azure API is designed, Terraform can only manage the deployment of the ARM Template - and not any resources which are created by it.
+ * > **Note on ARM Template Deployments:** Due to the way the underlying Azure API is designed, Terraform can only manage the deployment of the ARM Template - and not any resources which are created by it.
  * This means that when deleting the `azurerm_template_deployment` resource, Terraform will only remove the reference to the deployment, whilst leaving any resources created by that ARM Template Deployment.
  * One workaround for this is to use a unique Resource Group for each ARM Template Deployment, which means deleting the Resource Group would contain any resources created within it - however this isn't ideal. [More information](https://docs.microsoft.com/en-us/rest/api/resources/deployments#Deployments_Delete).
+ * 
+ * ## Example Usage
+ * 
+ * > **Note:** This example uses Storage Accounts and Public IP's which are natively supported by Terraform - we'd highly recommend using the Native Resources where possible instead rather than an ARM Template, for the reasons outlined above.
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acctestRG-01",
+ * });
+ * const azurerm_template_deployment_test = new azure.core.TemplateDeployment("test", {
+ *     deploymentMode: "Incremental",
+ *     name: "acctesttemplate-01",
+ *     parameters: {
+ *         storageAccountType: "Standard_GRS",
+ *     },
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     templateBody: "{\n  \"$schema\": \"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\n  \"contentVersion\": \"1.0.0.0\",\n  \"parameters\": {\n    \"storageAccountType\": {\n      \"type\": \"string\",\n      \"defaultValue\": \"Standard_LRS\",\n      \"allowedValues\": [\n        \"Standard_LRS\",\n        \"Standard_GRS\",\n        \"Standard_ZRS\"\n      ],\n      \"metadata\": {\n        \"description\": \"Storage Account type\"\n      }\n    }\n  },\n  \"variables\": {\n    \"location\": \"[resourceGroup().location]\",\n    \"storageAccountName\": \"[concat(uniquestring(resourceGroup().id), 'storage')]\",\n    \"publicIPAddressName\": \"[concat('myPublicIp', uniquestring(resourceGroup().id))]\",\n    \"publicIPAddressType\": \"Dynamic\",\n    \"apiVersion\": \"2015-06-15\",\n    \"dnsLabelPrefix\": \"terraform-acctest\"\n  },\n  \"resources\": [\n    {\n      \"type\": \"Microsoft.Storage/storageAccounts\",\n      \"name\": \"[variables('storageAccountName')]\",\n      \"apiVersion\": \"[variables('apiVersion')]\",\n      \"location\": \"[variables('location')]\",\n      \"properties\": {\n        \"accountType\": \"[parameters('storageAccountType')]\"\n      }\n    },\n    {\n      \"type\": \"Microsoft.Network/publicIPAddresses\",\n      \"apiVersion\": \"[variables('apiVersion')]\",\n      \"name\": \"[variables('publicIPAddressName')]\",\n      \"location\": \"[variables('location')]\",\n      \"properties\": {\n        \"publicIPAllocationMethod\": \"[variables('publicIPAddressType')]\",\n        \"dnsSettings\": {\n          \"domainNameLabel\": \"[variables('dnsLabelPrefix')]\"\n        }\n      }\n    }\n  ],\n  \"outputs\": {\n    \"storageAccountName\": {\n      \"type\": \"string\",\n      \"value\": \"[variables('storageAccountName')]\"\n    }\n  }\n}\n",
+ * });
+ * 
+ * export const storageAccountName = azurerm_template_deployment_test.outputs.apply(__arg0 => __arg0["storageAccountName"]);
+ * ```
  */
 export class TemplateDeployment extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/databricks/workspace.ts
+++ b/sdk/nodejs/databricks/workspace.ts
@@ -6,6 +6,27 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Databricks Workspace
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "example-resources",
+ * });
+ * const azurerm_databricks_workspace_test = new azure.databricks.Workspace("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "databricks-test",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: "Standard",
+ *     tags: {
+ *         Environment: "Production",
+ *     },
+ * });
+ * ```
  */
 export class Workspace extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/datalake/analyticsAccount.ts
+++ b/sdk/nodejs/datalake/analyticsAccount.ts
@@ -6,6 +6,29 @@ import * as utilities from "../utilities";
 
 /**
  * Manage an Azure Data Lake Analytics Account.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_example = new azure.core.ResourceGroup("example", {
+ *     location: "northeurope",
+ *     name: "tfex-datalake-account",
+ * });
+ * const azurerm_data_lake_store_example = new azure.datalake.Store("example", {
+ *     location: azurerm_resource_group_example.location,
+ *     name: "tfexdatalakestore",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ * });
+ * const azurerm_data_lake_analytics_account_example = new azure.datalake.AnalyticsAccount("example", {
+ *     defaultStoreAccountName: azurerm_data_lake_store_example.name,
+ *     location: azurerm_resource_group_example.location,
+ *     name: "tfexdatalakeaccount",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ * });
+ * ```
  */
 export class AnalyticsAccount extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/datalake/getStore.ts
+++ b/sdk/nodejs/datalake/getStore.ts
@@ -6,6 +6,20 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing Data Lake Store.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_data_lake_store_test = pulumi.output(azure.datalake.getStore({
+ *     name: "testdatalake",
+ *     resourceGroupName: "testdatalake",
+ * }));
+ * 
+ * export const dataLakeStoreId = azurerm_data_lake_store_test.apply(__arg0 => __arg0.id);
+ * ```
  */
 export function getStore(args: GetStoreArgs, opts?: pulumi.InvokeOptions): Promise<GetStoreResult> {
     return pulumi.runtime.invoke("azure:datalake/getStore:getStore", {

--- a/sdk/nodejs/datalake/store.ts
+++ b/sdk/nodejs/datalake/store.ts
@@ -6,6 +6,25 @@ import * as utilities from "../utilities";
 
 /**
  * Manage an Azure Data Lake Store.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_example = new azure.core.ResourceGroup("example", {
+ *     location: "northeurope",
+ *     name: "example",
+ * });
+ * const azurerm_data_lake_store_example = new azure.datalake.Store("example", {
+ *     encryptionState: "Enabled",
+ *     encryptionType: "SystemManaged",
+ *     location: azurerm_resource_group_example.location,
+ *     name: "consumptiondatalake",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ * });
+ * ```
  */
 export class Store extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/datalake/storeFile.ts
+++ b/sdk/nodejs/datalake/storeFile.ts
@@ -7,8 +7,30 @@ import * as utilities from "../utilities";
 /**
  * Manage a Azure Data Lake Store File.
  * 
- * ~> **Note:** If you want to change the data in the remote file without changing the `local_file_path`, then 
+ * > **Note:** If you want to change the data in the remote file without changing the `local_file_path`, then 
  * taint the resource so the `azurerm_data_lake_store_file` gets recreated with the new data.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_example = new azure.core.ResourceGroup("example", {
+ *     location: "northeurope",
+ *     name: "example",
+ * });
+ * const azurerm_data_lake_store_example = new azure.datalake.Store("example", {
+ *     location: azurerm_resource_group_example.location,
+ *     name: "consumptiondatalake",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ * });
+ * const azurerm_data_lake_store_file_example = new azure.datalake.StoreFile("example", {
+ *     localFilePath: "/path/to/local/file",
+ *     remoteFilePath: "/path/created/for/remote/file",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ * });
+ * ```
  */
 export class StoreFile extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/datalake/storeFirewallRule.ts
+++ b/sdk/nodejs/datalake/storeFirewallRule.ts
@@ -6,6 +6,30 @@ import * as utilities from "../utilities";
 
 /**
  * Manage a Azure Data Lake Store Firewall Rule.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_example = new azure.core.ResourceGroup("example", {
+ *     location: "northeurope",
+ *     name: "example",
+ * });
+ * const azurerm_data_lake_store_example = new azure.datalake.Store("example", {
+ *     location: azurerm_resource_group_example.location,
+ *     name: "consumptiondatalake",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ * });
+ * const azurerm_data_lake_store_firewall_rule_example = new azure.datalake.StoreFirewallRule("example", {
+ *     accountName: azurerm_data_lake_store_example.name,
+ *     endIpAddress: "2.3.4.5",
+ *     name: "office-ip-range",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     startIpAddress: "1.2.3.4",
+ * });
+ * ```
  */
 export class StoreFirewallRule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/devspace/controller.ts
+++ b/sdk/nodejs/devspace/controller.ts
@@ -6,6 +6,48 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a DevSpace Controller.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "westeurope",
+ *     name: "acctestRG1",
+ * });
+ * const azurerm_kubernetes_cluster_test = new azure.containerservice.KubernetesCluster("test", {
+ *     agentPoolProfile: {
+ *         count: Number.parseFloat("1"),
+ *         name: "default",
+ *         vmSize: "Standard_DS2_v2",
+ *     },
+ *     dnsPrefix: "acctestaks1",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "acctestaks1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     servicePrincipal: {
+ *         clientId: "00000000-0000-0000-0000-000000000000",
+ *         clientSecret: "00000000000000000000000000000000",
+ *     },
+ * });
+ * const azurerm_devspace_controller_test = new azure.devspace.Controller("test", {
+ *     hostSuffix: "suffix",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "acctestdsc1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         name: "S1",
+ *         tier: "Standard",
+ *     },
+ *     tags: {
+ *         Environment: "Testing",
+ *     },
+ *     targetContainerHostCredentialsBase64: azurerm_kubernetes_cluster_test.kubeConfigRaw.apply(__arg0 => Buffer.from(__arg0).toString("base64")),
+ *     targetContainerHostResourceId: azurerm_kubernetes_cluster_test.id,
+ * });
+ * ```
  */
 export class Controller extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/devtest/getLab.ts
+++ b/sdk/nodejs/devtest/getLab.ts
@@ -6,6 +6,20 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing Dev Test Lab.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_dev_test_lab_test = pulumi.output(azure.devtest.getLab({
+ *     name: "example-lab",
+ *     resourceGroupName: "example-resources",
+ * }));
+ * 
+ * export const uniqueIdentifier = azurerm_dev_test_lab_test.apply(__arg0 => __arg0.uniqueIdentifier);
+ * ```
  */
 export function getLab(args: GetLabArgs, opts?: pulumi.InvokeOptions): Promise<GetLabResult> {
     return pulumi.runtime.invoke("azure:devtest/getLab:getLab", {

--- a/sdk/nodejs/devtest/lab.ts
+++ b/sdk/nodejs/devtest/lab.ts
@@ -6,6 +6,26 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Dev Test Lab.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "example-resources",
+ * });
+ * const azurerm_dev_test_lab_test = new azure.devtest.Lab("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-devtestlab",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         Sydney: "Australia",
+ *     },
+ * });
+ * ```
  */
 export class Lab extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/devtest/linuxVirtualMachine.ts
+++ b/sdk/nodejs/devtest/linuxVirtualMachine.ts
@@ -6,6 +6,55 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Linux Virtual Machine within a Dev Test Lab.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * import * as fs from "fs";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "example-resources",
+ * });
+ * const azurerm_dev_test_lab_test = new azure.devtest.Lab("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-devtestlab",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         Sydney: "Australia",
+ *     },
+ * });
+ * const azurerm_dev_test_virtual_network_test = new azure.devtest.VirtualNetwork("test", {
+ *     labName: azurerm_dev_test_lab_test.name,
+ *     name: "example-network",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     subnet: {
+ *         useInVirtualMachineCreation: "Allow",
+ *         usePublicIpAddress: "Allow",
+ *     },
+ * });
+ * const azurerm_dev_test_linux_virtual_machine_test = new azure.devtest.LinuxVirtualMachine("test", {
+ *     galleryImageReference: {
+ *         offer: "UbuntuServer",
+ *         publisher: "Canonical",
+ *         sku: "18.04-LTS",
+ *         version: "latest",
+ *     },
+ *     labName: azurerm_dev_test_lab_test.name,
+ *     labSubnetName: azurerm_dev_test_virtual_network_test.subnet.apply(__arg0 => __arg0.name),
+ *     labVirtualNetworkId: azurerm_dev_test_virtual_network_test.id,
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-vm03",
+ *     notes: "Some notes about this Virtual Machine.",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     size: "Standard_DS2",
+ *     sshKey: fs.readFileSync("~/.ssh/id_rsa.pub", "utf-8"),
+ *     storageType: "Premium",
+ *     username: "exampleuser99",
+ * });
+ * ```
  */
 export class LinuxVirtualMachine extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/devtest/policy.ts
+++ b/sdk/nodejs/devtest/policy.ts
@@ -6,6 +6,38 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Policy within a Dev Test Policy Set.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "example-resources",
+ * });
+ * const azurerm_dev_test_lab_test = new azure.devtest.Lab("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-devtestlab",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         Sydney: "Australia",
+ *     },
+ * });
+ * const azurerm_dev_test_policy_test = new azure.devtest.Policy("test", {
+ *     evaluatorType: "MaxValuePolicy",
+ *     factData: "",
+ *     labName: azurerm_dev_test_lab_test.name,
+ *     name: "LabVmCount",
+ *     policySetName: "default",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         Acceptance: "Test",
+ *     },
+ *     threshold: "999",
+ * });
+ * ```
  */
 export class Policy extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/devtest/virtualNetwork.ts
+++ b/sdk/nodejs/devtest/virtualNetwork.ts
@@ -6,6 +6,35 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Virtual Network within a Dev Test Lab.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "example-resources",
+ * });
+ * const azurerm_dev_test_lab_test = new azure.devtest.Lab("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-devtestlab",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         Sydney: "Australia",
+ *     },
+ * });
+ * const azurerm_dev_test_virtual_network_test = new azure.devtest.VirtualNetwork("test", {
+ *     labName: azurerm_dev_test_lab_test.name,
+ *     name: "example-network",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     subnet: {
+ *         useInVirtualMachineCreation: "Allow",
+ *         usePublicIpAddress: "Allow",
+ *     },
+ * });
+ * ```
  */
 export class VirtualNetwork extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/devtest/windowsVirtualMachine.ts
+++ b/sdk/nodejs/devtest/windowsVirtualMachine.ts
@@ -6,6 +6,54 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Windows Virtual Machine within a Dev Test Lab.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "example-resources",
+ * });
+ * const azurerm_dev_test_lab_test = new azure.devtest.Lab("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-devtestlab",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         Sydney: "Australia",
+ *     },
+ * });
+ * const azurerm_dev_test_virtual_network_test = new azure.devtest.VirtualNetwork("test", {
+ *     labName: azurerm_dev_test_lab_test.name,
+ *     name: "example-network",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     subnet: {
+ *         useInVirtualMachineCreation: "Allow",
+ *         usePublicIpAddress: "Allow",
+ *     },
+ * });
+ * const azurerm_dev_test_windows_virtual_machine_test = new azure.devtest.WindowsVirtualMachine("test", {
+ *     galleryImageReference: {
+ *         offer: "UbuntuServer",
+ *         publisher: "Canonical",
+ *         sku: "18.04-LTS",
+ *         version: "latest",
+ *     },
+ *     labName: azurerm_dev_test_lab_test.name,
+ *     labSubnetName: azurerm_dev_test_virtual_network_test.subnet.apply(__arg0 => __arg0.name),
+ *     labVirtualNetworkId: azurerm_dev_test_virtual_network_test.id,
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-vm03",
+ *     notes: "Some notes about this Virtual Machine.",
+ *     password: "Pa$w0rd1234!",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     size: "Standard_DS2",
+ *     storageType: "Premium",
+ *     username: "exampleuser99",
+ * });
+ * ```
  */
 export class WindowsVirtualMachine extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/dns/aRecord.ts
+++ b/sdk/nodejs/dns/aRecord.ts
@@ -6,6 +6,29 @@ import * as utilities from "../utilities";
 
 /**
  * Enables you to manage DNS A Records within Azure DNS.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acceptanceTestResourceGroup1",
+ * });
+ * const azurerm_dns_zone_test = new azure.dns.Zone("test", {
+ *     name: "mydomain.com",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_dns_a_record_test = new azure.dns.ARecord("test", {
+ *     name: "test",
+ *     records: ["10.0.180.17"],
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     ttl: 300,
+ *     zoneName: azurerm_dns_zone_test.name,
+ * });
+ * ```
  */
 export class ARecord extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/dns/aaaaRecord.ts
+++ b/sdk/nodejs/dns/aaaaRecord.ts
@@ -6,6 +6,29 @@ import * as utilities from "../utilities";
 
 /**
  * Enables you to manage DNS AAAA Records within Azure DNS.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acceptanceTestResourceGroup1",
+ * });
+ * const azurerm_dns_zone_test = new azure.dns.Zone("test", {
+ *     name: "mydomain.com",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_dns_aaaa_record_test = new azure.dns.AaaaRecord("test", {
+ *     name: "test",
+ *     records: ["2607:f8b0:4009:1803::1005"],
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     ttl: 300,
+ *     zoneName: azurerm_dns_zone_test.name,
+ * });
+ * ```
  */
 export class AaaaRecord extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/dns/cNameRecord.ts
+++ b/sdk/nodejs/dns/cNameRecord.ts
@@ -6,6 +6,29 @@ import * as utilities from "../utilities";
 
 /**
  * Enables you to manage DNS CNAME Records within Azure DNS.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acceptanceTestResourceGroup1",
+ * });
+ * const azurerm_dns_zone_test = new azure.dns.Zone("test", {
+ *     name: "mydomain.com",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_dns_cname_record_test = new azure.dns.CNameRecord("test", {
+ *     name: "test",
+ *     record: "contoso.com",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     ttl: 300,
+ *     zoneName: azurerm_dns_zone_test.name,
+ * });
+ * ```
  */
 export class CNameRecord extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/dns/caaRecord.ts
+++ b/sdk/nodejs/dns/caaRecord.ts
@@ -6,6 +6,53 @@ import * as utilities from "../utilities";
 
 /**
  * Enables you to manage DNS CAA Records within Azure DNS.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acceptanceTestResourceGroup1",
+ * });
+ * const azurerm_dns_zone_test = new azure.dns.Zone("test", {
+ *     name: "mydomain.com",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_dns_caa_record_test = new azure.dns.CaaRecord("test", {
+ *     name: "test",
+ *     records: [
+ *         {
+ *             flags: 0,
+ *             tag: "issue",
+ *             value: "example.com",
+ *         },
+ *         {
+ *             flags: 0,
+ *             tag: "issue",
+ *             value: "example.net",
+ *         },
+ *         {
+ *             flags: 0,
+ *             tag: "issuewild",
+ *             value: ";",
+ *         },
+ *         {
+ *             flags: 0,
+ *             tag: "iodef",
+ *             value: "mailto:terraform@nonexisting.tld",
+ *         },
+ *     ],
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         Environment: "Production",
+ *     },
+ *     ttl: 300,
+ *     zoneName: azurerm_dns_zone_test.name,
+ * });
+ * ```
  */
 export class CaaRecord extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/dns/getZone.ts
+++ b/sdk/nodejs/dns/getZone.ts
@@ -6,6 +6,20 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing DNS Zone.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_dns_zone_test = pulumi.output(azure.dns.getZone({
+ *     name: "search-eventhubns",
+ *     resourceGroupName: "search-service",
+ * }));
+ * 
+ * export const dnsZoneId = azurerm_dns_zone_test.apply(__arg0 => __arg0.id);
+ * ```
  */
 export function getZone(args: GetZoneArgs, opts?: pulumi.InvokeOptions): Promise<GetZoneResult> {
     return pulumi.runtime.invoke("azure:dns/getZone:getZone", {

--- a/sdk/nodejs/dns/mxRecord.ts
+++ b/sdk/nodejs/dns/mxRecord.ts
@@ -6,6 +6,41 @@ import * as utilities from "../utilities";
 
 /**
  * Enables you to manage DNS MX Records within Azure DNS.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acceptanceTestResourceGroup1",
+ * });
+ * const azurerm_dns_zone_test = new azure.dns.Zone("test", {
+ *     name: "mydomain.com",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_dns_mx_record_test = new azure.dns.MxRecord("test", {
+ *     name: "test",
+ *     records: [
+ *         {
+ *             exchange: "mail1.contoso.com",
+ *             preference: "10",
+ *         },
+ *         {
+ *             exchange: "mail2.contoso.com",
+ *             preference: "20",
+ *         },
+ *     ],
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         Environment: "Production",
+ *     },
+ *     ttl: 300,
+ *     zoneName: azurerm_dns_zone_test.name,
+ * });
+ * ```
  */
 export class MxRecord extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/dns/nsRecord.ts
+++ b/sdk/nodejs/dns/nsRecord.ts
@@ -6,6 +6,35 @@ import * as utilities from "../utilities";
 
 /**
  * Enables you to manage DNS NS Records within Azure DNS.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acceptanceTestResourceGroup1",
+ * });
+ * const azurerm_dns_zone_test = new azure.dns.Zone("test", {
+ *     name: "mydomain.com",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_dns_ns_record_test = new azure.dns.NsRecord("test", {
+ *     name: "test",
+ *     records: [
+ *         "ns1.contoso.com",
+ *         "ns2.contoso.com",
+ *     ],
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         Environment: "Production",
+ *     },
+ *     ttl: 300,
+ *     zoneName: azurerm_dns_zone_test.name,
+ * });
+ * ```
  */
 export class NsRecord extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/dns/ptrRecord.ts
+++ b/sdk/nodejs/dns/ptrRecord.ts
@@ -6,6 +6,29 @@ import * as utilities from "../utilities";
 
 /**
  * Enables you to manage DNS PTR Records within Azure DNS.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acceptanceTestResourceGroup1",
+ * });
+ * const azurerm_dns_zone_test = new azure.dns.Zone("test", {
+ *     name: "mydomain.com",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_dns_ptr_record_test = new azure.dns.PtrRecord("test", {
+ *     name: "test",
+ *     records: ["yourdomain.com"],
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     ttl: 300,
+ *     zoneName: azurerm_dns_zone_test.name,
+ * });
+ * ```
  */
 export class PtrRecord extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/dns/srvRecord.ts
+++ b/sdk/nodejs/dns/srvRecord.ts
@@ -6,6 +6,37 @@ import * as utilities from "../utilities";
 
 /**
  * Enables you to manage DNS SRV Records within Azure DNS.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acceptanceTestResourceGroup1",
+ * });
+ * const azurerm_dns_zone_test = new azure.dns.Zone("test", {
+ *     name: "mydomain.com",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_dns_srv_record_test = new azure.dns.SrvRecord("test", {
+ *     name: "test",
+ *     records: [{
+ *         port: 8080,
+ *         priority: 1,
+ *         target: "target1.contoso.com",
+ *         weight: 5,
+ *     }],
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         Environment: "Production",
+ *     },
+ *     ttl: 300,
+ *     zoneName: azurerm_dns_zone_test.name,
+ * });
+ * ```
  */
 export class SrvRecord extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/dns/txtRecord.ts
+++ b/sdk/nodejs/dns/txtRecord.ts
@@ -6,6 +6,39 @@ import * as utilities from "../utilities";
 
 /**
  * Enables you to manage DNS TXT Records within Azure DNS.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acceptanceTestResourceGroup1",
+ * });
+ * const azurerm_dns_zone_test = new azure.dns.Zone("test", {
+ *     name: "mydomain.com",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_dns_txt_record_test = new azure.dns.TxtRecord("test", {
+ *     name: "test",
+ *     records: [
+ *         {
+ *             value: "google-site-authenticator",
+ *         },
+ *         {
+ *             value: "more site information here",
+ *         },
+ *     ],
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         Environment: "Production",
+ *     },
+ *     ttl: 300,
+ *     zoneName: azurerm_dns_zone_test.name,
+ * });
+ * ```
  */
 export class TxtRecord extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/dns/zone.ts
+++ b/sdk/nodejs/dns/zone.ts
@@ -6,6 +6,28 @@ import * as utilities from "../utilities";
 
 /**
  * Enables you to manage DNS zones within Azure DNS. These zones are hosted on Azure's name servers to which you can delegate the zone from the parent domain.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acceptanceTestResourceGroup1",
+ * });
+ * const azurerm_dns_zone_test = new azure.dns.Zone("test", {
+ *     name: "mydomain.com",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     zoneType: "Public",
+ * });
+ * const azurerm_dns_zone_test_private = new azure.dns.Zone("test_private", {
+ *     name: "mydomain.com",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     zoneType: "Private",
+ * });
+ * ```
  */
 export class Zone extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/eventhub/eventGridTopic.ts
+++ b/sdk/nodejs/eventhub/eventGridTopic.ts
@@ -7,7 +7,27 @@ import * as utilities from "../utilities";
 /**
  * Manages an EventGrid Topic
  * 
- * ~> **Note:** at this time EventGrid Topic's are only available in a limited number of regions.
+ * > **Note:** at this time EventGrid Topic's are only available in a limited number of regions.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US 2",
+ *     name: "resourceGroup1",
+ * });
+ * const azurerm_eventgrid_topic_test = new azure.eventhub.EventGridTopic("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "my-eventgrid-topic",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         environment: "Production",
+ *     },
+ * });
+ * ```
  */
 export class EventGridTopic extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/eventhub/eventHub.ts
+++ b/sdk/nodejs/eventhub/eventHub.ts
@@ -6,6 +6,35 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Event Hubs as a nested resource within a Event Hubs namespace.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "resourceGroup1",
+ * });
+ * const azurerm_eventhub_namespace_test = new azure.eventhub.EventHubNamespace("test", {
+ *     capacity: 1,
+ *     location: azurerm_resource_group_test.location,
+ *     name: "acceptanceTestEventHubNamespace",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: "Standard",
+ *     tags: {
+ *         environment: "Production",
+ *     },
+ * });
+ * const azurerm_eventhub_test = new azure.eventhub.EventHub("test", {
+ *     messageRetention: 1,
+ *     name: "acceptanceTestEventHub",
+ *     namespaceName: azurerm_eventhub_namespace_test.name,
+ *     partitionCount: 2,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * ```
  */
 export class EventHub extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/eventhub/eventHubAuthorizationRule.ts
+++ b/sdk/nodejs/eventhub/eventHubAuthorizationRule.ts
@@ -6,6 +6,44 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Event Hubs authorization Rule within an Event Hub.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "resourceGroup1",
+ * });
+ * const azurerm_eventhub_namespace_test = new azure.eventhub.EventHubNamespace("test", {
+ *     capacity: 2,
+ *     location: "West US",
+ *     name: "acceptanceTestEventHubNamespace",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: "Basic",
+ *     tags: {
+ *         environment: "Production",
+ *     },
+ * });
+ * const azurerm_eventhub_test = new azure.eventhub.EventHub("test", {
+ *     messageRetention: 2,
+ *     name: "acceptanceTestEventHub",
+ *     namespaceName: azurerm_eventhub_namespace_test.name,
+ *     partitionCount: 2,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_eventhub_authorization_rule_test = new azure.eventhub.EventHubAuthorizationRule("test", {
+ *     eventhubName: azurerm_eventhub_test.name,
+ *     listen: true,
+ *     manage: false,
+ *     name: "navi",
+ *     namespaceName: azurerm_eventhub_namespace_test.name,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     send: false,
+ * });
+ * ```
  */
 export class EventHubAuthorizationRule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/eventhub/eventHubConsumerGroup.ts
+++ b/sdk/nodejs/eventhub/eventHubConsumerGroup.ts
@@ -6,6 +6,42 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Event Hubs Consumer Group as a nested resource within an Event Hub.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "resourceGroup1",
+ * });
+ * const azurerm_eventhub_namespace_test = new azure.eventhub.EventHubNamespace("test", {
+ *     capacity: 2,
+ *     location: "West US",
+ *     name: "acceptanceTestEventHubNamespace",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: "Basic",
+ *     tags: {
+ *         environment: "Production",
+ *     },
+ * });
+ * const azurerm_eventhub_test = new azure.eventhub.EventHub("test", {
+ *     messageRetention: 2,
+ *     name: "acceptanceTestEventHub",
+ *     namespaceName: azurerm_eventhub_namespace_test.name,
+ *     partitionCount: 2,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_eventhub_consumer_group_test = new azure.eventhub.EventHubConsumerGroup("test", {
+ *     eventhubName: azurerm_eventhub_test.name,
+ *     name: "acceptanceTestEventHubConsumerGroup",
+ *     namespaceName: azurerm_eventhub_namespace_test.name,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     userMetadata: "some-meta-data",
+ * });
+ * ```
  */
 export class EventHubConsumerGroup extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/eventhub/eventHubNamespace.ts
+++ b/sdk/nodejs/eventhub/eventHubNamespace.ts
@@ -6,6 +6,28 @@ import * as utilities from "../utilities";
 
 /**
  * Manage an EventHub Namespace.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "resourceGroup1",
+ * });
+ * const azurerm_eventhub_namespace_test = new azure.eventhub.EventHubNamespace("test", {
+ *     capacity: 2,
+ *     location: azurerm_resource_group_test.location,
+ *     name: "acceptanceTestEventHubNamespace",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: "Standard",
+ *     tags: {
+ *         environment: "Production",
+ *     },
+ * });
+ * ```
  */
 export class EventHubNamespace extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/eventhub/eventHubNamespaceAuthorizationRule.ts
+++ b/sdk/nodejs/eventhub/eventHubNamespaceAuthorizationRule.ts
@@ -6,6 +6,36 @@ import * as utilities from "../utilities";
 
 /**
  * Manages an Authorization Rule for an Event Hub Namespace.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "resourceGroup1",
+ * });
+ * const azurerm_eventhub_namespace_test = new azure.eventhub.EventHubNamespace("test", {
+ *     capacity: 2,
+ *     location: azurerm_resource_group_test.location,
+ *     name: "acceptanceTestEventHubNamespace",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: "Basic",
+ *     tags: {
+ *         environment: "Production",
+ *     },
+ * });
+ * const azurerm_eventhub_namespace_authorization_rule_test = new azure.eventhub.EventHubNamespaceAuthorizationRule("test", {
+ *     listen: true,
+ *     manage: false,
+ *     name: "navi",
+ *     namespaceName: azurerm_eventhub_namespace_test.name,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     send: false,
+ * });
+ * ```
  */
 export class EventHubNamespaceAuthorizationRule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/eventhub/getEventhubNamespace.ts
+++ b/sdk/nodejs/eventhub/getEventhubNamespace.ts
@@ -6,6 +6,20 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing EventHub Namespace.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_eventhub_namespace_test = pulumi.output(azure.eventhub.getEventhubNamespace({
+ *     name: "search-eventhubns",
+ *     resourceGroupName: "search-service",
+ * }));
+ * 
+ * export const eventhubNamespaceId = azurerm_eventhub_namespace_test.apply(__arg0 => __arg0.id);
+ * ```
  */
 export function getEventhubNamespace(args: GetEventhubNamespaceArgs, opts?: pulumi.InvokeOptions): Promise<GetEventhubNamespaceResult> {
     return pulumi.runtime.invoke("azure:eventhub/getEventhubNamespace:getEventhubNamespace", {

--- a/sdk/nodejs/eventhub/namespace.ts
+++ b/sdk/nodejs/eventhub/namespace.ts
@@ -6,6 +6,27 @@ import * as utilities from "../utilities";
 
 /**
  * Manage a ServiceBus Namespace.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_example = new azure.core.ResourceGroup("example", {
+ *     location: "West Europe",
+ *     name: "terraform-servicebus",
+ * });
+ * const azurerm_servicebus_namespace_example = new azure.eventhub.Namespace("example", {
+ *     location: azurerm_resource_group_example.location,
+ *     name: "tfex_sevicebus_namespace",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     sku: "standard",
+ *     tags: {
+ *         source: "terraform",
+ *     },
+ * });
+ * ```
  */
 export class Namespace extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/eventhub/namespaceAuthorizationRule.ts
+++ b/sdk/nodejs/eventhub/namespaceAuthorizationRule.ts
@@ -6,6 +6,35 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a ServiceBus Namespace authorization Rule within a ServiceBus.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_example = new azure.core.ResourceGroup("example", {
+ *     location: "West US",
+ *     name: "terraform-servicebus",
+ * });
+ * const azurerm_servicebus_namespace_example = new azure.eventhub.Namespace("example", {
+ *     location: azurerm_resource_group_example.location,
+ *     name: "tfex_sevicebus_namespace",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     sku: "standard",
+ *     tags: {
+ *         source: "terraform",
+ *     },
+ * });
+ * const azurerm_servicebus_namespace_authorization_rule_example = new azure.eventhub.NamespaceAuthorizationRule("example", {
+ *     listen: true,
+ *     manage: false,
+ *     name: "examplerule",
+ *     namespaceName: azurerm_servicebus_namespace_example.name,
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     send: true,
+ * });
+ * ```
  */
 export class NamespaceAuthorizationRule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/eventhub/queue.ts
+++ b/sdk/nodejs/eventhub/queue.ts
@@ -6,6 +6,33 @@ import * as utilities from "../utilities";
 
 /**
  * Manage and manage a ServiceBus Queue.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_example = new azure.core.ResourceGroup("example", {
+ *     location: "West Europe",
+ *     name: "terraform-servicebus",
+ * });
+ * const azurerm_servicebus_namespace_example = new azure.eventhub.Namespace("example", {
+ *     location: azurerm_resource_group_example.location,
+ *     name: "tfex_sevicebus_namespace",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     sku: "standard",
+ *     tags: {
+ *         source: "terraform",
+ *     },
+ * });
+ * const azurerm_servicebus_queue_example = new azure.eventhub.Queue("example", {
+ *     enablePartitioning: true,
+ *     name: "tfex_servicebus_queue",
+ *     namespaceName: azurerm_servicebus_namespace_example.name,
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ * });
+ * ```
  */
 export class Queue extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/eventhub/queueAuthorizationRule.ts
+++ b/sdk/nodejs/eventhub/queueAuthorizationRule.ts
@@ -6,6 +6,42 @@ import * as utilities from "../utilities";
 
 /**
  * Manages an Authorization Rule for a ServiceBus Queue.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_example = new azure.core.ResourceGroup("example", {
+ *     location: "West US",
+ *     name: "terraform-servicebus",
+ * });
+ * const azurerm_servicebus_namespace_example = new azure.eventhub.Namespace("example", {
+ *     location: azurerm_resource_group_example.location,
+ *     name: "tfex_sevicebus_namespace",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     sku: "standard",
+ *     tags: {
+ *         source: "terraform",
+ *     },
+ * });
+ * const azurerm_servicebus_queue_example = new azure.eventhub.Queue("example", {
+ *     enablePartitioning: true,
+ *     name: "tfex_servicebus_queue",
+ *     namespaceName: azurerm_servicebus_namespace_example.name,
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ * });
+ * const azurerm_servicebus_queue_authorization_rule_example = new azure.eventhub.QueueAuthorizationRule("example", {
+ *     listen: true,
+ *     manage: false,
+ *     name: "examplerule",
+ *     namespaceName: azurerm_servicebus_namespace_example.name,
+ *     queueName: azurerm_servicebus_queue_example.name,
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     send: true,
+ * });
+ * ```
  */
 export class QueueAuthorizationRule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/eventhub/subscription.ts
+++ b/sdk/nodejs/eventhub/subscription.ts
@@ -6,6 +6,40 @@ import * as utilities from "../utilities";
 
 /**
  * Manage a ServiceBus Subscription.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_example = new azure.core.ResourceGroup("example", {
+ *     location: "West Europe",
+ *     name: "tfex-servicebus-subscription",
+ * });
+ * const azurerm_servicebus_namespace_example = new azure.eventhub.Namespace("example", {
+ *     location: azurerm_resource_group_example.location,
+ *     name: "tfex_sevicebus_namespace",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     sku: "standard",
+ *     tags: {
+ *         source: "terraform",
+ *     },
+ * });
+ * const azurerm_servicebus_topic_example = new azure.eventhub.Topic("example", {
+ *     enablePartitioning: true,
+ *     name: "tfex_sevicebus_topic",
+ *     namespaceName: azurerm_servicebus_namespace_example.name,
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ * });
+ * const azurerm_servicebus_subscription_example = new azure.eventhub.Subscription("example", {
+ *     maxDeliveryCount: 1,
+ *     name: "tfex_sevicebus_subscription",
+ *     namespaceName: azurerm_servicebus_namespace_example.name,
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     topicName: azurerm_servicebus_topic_example.name,
+ * });
+ * ```
  */
 export class Subscription extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/eventhub/subscriptionRule.ts
+++ b/sdk/nodejs/eventhub/subscriptionRule.ts
@@ -6,6 +6,95 @@ import * as utilities from "../utilities";
 
 /**
  * Manage a ServiceBus Subscription Rule.
+ * 
+ * ## Example Usage (SQL Filter)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_example = new azure.core.ResourceGroup("example", {
+ *     location: "West Europe",
+ *     name: "tfex-servicebus-subscription-rule-sql",
+ * });
+ * const azurerm_servicebus_namespace_example = new azure.eventhub.Namespace("example", {
+ *     location: azurerm_resource_group_example.location,
+ *     name: "tfex_sevicebus_namespace",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     sku: "standard",
+ *     tags: {
+ *         source: "terraform",
+ *     },
+ * });
+ * const azurerm_servicebus_topic_example = new azure.eventhub.Topic("example", {
+ *     enablePartitioning: true,
+ *     name: "tfex_sevicebus_topic",
+ *     namespaceName: azurerm_servicebus_namespace_example.name,
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ * });
+ * const azurerm_servicebus_subscription_example = new azure.eventhub.Subscription("example", {
+ *     maxDeliveryCount: 1,
+ *     name: "tfex_sevicebus_subscription",
+ *     namespaceName: azurerm_servicebus_namespace_example.name,
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     topicName: azurerm_servicebus_topic_example.name,
+ * });
+ * const azurerm_servicebus_subscription_rule_example = new azure.eventhub.SubscriptionRule("example", {
+ *     filterType: "SqlFilter",
+ *     name: "tfex_sevicebus_rule",
+ *     namespaceName: azurerm_servicebus_namespace_example.name,
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     sqlFilter: "color = 'red'",
+ *     subscriptionName: azurerm_servicebus_subscription_example.name,
+ *     topicName: azurerm_servicebus_topic_example.name,
+ * });
+ * ```
+ * 
+ * ## Example Usage (Correlation Filter)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_example = new azure.core.ResourceGroup("example", {
+ *     location: "West Europe",
+ *     name: "tfex-servicebus-subscription-rule-cor",
+ * });
+ * const azurerm_servicebus_namespace_example = new azure.eventhub.Namespace("example", {
+ *     location: azurerm_resource_group_example.location,
+ *     name: "tfex_sevicebus_namespace",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     sku: "standard",
+ *     tags: {
+ *         source: "terraform",
+ *     },
+ * });
+ * const azurerm_servicebus_topic_example = new azure.eventhub.Topic("example", {
+ *     enablePartitioning: true,
+ *     name: "tfex_sevicebus_topic",
+ *     namespaceName: azurerm_servicebus_namespace_example.name,
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ * });
+ * const azurerm_servicebus_subscription_example = new azure.eventhub.Subscription("example", {
+ *     maxDeliveryCount: 1,
+ *     name: "tfex_sevicebus_subscription",
+ *     namespaceName: azurerm_servicebus_namespace_example.name,
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     topicName: azurerm_servicebus_topic_example.name,
+ * });
+ * const azurerm_servicebus_subscription_rule_example = new azure.eventhub.SubscriptionRule("example", {
+ *     correlationFilter: {
+ *         correlationId: "high",
+ *         label: "red",
+ *     },
+ *     filterType: "CorrelationFilter",
+ *     name: "tfex_sevicebus_rule",
+ *     namespaceName: azurerm_servicebus_namespace_example.name,
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     subscriptionName: azurerm_servicebus_subscription_example.name,
+ *     topicName: azurerm_servicebus_topic_example.name,
+ * });
+ * ```
  */
 export class SubscriptionRule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/eventhub/topic.ts
+++ b/sdk/nodejs/eventhub/topic.ts
@@ -8,6 +8,33 @@ import * as utilities from "../utilities";
  * Manage a ServiceBus Topic.
  * 
  * **Note** Topics can only be created in Namespaces with an SKU of `standard` or higher.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_example = new azure.core.ResourceGroup("example", {
+ *     location: "West Europe",
+ *     name: "tfex-servicebus-topic",
+ * });
+ * const azurerm_servicebus_namespace_example = new azure.eventhub.Namespace("example", {
+ *     location: azurerm_resource_group_example.location,
+ *     name: "tfex_sevicebus_namespace",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     sku: "standard",
+ *     tags: {
+ *         source: "terraform",
+ *     },
+ * });
+ * const azurerm_servicebus_topic_example = new azure.eventhub.Topic("example", {
+ *     enablePartitioning: true,
+ *     name: "tfex_sevicebus_topic",
+ *     namespaceName: azurerm_servicebus_namespace_example.name,
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ * });
+ * ```
  */
 export class Topic extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/eventhub/topicAuthorizationRule.ts
+++ b/sdk/nodejs/eventhub/topicAuthorizationRule.ts
@@ -6,6 +6,41 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a ServiceBus Topic authorization Rule within a ServiceBus Topic.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_example = new azure.core.ResourceGroup("example", {
+ *     location: "West US",
+ *     name: "tfex-servicebus",
+ * });
+ * const azurerm_servicebus_namespace_example = new azure.eventhub.Namespace("example", {
+ *     location: azurerm_resource_group_example.location,
+ *     name: "tfex_servicebus_namespace",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     sku: "standard",
+ *     tags: {
+ *         source: "terraform",
+ *     },
+ * });
+ * const azurerm_servicebus_topic_example = new azure.eventhub.Topic("example", {
+ *     name: "tfex_servicebus_topic",
+ *     namespaceName: azurerm_servicebus_namespace_example.name,
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ * });
+ * const azurerm_servicebus_topic_authorization_rule_example = new azure.eventhub.TopicAuthorizationRule("example", {
+ *     listen: true,
+ *     manage: false,
+ *     name: "tfex_servicebus_topic_sasPolicy",
+ *     namespaceName: azurerm_servicebus_namespace_example.name,
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     send: false,
+ *     topicName: azurerm_servicebus_topic_example.name,
+ * });
+ * ```
  */
 export class TopicAuthorizationRule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/iot/ioTHub.ts
+++ b/sdk/nodejs/iot/ioTHub.ts
@@ -6,6 +6,61 @@ import * as utilities from "../utilities";
 
 /**
  * Manages an IotHub
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "resourceGroup1",
+ * });
+ * const azurerm_storage_account_test = new azure.storage.Account("test", {
+ *     accountReplicationType: "LRS",
+ *     accountTier: "Standard",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "teststa",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_iothub_test = new azure.iot.IoTHub("test", {
+ *     endpoints: [{
+ *         batchFrequencyInSeconds: 60,
+ *         connectionString: azurerm_storage_account_test.primaryBlobConnectionString,
+ *         containerName: "test",
+ *         encoding: "Avro",
+ *         fileNameFormat: "{iothub}/{partition}_{YYYY}_{MM}_{DD}_{HH}_{mm}",
+ *         maxChunkSizeInBytes: 10485760,
+ *         name: "export",
+ *         type: "AzureIotHub.StorageContainer",
+ *     }],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "test",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     routes: [{
+ *         condition: "true",
+ *         enabled: true,
+ *         endpointNames: ["export"],
+ *         name: "export",
+ *         source: "DeviceMessages",
+ *     }],
+ *     sku: {
+ *         capacity: Number.parseFloat("1"),
+ *         name: "S1",
+ *         tier: "Standard",
+ *     },
+ *     tags: {
+ *         purpose: "testing",
+ *     },
+ * });
+ * const azurerm_storage_container_test = new azure.storage.Container("test", {
+ *     containerAccessType: "private",
+ *     name: "test",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     storageAccountName: azurerm_storage_account_test.name,
+ * });
+ * ```
  */
 export class IoTHub extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/keyvault/accessPolicy.ts
+++ b/sdk/nodejs/keyvault/accessPolicy.ts
@@ -7,7 +7,7 @@ import * as utilities from "../utilities";
 /**
  * Manages a Key Vault Access Policy.
  * 
- * ~> **NOTE:** It's possible to define Key Vault Access Policies both within the `azurerm_key_vault` resource via the `access_policy` block and by using the `azurerm_key_vault_access_policy` resource. However it's not possible to use both methods to manage Access Policies within a KeyVault, since there'll be conflicts.
+ * > **NOTE:** It's possible to define Key Vault Access Policies both within the `azurerm_key_vault` resource via the `access_policy` block and by using the `azurerm_key_vault_access_policy` resource. However it's not possible to use both methods to manage Access Policies within a KeyVault, since there'll be conflicts.
  * 
  * -> **NOTE:** Azure permits a maximum of 16 Access Policies per Key Vault - [more information can be found in this document](https://docs.microsoft.com/en-us/azure/key-vault/key-vault-secure-your-key-vault#data-plane-access-control).
  */

--- a/sdk/nodejs/keyvault/certifiate.ts
+++ b/sdk/nodejs/keyvault/certifiate.ts
@@ -6,6 +6,219 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Key Vault Certificate.
+ * 
+ * ## Example Usage (Importing a PFX)
+ * 
+ * > **Note:** this example assumed the PFX file is located in the same directory at `certificate-to-import.pfx`.
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * import * as fs from "fs";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "key-vault-certificate-example",
+ * });
+ * const azurerm_client_config_current = pulumi.output(azure.core.getClientConfig({}));
+ * const azurerm_key_vault_test = new azure.keyvault.KeyVault("test", {
+ *     accessPolicies: [{
+ *         certificatePermissions: [
+ *             "create",
+ *             "delete",
+ *             "deleteissuers",
+ *             "get",
+ *             "getissuers",
+ *             "import",
+ *             "list",
+ *             "listissuers",
+ *             "managecontacts",
+ *             "manageissuers",
+ *             "setissuers",
+ *             "update",
+ *         ],
+ *         keyPermissions: [
+ *             "backup",
+ *             "create",
+ *             "decrypt",
+ *             "delete",
+ *             "encrypt",
+ *             "get",
+ *             "import",
+ *             "list",
+ *             "purge",
+ *             "recover",
+ *             "restore",
+ *             "sign",
+ *             "unwrapKey",
+ *             "update",
+ *             "verify",
+ *             "wrapKey",
+ *         ],
+ *         objectId: azurerm_client_config_current.apply(__arg0 => __arg0.servicePrincipalObjectId),
+ *         secretPermissions: [
+ *             "backup",
+ *             "delete",
+ *             "get",
+ *             "list",
+ *             "purge",
+ *             "recover",
+ *             "restore",
+ *             "set",
+ *         ],
+ *         tenantId: azurerm_client_config_current.apply(__arg0 => __arg0.tenantId),
+ *     }],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "keyvaultcertexample",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         name: "standard",
+ *     },
+ *     tags: {
+ *         environment: "Production",
+ *     },
+ *     tenantId: azurerm_client_config_current.apply(__arg0 => __arg0.tenantId),
+ * });
+ * const azurerm_key_vault_certificate_test = new azure.keyvault.Certifiate("test", {
+ *     certificate: {
+ *         contents: Buffer.from(fs.readFileSync("certificate-to-import.pfx", "utf-8")).toString("base64"),
+ *         password: "",
+ *     },
+ *     certificatePolicy: {
+ *         issuerParameters: {
+ *             name: "Self",
+ *         },
+ *         keyProperties: {
+ *             exportable: true,
+ *             keySize: 2048,
+ *             keyType: "RSA",
+ *             reuseKey: false,
+ *         },
+ *         secretProperties: {
+ *             contentType: "application/x-pkcs12",
+ *         },
+ *     },
+ *     name: "imported-cert",
+ *     vaultUri: azurerm_key_vault_test.vaultUri,
+ * });
+ * ```
+ * 
+ * ## Example Usage (Generating a new certificate)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "key-vault-certificate-example",
+ * });
+ * const azurerm_client_config_current = pulumi.output(azure.core.getClientConfig({}));
+ * const azurerm_key_vault_test = new azure.keyvault.KeyVault("test", {
+ *     accessPolicies: [{
+ *         certificatePermissions: [
+ *             "create",
+ *             "delete",
+ *             "deleteissuers",
+ *             "get",
+ *             "getissuers",
+ *             "import",
+ *             "list",
+ *             "listissuers",
+ *             "managecontacts",
+ *             "manageissuers",
+ *             "setissuers",
+ *             "update",
+ *         ],
+ *         keyPermissions: [
+ *             "backup",
+ *             "create",
+ *             "decrypt",
+ *             "delete",
+ *             "encrypt",
+ *             "get",
+ *             "import",
+ *             "list",
+ *             "purge",
+ *             "recover",
+ *             "restore",
+ *             "sign",
+ *             "unwrapKey",
+ *             "update",
+ *             "verify",
+ *             "wrapKey",
+ *         ],
+ *         objectId: azurerm_client_config_current.apply(__arg0 => __arg0.servicePrincipalObjectId),
+ *         secretPermissions: [
+ *             "backup",
+ *             "delete",
+ *             "get",
+ *             "list",
+ *             "purge",
+ *             "recover",
+ *             "restore",
+ *             "set",
+ *         ],
+ *         tenantId: azurerm_client_config_current.apply(__arg0 => __arg0.tenantId),
+ *     }],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "keyvaultcertexample",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         name: "standard",
+ *     },
+ *     tags: {
+ *         environment: "Production",
+ *     },
+ *     tenantId: azurerm_client_config_current.apply(__arg0 => __arg0.tenantId),
+ * });
+ * const azurerm_key_vault_certificate_test = new azure.keyvault.Certifiate("test", {
+ *     certificatePolicy: {
+ *         issuerParameters: {
+ *             name: "Self",
+ *         },
+ *         keyProperties: {
+ *             exportable: true,
+ *             keySize: 2048,
+ *             keyType: "RSA",
+ *             reuseKey: true,
+ *         },
+ *         lifetimeActions: [{
+ *             action: {
+ *                 actionType: "AutoRenew",
+ *             },
+ *             trigger: {
+ *                 daysBeforeExpiry: 30,
+ *             },
+ *         }],
+ *         secretProperties: {
+ *             contentType: "application/x-pkcs12",
+ *         },
+ *         x509CertificateProperties: {
+ *             extendedKeyUsages: ["1.3.6.1.5.5.7.3.1"],
+ *             keyUsages: [
+ *                 "cRLSign",
+ *                 "dataEncipherment",
+ *                 "digitalSignature",
+ *                 "keyAgreement",
+ *                 "keyCertSign",
+ *                 "keyEncipherment",
+ *             ],
+ *             subject: "CN=hello-world",
+ *             subjectAlternativeNames: {
+ *                 dnsNames: [
+ *                     "internal.contoso.com",
+ *                     "domain.hello.world",
+ *                 ],
+ *             },
+ *             validityInMonths: 12,
+ *         },
+ *     },
+ *     name: "generated-cert",
+ *     vaultUri: azurerm_key_vault_test.vaultUri,
+ * });
+ * ```
+ * 
  */
 export class Certifiate extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/keyvault/getKey.ts
+++ b/sdk/nodejs/keyvault/getKey.ts
@@ -7,7 +7,7 @@ import * as utilities from "../utilities";
 /**
  * Use this data source to access information about an existing Key Vault Key.
  * 
- * ~> **Note:** All arguments including the secret value will be stored in the raw state as plain-text.
+ * > **Note:** All arguments including the secret value will be stored in the raw state as plain-text.
  * [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
  */
 export function getKey(args: GetKeyArgs, opts?: pulumi.InvokeOptions): Promise<GetKeyResult> {

--- a/sdk/nodejs/keyvault/getKeyVault.ts
+++ b/sdk/nodejs/keyvault/getKeyVault.ts
@@ -6,6 +6,20 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing Key Vault.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_key_vault_test = pulumi.output(azure.keyvault.getKeyVault({
+ *     name: "mykeyvault",
+ *     resourceGroupName: "some-resource-group",
+ * }));
+ * 
+ * export const vaultUri = azurerm_key_vault_test.apply(__arg0 => __arg0.vaultUri);
+ * ```
  */
 export function getKeyVault(args: GetKeyVaultArgs, opts?: pulumi.InvokeOptions): Promise<GetKeyVaultResult> {
     return pulumi.runtime.invoke("azure:keyvault/getKeyVault:getKeyVault", {

--- a/sdk/nodejs/keyvault/getSecret.ts
+++ b/sdk/nodejs/keyvault/getSecret.ts
@@ -7,8 +7,22 @@ import * as utilities from "../utilities";
 /**
  * Use this data source to access information about an existing Key Vault Secret.
  * 
- * ~> **Note:** All arguments including the secret value will be stored in the raw state as plain-text.
+ * > **Note:** All arguments including the secret value will be stored in the raw state as plain-text.
  * [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_key_vault_secret_test = pulumi.output(azure.keyvault.getSecret({
+ *     name: "secret-sauce",
+ *     vaultUri: "https://rickslab.vault.azure.net/",
+ * }));
+ * 
+ * export const secretValue = azurerm_key_vault_secret_test.apply(__arg0 => __arg0.value);
+ * ```
  */
 export function getSecret(args: GetSecretArgs, opts?: pulumi.InvokeOptions): Promise<GetSecretResult> {
     return pulumi.runtime.invoke("azure:keyvault/getSecret:getSecret", {

--- a/sdk/nodejs/keyvault/key.ts
+++ b/sdk/nodejs/keyvault/key.ts
@@ -6,6 +6,62 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Key Vault Key.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * import * as random from "@pulumi/random";
+ * import sprintf = require("sprintf-js");
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "my-resource-group",
+ * });
+ * const azurerm_client_config_current = pulumi.output(azure.core.getClientConfig({}));
+ * const random_id_server = new random.RandomId("server", {
+ *     byteLength: 8,
+ *     keepers: {
+ *         ami_id: 1,
+ *     },
+ * });
+ * const azurerm_key_vault_test = new azure.keyvault.KeyVault("test", {
+ *     accessPolicies: [{
+ *         keyPermissions: [
+ *             "create",
+ *             "get",
+ *         ],
+ *         objectId: azurerm_client_config_current.apply(__arg0 => __arg0.servicePrincipalObjectId),
+ *         secretPermissions: ["set"],
+ *         tenantId: azurerm_client_config_current.apply(__arg0 => __arg0.tenantId),
+ *     }],
+ *     location: azurerm_resource_group_test.location,
+ *     name: random_id_server.hex.apply(__arg0 => sprintf.sprintf("%s%s", "kv", __arg0)),
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         name: "premium",
+ *     },
+ *     tags: {
+ *         environment: "Production",
+ *     },
+ *     tenantId: azurerm_client_config_current.apply(__arg0 => __arg0.tenantId),
+ * });
+ * const azurerm_key_vault_key_generated = new azure.keyvault.Key("generated", {
+ *     keyOpts: [
+ *         "decrypt",
+ *         "encrypt",
+ *         "sign",
+ *         "unwrapKey",
+ *         "verify",
+ *         "wrapKey",
+ *     ],
+ *     keySize: 2048,
+ *     keyType: "RSA",
+ *     name: "generated-certificate",
+ *     vaultUri: azurerm_key_vault_test.vaultUri,
+ * });
+ * ```
  */
 export class Key extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/keyvault/keyVault.ts
+++ b/sdk/nodejs/keyvault/keyVault.ts
@@ -7,7 +7,42 @@ import * as utilities from "../utilities";
 /**
  * Manages a Key Vault.
  * 
- * ~> **NOTE:** It's possible to define Key Vault Access Policies both within the `azurerm_key_vault` resource via the `access_policy` block and by using the `azurerm_key_vault_access_policy` resource. However it's not possible to use both methods to manage Access Policies within a KeyVault, since there'll be conflicts.
+ * > **NOTE:** It's possible to define Key Vault Access Policies both within the `azurerm_key_vault` resource via the `access_policy` block and by using the `azurerm_key_vault_access_policy` resource. However it's not possible to use both methods to manage Access Policies within a KeyVault, since there'll be conflicts.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "resourceGroup1",
+ * });
+ * const azurerm_key_vault_test = new azure.keyvault.KeyVault("test", {
+ *     accessPolicies: [{
+ *         keyPermissions: ["get"],
+ *         objectId: "d746815a-0433-4a21-b95d-fc437d2d475b",
+ *         secretPermissions: ["get"],
+ *         tenantId: "d6e396d0-5584-41dc-9fc0-268df99bc610",
+ *     }],
+ *     enabledForDiskEncryption: true,
+ *     location: azurerm_resource_group_test.location,
+ *     name: "testvault",
+ *     networkAcls: {
+ *         bypass: "AzureServices",
+ *         defaultAction: "Deny",
+ *     },
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         name: "standard",
+ *     },
+ *     tags: {
+ *         environment: "Production",
+ *     },
+ *     tenantId: "d6e396d0-5584-41dc-9fc0-268df99bc610",
+ * });
+ * ```
  */
 export class KeyVault extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/lb/backendAddressPool.ts
+++ b/sdk/nodejs/lb/backendAddressPool.ts
@@ -7,7 +7,39 @@ import * as utilities from "../utilities";
 /**
  * Manage a Load Balancer Backend Address Pool.
  * 
- * ~> **NOTE:** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
+ * > **NOTE:** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "LoadBalancerRG",
+ * });
+ * const azurerm_public_ip_test = new azure.network.PublicIp("test", {
+ *     location: "West US",
+ *     name: "PublicIPForLB",
+ *     publicIpAddressAllocation: "static",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_lb_test = new azure.lb.LoadBalancer("test", {
+ *     frontendIpConfigurations: [{
+ *         name: "PublicIPAddress",
+ *         publicIpAddressId: azurerm_public_ip_test.id,
+ *     }],
+ *     location: "West US",
+ *     name: "TestLoadBalancer",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_lb_backend_address_pool_test = new azure.lb.BackendAddressPool("test", {
+ *     loadbalancerId: azurerm_lb_test.id,
+ *     name: "BackEndAddressPool",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * ```
  */
 export class BackendAddressPool extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/lb/loadBalancer.ts
+++ b/sdk/nodejs/lb/loadBalancer.ts
@@ -6,6 +6,33 @@ import * as utilities from "../utilities";
 
 /**
  * Manage a Load Balancer Resource.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "LoadBalancerRG",
+ * });
+ * const azurerm_public_ip_test = new azure.network.PublicIp("test", {
+ *     location: "West US",
+ *     name: "PublicIPForLB",
+ *     publicIpAddressAllocation: "static",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_lb_test = new azure.lb.LoadBalancer("test", {
+ *     frontendIpConfigurations: [{
+ *         name: "PublicIPAddress",
+ *         publicIpAddressId: azurerm_public_ip_test.id,
+ *     }],
+ *     location: "West US",
+ *     name: "TestLoadBalancer",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * ```
  */
 export class LoadBalancer extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/lb/natPool.ts
+++ b/sdk/nodejs/lb/natPool.ts
@@ -7,7 +7,44 @@ import * as utilities from "../utilities";
 /**
  * Manages a Load Balancer NAT pool.
  * 
- * ~> **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
+ * > **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "LoadBalancerRG",
+ * });
+ * const azurerm_public_ip_test = new azure.network.PublicIp("test", {
+ *     location: "West US",
+ *     name: "PublicIPForLB",
+ *     publicIpAddressAllocation: "static",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_lb_test = new azure.lb.LoadBalancer("test", {
+ *     frontendIpConfigurations: [{
+ *         name: "PublicIPAddress",
+ *         publicIpAddressId: azurerm_public_ip_test.id,
+ *     }],
+ *     location: "West US",
+ *     name: "TestLoadBalancer",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_lb_nat_pool_test = new azure.lb.NatPool("test", {
+ *     backendPort: 8080,
+ *     frontendIpConfigurationName: "PublicIPAddress",
+ *     frontendPortEnd: 81,
+ *     frontendPortStart: 80,
+ *     loadbalancerId: azurerm_lb_test.id,
+ *     name: "SampleApplicationPool",
+ *     protocol: "Tcp",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * ```
  */
 export class NatPool extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/lb/natRule.ts
+++ b/sdk/nodejs/lb/natRule.ts
@@ -7,7 +7,43 @@ import * as utilities from "../utilities";
 /**
  * Manages a Load Balancer NAT Rule.
  * 
- * ~> **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
+ * > **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "LoadBalancerRG",
+ * });
+ * const azurerm_public_ip_test = new azure.network.PublicIp("test", {
+ *     location: "West US",
+ *     name: "PublicIPForLB",
+ *     publicIpAddressAllocation: "static",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_lb_test = new azure.lb.LoadBalancer("test", {
+ *     frontendIpConfigurations: [{
+ *         name: "PublicIPAddress",
+ *         publicIpAddressId: azurerm_public_ip_test.id,
+ *     }],
+ *     location: "West US",
+ *     name: "TestLoadBalancer",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_lb_nat_rule_test = new azure.lb.NatRule("test", {
+ *     backendPort: 3389,
+ *     frontendIpConfigurationName: "PublicIPAddress",
+ *     frontendPort: 3389,
+ *     loadbalancerId: azurerm_lb_test.id,
+ *     name: "RDPAccess",
+ *     protocol: "Tcp",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * ```
  */
 export class NatRule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/lb/probe.ts
+++ b/sdk/nodejs/lb/probe.ts
@@ -7,7 +7,40 @@ import * as utilities from "../utilities";
 /**
  * Manages a LoadBalancer Probe Resource.
  * 
- * ~> **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
+ * > **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "LoadBalancerRG",
+ * });
+ * const azurerm_public_ip_test = new azure.network.PublicIp("test", {
+ *     location: "West US",
+ *     name: "PublicIPForLB",
+ *     publicIpAddressAllocation: "static",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_lb_test = new azure.lb.LoadBalancer("test", {
+ *     frontendIpConfigurations: [{
+ *         name: "PublicIPAddress",
+ *         publicIpAddressId: azurerm_public_ip_test.id,
+ *     }],
+ *     location: "West US",
+ *     name: "TestLoadBalancer",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_lb_probe_test = new azure.lb.Probe("test", {
+ *     loadbalancerId: azurerm_lb_test.id,
+ *     name: "ssh-running-probe",
+ *     port: 22,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * ```
  */
 export class Probe extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/lb/rule.ts
+++ b/sdk/nodejs/lb/rule.ts
@@ -7,7 +7,43 @@ import * as utilities from "../utilities";
 /**
  * Manages a Load Balancer Rule.
  * 
- * ~> **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
+ * > **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "LoadBalancerRG",
+ * });
+ * const azurerm_public_ip_test = new azure.network.PublicIp("test", {
+ *     location: "West US",
+ *     name: "PublicIPForLB",
+ *     publicIpAddressAllocation: "static",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_lb_test = new azure.lb.LoadBalancer("test", {
+ *     frontendIpConfigurations: [{
+ *         name: "PublicIPAddress",
+ *         publicIpAddressId: azurerm_public_ip_test.id,
+ *     }],
+ *     location: "West US",
+ *     name: "TestLoadBalancer",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_lb_rule_test = new azure.lb.Rule("test", {
+ *     backendPort: 3389,
+ *     frontendIpConfigurationName: "PublicIPAddress",
+ *     frontendPort: 3389,
+ *     loadbalancerId: azurerm_lb_test.id,
+ *     name: "LBRule",
+ *     protocol: "Tcp",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * ```
  */
 export class Rule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/logicapps/actionCustom.ts
+++ b/sdk/nodejs/logicapps/actionCustom.ts
@@ -6,6 +6,28 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Custom Action within a Logic App Workflow
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "East US",
+ *     name: "workflow-resources",
+ * });
+ * const azurerm_logic_app_workflow_test = new azure.logicapps.Workflow("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "workflow1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_logic_app_action_custom_test = new azure.logicapps.ActionCustom("test", {
+ *     body: "{\n    \"description\": \"A variable to configure the auto expiration age in days. Configured in negative number. Default is -30 (30 days old).\",\n    \"inputs\": {\n        \"variables\": [\n            {\n                \"name\": \"ExpirationAgeInDays\",\n                \"type\": \"Integer\",\n                \"value\": -30\n            }\n        ]\n    },\n    \"runAfter\": {},\n    \"type\": \"InitializeVariable\"\n}\n",
+ *     logicAppId: azurerm_logic_app_workflow_test.id,
+ *     name: "example-action",
+ * });
+ * ```
  */
 export class ActionCustom extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/logicapps/actionHttp.ts
+++ b/sdk/nodejs/logicapps/actionHttp.ts
@@ -6,6 +6,29 @@ import * as utilities from "../utilities";
 
 /**
  * Manages an HTTP Action within a Logic App Workflow
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "East US",
+ *     name: "workflow-resources",
+ * });
+ * const azurerm_logic_app_workflow_test = new azure.logicapps.Workflow("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "workflow1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_logic_app_action_http_test = new azure.logicapps.ActionHttp("test", {
+ *     logicAppId: azurerm_logic_app_workflow_test.id,
+ *     method: "GET",
+ *     name: "webhook",
+ *     uri: "http://example.com/some-webhook",
+ * });
+ * ```
  */
 export class ActionHttp extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/logicapps/getWorkflow.ts
+++ b/sdk/nodejs/logicapps/getWorkflow.ts
@@ -6,6 +6,20 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing Logic App Workflow.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_logic_app_workflow_test = pulumi.output(azure.logicapps.getWorkflow({
+ *     name: "workflow1",
+ *     resourceGroupName: "my-resource-group",
+ * }));
+ * 
+ * export const accessEndpoint = azurerm_logic_app_workflow_test.apply(__arg0 => __arg0.accessEndpoint);
+ * ```
  */
 export function getWorkflow(args: GetWorkflowArgs, opts?: pulumi.InvokeOptions): Promise<GetWorkflowResult> {
     return pulumi.runtime.invoke("azure:logicapps/getWorkflow:getWorkflow", {

--- a/sdk/nodejs/logicapps/triggerCustom.ts
+++ b/sdk/nodejs/logicapps/triggerCustom.ts
@@ -6,6 +6,28 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Custom Trigger within a Logic App Workflow
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "East US",
+ *     name: "workflow-resources",
+ * });
+ * const azurerm_logic_app_workflow_test = new azure.logicapps.Workflow("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "workflow1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_logic_app_trigger_custom_test = new azure.logicapps.TriggerCustom("test", {
+ *     body: "{\n  \"recurrence\": {\n    \"frequency\": \"Day\",\n    \"interval\": 1\n  },\n  \"type\": \"Recurrence\"\n}\n",
+ *     logicAppId: azurerm_logic_app_workflow_test.id,
+ *     name: "example-trigger",
+ * });
+ * ```
  */
 export class TriggerCustom extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/logicapps/triggerHttpRequest.ts
+++ b/sdk/nodejs/logicapps/triggerHttpRequest.ts
@@ -6,6 +6,28 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a HTTP Request Trigger within a Logic App Workflow
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "East US",
+ *     name: "workflow-resources",
+ * });
+ * const azurerm_logic_app_workflow_test = new azure.logicapps.Workflow("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "workflow1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_logic_app_trigger_http_request_test = new azure.logicapps.TriggerHttpRequest("test", {
+ *     logicAppId: azurerm_logic_app_workflow_test.id,
+ *     name: "some-http-trigger",
+ *     schema: "{\n    \"type\": \"object\",\n    \"properties\": {\n        \"hello\": {\n            \"type\": \"string\"\n        }\n    }\n}\n",
+ * });
+ * ```
  */
 export class TriggerHttpRequest extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/logicapps/triggerRecurrence.ts
+++ b/sdk/nodejs/logicapps/triggerRecurrence.ts
@@ -6,6 +6,29 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Recurrence Trigger within a Logic App Workflow
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "East US",
+ *     name: "workflow-resources",
+ * });
+ * const azurerm_logic_app_workflow_test = new azure.logicapps.Workflow("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "workflow1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_logic_app_trigger_recurrence_test = new azure.logicapps.TriggerRecurrence("test", {
+ *     frequency: "Day",
+ *     interval: 1,
+ *     logicAppId: azurerm_logic_app_workflow_test.id,
+ *     name: "run-every-day",
+ * });
+ * ```
  */
 export class TriggerRecurrence extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/logicapps/workflow.ts
+++ b/sdk/nodejs/logicapps/workflow.ts
@@ -6,6 +6,23 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Logic App Workflow.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "East US",
+ *     name: "workflow-resources",
+ * });
+ * const azurerm_logic_app_workflow_test = new azure.logicapps.Workflow("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "workflow1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * ```
  */
 export class Workflow extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/managementgroups/getManagementGroup.ts
+++ b/sdk/nodejs/managementgroups/getManagementGroup.ts
@@ -6,6 +6,19 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing Management Group.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_management_group_test = pulumi.output(azure.managementgroups.getManagementGroup({
+ *     groupId: "00000000-0000-0000-0000-000000000000",
+ * }));
+ * 
+ * export const displayName = azurerm_management_group_test.apply(__arg0 => __arg0.displayName);
+ * ```
  */
 export function getManagementGroup(args: GetManagementGroupArgs, opts?: pulumi.InvokeOptions): Promise<GetManagementGroupResult> {
     return pulumi.runtime.invoke("azure:managementgroups/getManagementGroup:getManagementGroup", {

--- a/sdk/nodejs/managementgroups/managementGroup.ts
+++ b/sdk/nodejs/managementgroups/managementGroup.ts
@@ -6,6 +6,18 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Management Group.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_subscription_current = pulumi.output(azure.core.getSubscription({}));
+ * const azurerm_management_group_test = new azure.managementgroups.ManagementGroup("test", {
+ *     subscriptionIds: [azurerm_subscription_current.apply(__arg0 => __arg0.id)],
+ * });
+ * ```
  */
 export class ManagementGroup extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/managementresource/manangementLock.ts
+++ b/sdk/nodejs/managementresource/manangementLock.ts
@@ -6,6 +6,63 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Management Lock which is scoped to a Subscription, Resource Group or Resource.
+ * 
+ * ## Example Usage (Subscription Level Lock)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_subscription_current = pulumi.output(azure.core.getSubscription({}));
+ * const azurerm_management_lock_subscription_level = new azure.managementresource.ManangementLock("subscription-level", {
+ *     lockLevel: "CanNotDelete",
+ *     name: "subscription-level",
+ *     notes: "Items can't be deleted in this subscription!",
+ *     scope: azurerm_subscription_current.apply(__arg0 => __arg0.id),
+ * });
+ * ```
+ * ###  Example Usage (Resource Group Level Lock)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "locked-resource-group",
+ * });
+ * const azurerm_management_lock_resource_group_level = new azure.managementresource.ManangementLock("resource-group-level", {
+ *     lockLevel: "ReadOnly",
+ *     name: "resource-group-level",
+ *     notes: "This Resource Group is Read-Only",
+ *     scope: azurerm_resource_group_test.id,
+ * });
+ * ```
+ * 
+ * ## Example Usage (Resource Level Lock)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "locked-resource-group",
+ * });
+ * const azurerm_public_ip_test = new azure.network.PublicIp("test", {
+ *     idleTimeoutInMinutes: 30,
+ *     location: azurerm_resource_group_test.location,
+ *     name: "locked-publicip",
+ *     publicIpAddressAllocation: "static",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_management_lock_public_ip = new azure.managementresource.ManangementLock("public-ip", {
+ *     lockLevel: "CanNotDelete",
+ *     name: "resource-ip",
+ *     notes: "Locked because it's needed by a third-party",
+ *     scope: azurerm_public_ip_test.id,
+ * });
+ * ```
  */
 export class ManangementLock extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/mariadb/database.ts
+++ b/sdk/nodejs/mariadb/database.ts
@@ -6,6 +6,45 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a MariaDB Database within a MariaDB Server
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_example = new azure.core.ResourceGroup("example", {
+ *     location: "westeurope",
+ *     name: "tfex-mariadb-database-RG",
+ * });
+ * const azurerm_mariadb_server_example = new azure.mariadb.Server("example", {
+ *     administratorLogin: "acctestun",
+ *     administratorLoginPassword: "H@Sh1CoR3!",
+ *     location: azurerm_resource_group_example.location,
+ *     name: "mariadb-svr",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     sku: {
+ *         capacity: 2,
+ *         family: "Gen5",
+ *         name: "B_Gen5_2",
+ *         tier: "Basic",
+ *     },
+ *     sslEnforcement: "Enabled",
+ *     storageProfile: {
+ *         backupRetentionDays: 7,
+ *         geoRedundantBackup: "Disabled",
+ *         storageMb: 51200,
+ *     },
+ *     version: "10.2",
+ * });
+ * const azurerm_mariadb_database_example = new azure.mariadb.Database("example", {
+ *     charset: "utf8",
+ *     collation: "utf8_general_ci",
+ *     name: "mariadb_database",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     serverName: azurerm_mariadb_server_example.name,
+ * });
+ * ```
  */
 export class Database extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/mariadb/server.ts
+++ b/sdk/nodejs/mariadb/server.ts
@@ -8,6 +8,38 @@ import * as utilities from "../utilities";
  * Manages a MariaDB Server.
  * 
  * -> **NOTE** MariaDB Server is currently in Public Preview. You can find more information, including [how to register for the Public Preview here](https://azure.microsoft.com/en-us/updates/mariadb-public-preview/).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "api-rg-pro",
+ * });
+ * const azurerm_mariadb_server_test = new azure.mariadb.Server("test", {
+ *     administratorLogin: "mariadbadmin",
+ *     administratorLoginPassword: "H@Sh1CoR3!",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "mariadb-server-1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         capacity: 2,
+ *         family: "Gen5",
+ *         name: "B_Gen5_2",
+ *         tier: "Basic",
+ *     },
+ *     sslEnforcement: "Enabled",
+ *     storageProfile: {
+ *         backupRetentionDays: 7,
+ *         geoRedundantBackup: "Disabled",
+ *         storageMb: 5120,
+ *     },
+ *     version: "10.2",
+ * });
+ * ```
  */
 export class Server extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/monitoring/actionGroup.ts
+++ b/sdk/nodejs/monitoring/actionGroup.ts
@@ -6,6 +6,42 @@ import * as utilities from "../utilities";
 
 /**
  * Manages an Action Group within Azure Monitor.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "monitoring-resources",
+ * });
+ * const azurerm_monitor_action_group_test = new azure.monitoring.ActionGroup("test", {
+ *     emailReceivers: [
+ *         {
+ *             emailAddress: "admin@contoso.com",
+ *             name: "sendtoadmin",
+ *         },
+ *         {
+ *             emailAddress: "devops@contoso.com",
+ *             name: "sendtodevops",
+ *         },
+ *     ],
+ *     name: "CriticalAlertsAction",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     shortName: "p0action",
+ *     smsReceivers: [{
+ *         countryCode: "1",
+ *         name: "oncallmsg",
+ *         phoneNumber: "1231231234",
+ *     }],
+ *     webhookReceivers: [{
+ *         name: "callmyapiaswell",
+ *         serviceUri: "http://example.com/alert",
+ *     }],
+ * });
+ * ```
  */
 export class ActionGroup extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/monitoring/activityLogAlert.ts
+++ b/sdk/nodejs/monitoring/activityLogAlert.ts
@@ -4,6 +4,53 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_main = new azure.core.ResourceGroup("main", {
+ *     location: "West US",
+ *     name: "example-resources",
+ * });
+ * const azurerm_monitor_action_group_main = new azure.monitoring.ActionGroup("main", {
+ *     name: "example-actiongroup",
+ *     resourceGroupName: azurerm_resource_group_main.name,
+ *     shortName: "p0action",
+ *     webhookReceivers: [{
+ *         name: "callmyapi",
+ *         serviceUri: "http://example.com/alert",
+ *     }],
+ * });
+ * const azurerm_storage_account_to_monitor = new azure.storage.Account("to_monitor", {
+ *     accountReplicationType: "GRS",
+ *     accountTier: "Standard",
+ *     location: azurerm_resource_group_main.location,
+ *     name: "examplesa",
+ *     resourceGroupName: azurerm_resource_group_main.name,
+ * });
+ * const azurerm_monitor_activity_log_alert_main = new azure.monitoring.ActivityLogAlert("main", {
+ *     actions: [{
+ *         actionGroupId: azurerm_monitor_action_group_main.id,
+ *         webhookProperties: {
+ *             from: "terraform",
+ *         },
+ *     }],
+ *     criteria: {
+ *         category: "Recommendation",
+ *         operationName: "Microsoft.Storage/storageAccounts/write",
+ *         resourceId: azurerm_storage_account_to_monitor.id,
+ *     },
+ *     description: "This alert will monitor a specific storage account updates.",
+ *     name: "example-activitylogalert",
+ *     resourceGroupName: azurerm_resource_group_main.name,
+ *     scopes: [azurerm_resource_group_main.id],
+ * });
+ * ```
+ */
 export class ActivityLogAlert extends pulumi.CustomResource {
     /**
      * Get an existing ActivityLogAlert resource's state with the given name, ID, and optional extra

--- a/sdk/nodejs/monitoring/diagnosticSetting.ts
+++ b/sdk/nodejs/monitoring/diagnosticSetting.ts
@@ -6,6 +6,44 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Diagnostic Setting for an existing Resource.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "example-resources",
+ * });
+ * const azurerm_key_vault_test = pulumi.output(azure.keyvault.getKeyVault({
+ *     name: "example-vault",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * }));
+ * const azurerm_storage_account_test = pulumi.output(azure.storage.getAccount({
+ *     name: "examplestoracc",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * }));
+ * const azurerm_monitor_diagnostic_setting_test = new azure.monitoring.DiagnosticSetting("test", {
+ *     logs: [{
+ *         category: "AuditEvent",
+ *         enabled: false,
+ *         retentionPolicy: {
+ *             enabled: false,
+ *         },
+ *     }],
+ *     metrics: [{
+ *         category: "AllMetrics",
+ *         retentionPolicy: {
+ *             enabled: false,
+ *         },
+ *     }],
+ *     name: "example",
+ *     storageAccountId: azurerm_storage_account_test.apply(__arg0 => __arg0.id),
+ *     targetResourceId: azurerm_key_vault_test.apply(__arg0 => __arg0.id),
+ * });
+ * ```
  */
 export class DiagnosticSetting extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/monitoring/getActionGroup.ts
+++ b/sdk/nodejs/monitoring/getActionGroup.ts
@@ -4,6 +4,22 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_monitor_action_group_example = pulumi.output(azure.monitoring.getActionGroup({
+ *     name: "tfex-actiongroup",
+ *     resourceGroupName: "terraform-example-rg",
+ * }));
+ * 
+ * export const actionGroupId = azurerm_monitor_action_group_example.apply(__arg0 => __arg0.id);
+ * ```
+ */
 export function getActionGroup(args: GetActionGroupArgs, opts?: pulumi.InvokeOptions): Promise<GetActionGroupResult> {
     return pulumi.runtime.invoke("azure:monitoring/getActionGroup:getActionGroup", {
         "name": args.name,

--- a/sdk/nodejs/monitoring/getLogProfile.ts
+++ b/sdk/nodejs/monitoring/getLogProfile.ts
@@ -6,6 +6,19 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access the properties of a Log Profile.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_monitor_log_profile_test = pulumi.output(azure.monitoring.getLogProfile({
+ *     name: "test-logprofile",
+ * }));
+ * 
+ * export const logProfileStorageAccountId = azurerm_monitor_log_profile_test.apply(__arg0 => __arg0.storageAccountId);
+ * ```
  */
 export function getLogProfile(args: GetLogProfileArgs, opts?: pulumi.InvokeOptions): Promise<GetLogProfileResult> {
     return pulumi.runtime.invoke("azure:monitoring/getLogProfile:getLogProfile", {

--- a/sdk/nodejs/monitoring/logProfile.ts
+++ b/sdk/nodejs/monitoring/logProfile.ts
@@ -8,6 +8,50 @@ import * as utilities from "../utilities";
  * Manages a [Log Profile](https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitoring-overview-activity-logs#export-the-activity-log-with-a-log-profile). A Log Profile configures how Activity Logs are exported.
  * 
  * -> **NOTE:** It's only possible to configure one Log Profile per Subscription. If you are trying to create more than one Log Profile, an error with `StatusCode=409` will occur.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "eastus",
+ *     name: "logprofiletest-rg",
+ * });
+ * const azurerm_eventhub_namespace_test = new azure.eventhub.EventHubNamespace("test", {
+ *     capacity: 2,
+ *     location: azurerm_resource_group_test.location,
+ *     name: "logprofileeventhub",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: "Standard",
+ * });
+ * const azurerm_storage_account_test = new azure.storage.Account("test", {
+ *     accountReplicationType: "GRS",
+ *     accountTier: "Standard",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "afscsdfytw",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_monitor_log_profile_test = new azure.monitoring.LogProfile("test", {
+ *     categories: [
+ *         "Action",
+ *         "Delete",
+ *         "Write",
+ *     ],
+ *     locations: [
+ *         "westus",
+ *         "global",
+ *     ],
+ *     name: "default",
+ *     retentionPolicy: {
+ *         days: 7,
+ *         enabled: true,
+ *     },
+ *     servicebusRuleId: azurerm_eventhub_namespace_test.id.apply(__arg0 => `${__arg0}/authorizationrules/RootManageSharedAccessKey`),
+ *     storageAccountId: azurerm_storage_account_test.id,
+ * });
+ * ```
  */
 export class LogProfile extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/monitoring/metricAlert.ts
+++ b/sdk/nodejs/monitoring/metricAlert.ts
@@ -4,6 +4,57 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_main = new azure.core.ResourceGroup("main", {
+ *     location: "West US",
+ *     name: "example-resources",
+ * });
+ * const azurerm_monitor_action_group_main = new azure.monitoring.ActionGroup("main", {
+ *     name: "example-actiongroup",
+ *     resourceGroupName: azurerm_resource_group_main.name,
+ *     shortName: "exampleact",
+ *     webhookReceivers: [{
+ *         name: "callmyapi",
+ *         serviceUri: "http://example.com/alert",
+ *     }],
+ * });
+ * const azurerm_storage_account_to_monitor = new azure.storage.Account("to_monitor", {
+ *     accountReplicationType: "LRS",
+ *     accountTier: "Standard",
+ *     location: azurerm_resource_group_main.location,
+ *     name: "examplestorageaccount",
+ *     resourceGroupName: azurerm_resource_group_main.name,
+ * });
+ * const azurerm_monitor_metric_alert_test = new azure.monitoring.MetricAlert("test", {
+ *     actions: [{
+ *         actionGroupId: azurerm_monitor_action_group_main.id,
+ *     }],
+ *     criterias: [{
+ *         aggregation: "Total",
+ *         dimensions: [{
+ *             name: "ApiName",
+ *             operator: "Include",
+ *             values: ["*"],
+ *         }],
+ *         metricName: "Transactions",
+ *         metricNamespace: "Microsoft.Storage/storageAccounts",
+ *         operator: "GreaterThan",
+ *         threshold: 50,
+ *     }],
+ *     description: "Action will be triggered when Transactions count is greater than 50.",
+ *     name: "example-metricalert",
+ *     resourceGroupName: azurerm_resource_group_main.name,
+ *     scopes: azurerm_storage_account_to_monitor.id,
+ * });
+ * ```
+ */
 export class MetricAlert extends pulumi.CustomResource {
     /**
      * Get an existing MetricAlert resource's state with the given name, ID, and optional extra

--- a/sdk/nodejs/msi/userAssignedIdentity.ts
+++ b/sdk/nodejs/msi/userAssignedIdentity.ts
@@ -4,6 +4,25 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "eastus",
+ *     name: "acceptanceTestResourceGroup1",
+ * });
+ * const azurerm_user_assigned_identity_testIdentity = new azure.msi.UserAssignedIdentity("testIdentity", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "search-api",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * ```
+ */
 export class UserAssignedIdentity extends pulumi.CustomResource {
     /**
      * Get an existing UserAssignedIdentity resource's state with the given name, ID, and optional extra

--- a/sdk/nodejs/mssql/elasticPool.ts
+++ b/sdk/nodejs/mssql/elasticPool.ts
@@ -6,6 +6,42 @@ import * as utilities from "../utilities";
 
 /**
  * Allows you to manage an Azure SQL Elastic Pool via the `2017-10-01-preview` API which allows for `vCore` and `DTU` based configurations.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "westeurope",
+ *     name: "my-resource-group",
+ * });
+ * const azurerm_sql_server_test = new azure.sql.SqlServer("test", {
+ *     administratorLogin: "4dm1n157r470r",
+ *     administratorLoginPassword: "4-v3ry-53cr37-p455w0rd",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "my-sql-server",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     version: "12.0",
+ * });
+ * const azurerm_mssql_elasticpool_test = new azure.mssql.ElasticPool("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "test-epool",
+ *     perDatabaseSettings: {
+ *         maxCapacity: 4,
+ *         minCapacity: 0.250000,
+ *     },
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     serverName: azurerm_sql_server_test.name,
+ *     sku: {
+ *         capacity: 4,
+ *         family: "Gen5",
+ *         name: "GP_Gen5",
+ *         tier: "GeneralPurpose",
+ *     },
+ * });
+ * ```
  */
 export class ElasticPool extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/mysql/configuration.ts
+++ b/sdk/nodejs/mysql/configuration.ts
@@ -6,6 +6,44 @@ import * as utilities from "../utilities";
 
 /**
  * Sets a MySQL Configuration value on a MySQL Server.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "api-rg-pro",
+ * });
+ * const azurerm_mysql_server_test = new azure.mysql.Server("test", {
+ *     administratorLogin: "psqladminun",
+ *     administratorLoginPassword: "H@Sh1CoR3!",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "mysql-server-1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         capacity: 2,
+ *         family: "Gen4",
+ *         name: "B_Gen4_2",
+ *         tier: "Basic",
+ *     },
+ *     sslEnforcement: "Enabled",
+ *     storageProfile: {
+ *         backupRetentionDays: 7,
+ *         geoRedundantBackup: "Disabled",
+ *         storageMb: 5120,
+ *     },
+ *     version: "5.7",
+ * });
+ * const azurerm_mysql_configuration_test = new azure.mysql.Configuration("test", {
+ *     name: "interactive_timeout",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     serverName: azurerm_mysql_server_test.name,
+ *     value: "600",
+ * });
+ * ```
  */
 export class Configuration extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/mysql/database.ts
+++ b/sdk/nodejs/mysql/database.ts
@@ -6,6 +6,45 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a MySQL Database within a MySQL Server
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "api-rg-pro",
+ * });
+ * const azurerm_mysql_server_test = new azure.mysql.Server("test", {
+ *     administratorLogin: "mysqladminun",
+ *     administratorLoginPassword: "H@Sh1CoR3!",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "mysql-server-1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         capacity: 2,
+ *         family: "Gen4",
+ *         name: "B_Gen4_2",
+ *         tier: "Basic",
+ *     },
+ *     sslEnforcement: "Enabled",
+ *     storageProfile: {
+ *         backupRetentionDays: 7,
+ *         geoRedundantBackup: "Disabled",
+ *         storageMb: 5120,
+ *     },
+ *     version: "5.7",
+ * });
+ * const azurerm_mysql_database_test = new azure.mysql.Database("test", {
+ *     charset: "utf8",
+ *     collation: "utf8_unicode_ci",
+ *     name: "exampledb",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     serverName: azurerm_mysql_server_test.name,
+ * });
+ * ```
  */
 export class Database extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/mysql/firewallRule.ts
+++ b/sdk/nodejs/mysql/firewallRule.ts
@@ -6,6 +6,46 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Firewall Rule for a MySQL Server
+ * 
+ * ## Example Usage (Single IP Address)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_mysql_server_test = new azure.mysql.Server("test", {});
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "api-rg-pro",
+ * });
+ * const azurerm_mysql_firewall_rule_test = new azure.mysql.FirewallRule("test", {
+ *     endIpAddress: "40.112.8.12",
+ *     name: "office",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     serverName: azurerm_mysql_server_test.name,
+ *     startIpAddress: "40.112.8.12",
+ * });
+ * ```
+ * 
+ * ## Example Usage (IP Range)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_mysql_server_test = new azure.mysql.Server("test", {});
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "api-rg-pro",
+ * });
+ * const azurerm_mysql_firewall_rule_test = new azure.mysql.FirewallRule("test", {
+ *     endIpAddress: "40.112.255.255",
+ *     name: "office",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     serverName: azurerm_mysql_server_test.name,
+ *     startIpAddress: "40.112.0.0",
+ * });
+ * ```
  */
 export class FirewallRule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/mysql/server.ts
+++ b/sdk/nodejs/mysql/server.ts
@@ -6,6 +6,38 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a MySQL Server.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "api-rg-pro",
+ * });
+ * const azurerm_mysql_server_test = new azure.mysql.Server("test", {
+ *     administratorLogin: "mysqladminun",
+ *     administratorLoginPassword: "H@Sh1CoR3!",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "mysql-server-1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         capacity: 2,
+ *         family: "Gen4",
+ *         name: "B_Gen4_2",
+ *         tier: "Basic",
+ *     },
+ *     sslEnforcement: "Enabled",
+ *     storageProfile: {
+ *         backupRetentionDays: 7,
+ *         geoRedundantBackup: "Disabled",
+ *         storageMb: 5120,
+ *     },
+ *     version: "5.7",
+ * });
+ * ```
  */
 export class Server extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/mysql/virtualNetworkRule.ts
+++ b/sdk/nodejs/mysql/virtualNetworkRule.ts
@@ -8,6 +8,57 @@ import * as utilities from "../utilities";
  * Manages a MySQL Virtual Network Rule.
  * 
  * -> **NOTE:** MySQL Virtual Network Rules [can only be used with SKU Tiers of `GeneralPurpose` or `MemoryOptimized`](https://docs.microsoft.com/en-us/azure/mysql/concepts-data-access-and-security-vnet)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "example-resources",
+ * });
+ * const azurerm_mysql_server_test = new azure.mysql.Server("test", {
+ *     administratorLogin: "mysqladminun",
+ *     administratorLoginPassword: "H@Sh1CoR3!",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "mysql-server-1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         capacity: 2,
+ *         family: "Gen5",
+ *         name: "GP_Gen5_2",
+ *         tier: "GeneralPurpose",
+ *     },
+ *     sslEnforcement: "Enabled",
+ *     storageProfile: {
+ *         backupRetentionDays: 7,
+ *         geoRedundantBackup: "Disabled",
+ *         storageMb: 5120,
+ *     },
+ *     version: "5.7",
+ * });
+ * const azurerm_virtual_network_test = new azure.network.VirtualNetwork("test", {
+ *     addressSpaces: ["10.7.29.0/29"],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-vnet",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_subnet_internal = new azure.network.Subnet("internal", {
+ *     addressPrefix: "10.7.29.0/29",
+ *     name: "internal",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     serviceEndpoints: ["Microsoft.Sql"],
+ *     virtualNetworkName: azurerm_virtual_network_test.name,
+ * });
+ * const azurerm_mysql_virtual_network_rule_test = new azure.mysql.VirtualNetworkRule("test", {
+ *     name: "mysql-vnet-rule",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     serverName: azurerm_mysql_server_test.name,
+ *     subnetId: azurerm_subnet_internal.id,
+ * });
+ * ```
  */
 export class VirtualNetworkRule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/network/applicationGateway.ts
+++ b/sdk/nodejs/network/applicationGateway.ts
@@ -4,6 +4,95 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "example-resources",
+ * });
+ * const azurerm_virtual_network_test = new azure.network.VirtualNetwork("test", {
+ *     addressSpaces: ["10.254.0.0/16"],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-network",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const local_backend_address_pool_name = azurerm_virtual_network_test.name.apply(__arg0 => `${__arg0}-beap`);
+ * const local_frontend_ip_configuration_name = azurerm_virtual_network_test.name.apply(__arg0 => `${__arg0}-feip`);
+ * const local_frontend_port_name = azurerm_virtual_network_test.name.apply(__arg0 => `${__arg0}-feport`);
+ * const local_http_setting_name = azurerm_virtual_network_test.name.apply(__arg0 => `${__arg0}-be-htst`);
+ * const local_listener_name = azurerm_virtual_network_test.name.apply(__arg0 => `${__arg0}-httplstn`);
+ * const local_request_routing_rule_name = azurerm_virtual_network_test.name.apply(__arg0 => `${__arg0}-rqrt`);
+ * const azurerm_public_ip_test = new azure.network.PublicIp("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-pip",
+ *     publicIpAddressAllocation: "dynamic",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_subnet_frontend = new azure.network.Subnet("frontend", {
+ *     addressPrefix: "10.254.0.0/24",
+ *     name: "frontend",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     virtualNetworkName: azurerm_virtual_network_test.name,
+ * });
+ * const azurerm_application_gateway_network = new azure.network.ApplicationGateway("network", {
+ *     backendAddressPools: [{
+ *         name: local_backend_address_pool_name,
+ *     }],
+ *     backendHttpSettings: [{
+ *         cookieBasedAffinity: "Disabled",
+ *         name: local_http_setting_name,
+ *         port: 80,
+ *         protocol: "Http",
+ *         requestTimeout: 1,
+ *     }],
+ *     frontendIpConfigurations: [{
+ *         name: local_frontend_ip_configuration_name,
+ *         publicIpAddressId: azurerm_public_ip_test.id,
+ *     }],
+ *     frontendPorts: [{
+ *         name: local_frontend_port_name,
+ *         port: 80,
+ *     }],
+ *     gatewayIpConfigurations: [{
+ *         name: "my-gateway-ip-configuration",
+ *         subnetId: azurerm_subnet_frontend.id,
+ *     }],
+ *     httpListeners: [{
+ *         frontendIpConfigurationName: local_frontend_ip_configuration_name,
+ *         frontendPortName: local_frontend_port_name,
+ *         name: local_listener_name,
+ *         protocol: "Http",
+ *     }],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-appgateway",
+ *     requestRoutingRules: [{
+ *         backendAddressPoolName: local_backend_address_pool_name,
+ *         backendHttpSettingsName: local_http_setting_name,
+ *         httpListenerName: local_listener_name,
+ *         name: local_request_routing_rule_name,
+ *         ruleType: "Basic",
+ *     }],
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         capacity: 2,
+ *         name: "Standard_Small",
+ *         tier: "Standard",
+ *     },
+ * });
+ * const azurerm_subnet_backend = new azure.network.Subnet("backend", {
+ *     addressPrefix: "10.254.2.0/24",
+ *     name: "backend",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     virtualNetworkName: azurerm_virtual_network_test.name,
+ * });
+ * ```
+ */
 export class ApplicationGateway extends pulumi.CustomResource {
     /**
      * Get an existing ApplicationGateway resource's state with the given name, ID, and optional extra

--- a/sdk/nodejs/network/applicationSecurityGroup.ts
+++ b/sdk/nodejs/network/applicationSecurityGroup.ts
@@ -6,6 +6,26 @@ import * as utilities from "../utilities";
 
 /**
  * Manage an Application Security Group.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "tf-test",
+ * });
+ * const azurerm_application_security_group_test = new azure.network.ApplicationSecurityGroup("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "tf-appsecuritygroup",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         Hello: "World",
+ *     },
+ * });
+ * ```
  */
 export class ApplicationSecurityGroup extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/network/expressRouteCircuit.ts
+++ b/sdk/nodejs/network/expressRouteCircuit.ts
@@ -6,6 +6,33 @@ import * as utilities from "../utilities";
 
 /**
  * Manages an ExpressRoute circuit.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "exprtTest",
+ * });
+ * const azurerm_express_route_circuit_test = new azure.network.ExpressRouteCircuit("test", {
+ *     bandwidthInMbps: 50,
+ *     location: azurerm_resource_group_test.location,
+ *     name: "expressRoute1",
+ *     peeringLocation: "Silicon Valley",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     serviceProviderName: "Equinix",
+ *     sku: {
+ *         family: "MeteredData",
+ *         tier: "Standard",
+ *     },
+ *     tags: {
+ *         environment: "Production",
+ *     },
+ * });
+ * ```
  */
 export class ExpressRouteCircuit extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/network/expressRouteCircuitAuthorization.ts
+++ b/sdk/nodejs/network/expressRouteCircuitAuthorization.ts
@@ -6,6 +6,39 @@ import * as utilities from "../utilities";
 
 /**
  * Manages an ExpressRoute Circuit Authorization.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "exprtTest",
+ * });
+ * const azurerm_express_route_circuit_test = new azure.network.ExpressRouteCircuit("test", {
+ *     allowClassicOperations: false,
+ *     bandwidthInMbps: 50,
+ *     location: azurerm_resource_group_test.location,
+ *     name: "expressRoute1",
+ *     peeringLocation: "Silicon Valley",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     serviceProviderName: "Equinix",
+ *     sku: {
+ *         family: "MeteredData",
+ *         tier: "Standard",
+ *     },
+ *     tags: {
+ *         environment: "Production",
+ *     },
+ * });
+ * const azurerm_express_route_circuit_authorization_test = new azure.network.ExpressRouteCircuitAuthorization("test", {
+ *     expressRouteCircuitName: azurerm_express_route_circuit_test.name,
+ *     name: "exampleERCAuth",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * ```
  */
 export class ExpressRouteCircuitAuthorization extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/network/expressRouteCircuitPeering.ts
+++ b/sdk/nodejs/network/expressRouteCircuitPeering.ts
@@ -6,6 +6,46 @@ import * as utilities from "../utilities";
 
 /**
  * Manages an ExpressRoute Circuit Peering.
+ * 
+ * ## Example Usage (Creating a Microsoft Peering)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "exprtTest",
+ * });
+ * const azurerm_express_route_circuit_test = new azure.network.ExpressRouteCircuit("test", {
+ *     allowClassicOperations: false,
+ *     bandwidthInMbps: 50,
+ *     location: azurerm_resource_group_test.location,
+ *     name: "expressRoute1",
+ *     peeringLocation: "Silicon Valley",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     serviceProviderName: "Equinix",
+ *     sku: {
+ *         family: "MeteredData",
+ *         tier: "Standard",
+ *     },
+ *     tags: {
+ *         environment: "Production",
+ *     },
+ * });
+ * const azurerm_express_route_circuit_peering_test = new azure.network.ExpressRouteCircuitPeering("test", {
+ *     expressRouteCircuitName: azurerm_express_route_circuit_test.name,
+ *     microsoftPeeringConfig: {
+ *         advertisedPublicPrefixes: ["123.1.0.0/24"],
+ *     },
+ *     peerAsn: 100,
+ *     peeringType: "MicrosoftPeering",
+ *     primaryPeerAddressPrefix: "123.0.0.0/30",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     secondaryPeerAddressPrefix: "123.0.0.4/30",
+ *     vlanId: 300,
+ * });
+ * ```
  */
 export class ExpressRouteCircuitPeering extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/network/firewall.ts
+++ b/sdk/nodejs/network/firewall.ts
@@ -8,6 +8,47 @@ import * as utilities from "../utilities";
  * Manages an Azure Firewall.
  * 
  * -> **NOTE** Azure Firewall is currently in Public Preview.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "North Europe",
+ *     name: "example-resources",
+ * });
+ * const azurerm_public_ip_test = new azure.network.PublicIp("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "testpip",
+ *     publicIpAddressAllocation: "Static",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: "Standard",
+ * });
+ * const azurerm_virtual_network_test = new azure.network.VirtualNetwork("test", {
+ *     addressSpaces: ["10.0.0.0/16"],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "testvnet",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_subnet_test = new azure.network.Subnet("test", {
+ *     addressPrefix: "10.0.1.0/24",
+ *     name: "AzureFirewallSubnet",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     virtualNetworkName: azurerm_virtual_network_test.name,
+ * });
+ * const azurerm_firewall_test = new azure.network.Firewall("test", {
+ *     ipConfiguration: {
+ *         internalPublicIpAddressId: azurerm_public_ip_test.id,
+ *         name: "configuration",
+ *         subnetId: azurerm_subnet_test.id,
+ *     },
+ *     location: azurerm_resource_group_test.location,
+ *     name: "testfirewall",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * ```
  */
 export class Firewall extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/network/firewallNetworkRuleCollection.ts
+++ b/sdk/nodejs/network/firewallNetworkRuleCollection.ts
@@ -8,6 +8,67 @@ import * as utilities from "../utilities";
  * Manages a Network Rule Collection within an Azure Firewall.
  * 
  * -> **NOTE** Azure Firewall is currently in Public Preview.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "North Europe",
+ *     name: "example-resources",
+ * });
+ * const azurerm_public_ip_test = new azure.network.PublicIp("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "testpip",
+ *     publicIpAddressAllocation: "Static",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: "Standard",
+ * });
+ * const azurerm_virtual_network_test = new azure.network.VirtualNetwork("test", {
+ *     addressSpaces: ["10.0.0.0/16"],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "testvnet",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_subnet_test = new azure.network.Subnet("test", {
+ *     addressPrefix: "10.0.1.0/24",
+ *     name: "AzureFirewallSubnet",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     virtualNetworkName: azurerm_virtual_network_test.name,
+ * });
+ * const azurerm_firewall_test = new azure.network.Firewall("test", {
+ *     ipConfiguration: {
+ *         internalPublicIpAddressId: azurerm_public_ip_test.id,
+ *         name: "configuration",
+ *         subnetId: azurerm_subnet_test.id,
+ *     },
+ *     location: azurerm_resource_group_test.location,
+ *     name: "testfirewall",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_firewall_network_rule_collection_test = new azure.network.FirewallNetworkRuleCollection("test", {
+ *     action: "Allow",
+ *     azureFirewallName: azurerm_firewall_test.name,
+ *     name: "testcollection",
+ *     priority: 100,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     rules: [{
+ *         destinationAddresses: [
+ *             "8.8.8.8",
+ *             "8.8.4.4",
+ *         ],
+ *         destinationPorts: ["53"],
+ *         name: "testrule",
+ *         protocols: [
+ *             "TCP",
+ *             "UDP",
+ *         ],
+ *         sourceAddresses: ["10.0.0.0/16"],
+ *     }],
+ * });
+ * ```
  */
 export class FirewallNetworkRuleCollection extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/network/getApplicationSecurityGroup.ts
+++ b/sdk/nodejs/network/getApplicationSecurityGroup.ts
@@ -6,6 +6,20 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing Application Security Group.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_application_security_group_test = pulumi.output(azure.network.getApplicationSecurityGroup({
+ *     name: "tf-appsecuritygroup",
+ *     resourceGroupName: "my-resource-group",
+ * }));
+ * 
+ * export const applicationSecurityGroupId = azurerm_application_security_group_test.apply(__arg0 => __arg0.id);
+ * ```
  */
 export function getApplicationSecurityGroup(args: GetApplicationSecurityGroupArgs, opts?: pulumi.InvokeOptions): Promise<GetApplicationSecurityGroupResult> {
     return pulumi.runtime.invoke("azure:network/getApplicationSecurityGroup:getApplicationSecurityGroup", {

--- a/sdk/nodejs/network/getNetworkInterface.ts
+++ b/sdk/nodejs/network/getNetworkInterface.ts
@@ -6,6 +6,20 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing Network Interface.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_network_interface_test = pulumi.output(azure.network.getNetworkInterface({
+ *     name: "acctest-nic",
+ *     resourceGroupName: "networking",
+ * }));
+ * 
+ * export const networkInterfaceId = azurerm_network_interface_test.apply(__arg0 => __arg0.id);
+ * ```
  */
 export function getNetworkInterface(args: GetNetworkInterfaceArgs, opts?: pulumi.InvokeOptions): Promise<GetNetworkInterfaceResult> {
     return pulumi.runtime.invoke("azure:network/getNetworkInterface:getNetworkInterface", {

--- a/sdk/nodejs/network/getPublicIP.ts
+++ b/sdk/nodejs/network/getPublicIP.ts
@@ -6,6 +6,79 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing Public IP Address.
+ * 
+ * ## Example Usage (reference an existing)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_public_ip_test = pulumi.output(azure.network.getPublicIP({
+ *     name: "name_of_public_ip",
+ *     resourceGroupName: "name_of_resource_group",
+ * }));
+ * 
+ * export const domainNameLabel = azurerm_public_ip_test.apply(__arg0 => __arg0.domainNameLabel);
+ * export const publicIpAddress = azurerm_public_ip_test.apply(__arg0 => __arg0.ipAddress);
+ * ```
+ * 
+ * ## Example Usage (Retrieve the Dynamic Public IP of a new VM)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US 2",
+ *     name: "test-resources",
+ * });
+ * const azurerm_public_ip_test = new azure.network.PublicIp("test", {
+ *     idleTimeoutInMinutes: 30,
+ *     location: azurerm_resource_group_test.location,
+ *     name: "test-pip",
+ *     publicIpAddressAllocation: "Dynamic",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         environment: "test",
+ *     },
+ * });
+ * const azurerm_virtual_network_test = new azure.network.VirtualNetwork("test", {
+ *     addressSpaces: ["10.0.0.0/16"],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "test-network",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_subnet_test = new azure.network.Subnet("test", {
+ *     addressPrefix: "10.0.2.0/24",
+ *     name: "acctsub",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     virtualNetworkName: azurerm_virtual_network_test.name,
+ * });
+ * const azurerm_network_interface_test = new azure.network.NetworkInterface("test", {
+ *     ipConfigurations: [{
+ *         name: "testconfiguration1",
+ *         privateIpAddress: "10.0.2.5",
+ *         privateIpAddressAllocation: "static",
+ *         publicIpAddressId: azurerm_public_ip_test.id,
+ *         subnetId: azurerm_subnet_test.id,
+ *     }],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "test-nic",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_virtual_machine_test = new azure.compute.VirtualMachine("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "test-vm",
+ *     networkInterfaceIds: [azurerm_network_interface_test.id],
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_public_ip_test = pulumi.output(azure.network.getPublicIP({
+ *     name: azurerm_public_ip_test.name,
+ *     resourceGroupName: azurerm_virtual_machine_test.resourceGroupName,
+ * }));
+ * 
+ * export const publicIpAddress = azurerm_public_ip_test.apply(__arg0 => __arg0.ipAddress);
+ * ```
  */
 export function getPublicIP(args: GetPublicIPArgs, opts?: pulumi.InvokeOptions): Promise<GetPublicIPResult> {
     return pulumi.runtime.invoke("azure:network/getPublicIP:getPublicIP", {

--- a/sdk/nodejs/network/getPublicIPs.ts
+++ b/sdk/nodejs/network/getPublicIPs.ts
@@ -6,6 +6,18 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about a set of existing Public IP Addresses.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_public_ips_test = pulumi.output(azure.network.getPublicIPs({
+ *     attached: false,
+ *     resourceGroupName: "pip-test",
+ * }));
+ * ```
  */
 export function getPublicIPs(args: GetPublicIPsArgs, opts?: pulumi.InvokeOptions): Promise<GetPublicIPsResult> {
     return pulumi.runtime.invoke("azure:network/getPublicIPs:getPublicIPs", {

--- a/sdk/nodejs/network/getRouteTable.ts
+++ b/sdk/nodejs/network/getRouteTable.ts
@@ -6,6 +6,18 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing Route Table.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_route_table_test = pulumi.output(azure.network.getRouteTable({
+ *     name: "myroutetable",
+ *     resourceGroupName: "some-resource-group",
+ * }));
+ * ```
  */
 export function getRouteTable(args: GetRouteTableArgs, opts?: pulumi.InvokeOptions): Promise<GetRouteTableResult> {
     return pulumi.runtime.invoke("azure:network/getRouteTable:getRouteTable", {

--- a/sdk/nodejs/network/getSubnet.ts
+++ b/sdk/nodejs/network/getSubnet.ts
@@ -6,6 +6,21 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing Subnet within a Virtual Network.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_subnet_test = pulumi.output(azure.network.getSubnet({
+ *     name: "backend",
+ *     resourceGroupName: "networking",
+ *     virtualNetworkName: "production",
+ * }));
+ * 
+ * export const subnetId = azurerm_subnet_test.apply(__arg0 => __arg0.id);
+ * ```
  */
 export function getSubnet(args: GetSubnetArgs, opts?: pulumi.InvokeOptions): Promise<GetSubnetResult> {
     return pulumi.runtime.invoke("azure:network/getSubnet:getSubnet", {

--- a/sdk/nodejs/network/getVirtualNetwork.ts
+++ b/sdk/nodejs/network/getVirtualNetwork.ts
@@ -6,6 +6,20 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing Virtual Network.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_virtual_network_test = pulumi.output(azure.network.getVirtualNetwork({
+ *     name: "production",
+ *     resourceGroupName: "networking",
+ * }));
+ * 
+ * export const virtualNetworkId = azurerm_virtual_network_test.apply(__arg0 => __arg0.id);
+ * ```
  */
 export function getVirtualNetwork(args: GetVirtualNetworkArgs, opts?: pulumi.InvokeOptions): Promise<GetVirtualNetworkResult> {
     return pulumi.runtime.invoke("azure:network/getVirtualNetwork:getVirtualNetwork", {

--- a/sdk/nodejs/network/getVirtualNetworkGateway.ts
+++ b/sdk/nodejs/network/getVirtualNetworkGateway.ts
@@ -6,6 +6,20 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing Virtual Network Gateway.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_virtual_network_gateway_test = pulumi.output(azure.network.getVirtualNetworkGateway({
+ *     name: "production",
+ *     resourceGroupName: "networking",
+ * }));
+ * 
+ * export const virtualNetworkGatewayId = azurerm_virtual_network_gateway_test.apply(__arg0 => __arg0.id);
+ * ```
  */
 export function getVirtualNetworkGateway(args: GetVirtualNetworkGatewayArgs, opts?: pulumi.InvokeOptions): Promise<GetVirtualNetworkGatewayResult> {
     return pulumi.runtime.invoke("azure:network/getVirtualNetworkGateway:getVirtualNetworkGateway", {

--- a/sdk/nodejs/network/localNetworkGateway.ts
+++ b/sdk/nodejs/network/localNetworkGateway.ts
@@ -6,6 +6,25 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a local network gateway connection over which specific connections can be configured.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "localNetworkGWTest",
+ * });
+ * const azurerm_local_network_gateway_home = new azure.network.LocalNetworkGateway("home", {
+ *     addressSpaces: ["10.0.0.0/16"],
+ *     gatewayAddress: "12.13.14.15",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "backHome",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * ```
  */
 export class LocalNetworkGateway extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/network/networkInterface.ts
+++ b/sdk/nodejs/network/networkInterface.ts
@@ -6,6 +6,43 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Network Interface located in a Virtual Network, usually attached to a Virtual Machine.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acceptanceTestResourceGroup1",
+ * });
+ * const azurerm_virtual_network_test = new azure.network.VirtualNetwork("test", {
+ *     addressSpaces: ["10.0.0.0/16"],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "acceptanceTestVirtualNetwork1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_subnet_test = new azure.network.Subnet("test", {
+ *     addressPrefix: "10.0.2.0/24",
+ *     name: "testsubnet",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     virtualNetworkName: azurerm_virtual_network_test.name,
+ * });
+ * const azurerm_network_interface_test = new azure.network.NetworkInterface("test", {
+ *     ipConfigurations: [{
+ *         name: "testconfiguration1",
+ *         privateIpAddressAllocation: "dynamic",
+ *         subnetId: azurerm_subnet_test.id,
+ *     }],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "acceptanceTestNetworkInterface1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         environment: "staging",
+ *     },
+ * });
+ * ```
  */
 export class NetworkInterface extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/network/networkInterfaceBackendAddressPoolAssociation.ts
+++ b/sdk/nodejs/network/networkInterfaceBackendAddressPoolAssociation.ts
@@ -6,6 +6,65 @@ import * as utilities from "../utilities";
 
 /**
  * Manages the association between a Network Interface and a Load Balancer's Backend Address Pool.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "example-resources",
+ * });
+ * const azurerm_public_ip_test = new azure.network.PublicIp("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-pip",
+ *     publicIpAddressAllocation: "static",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_lb_test = new azure.lb.LoadBalancer("test", {
+ *     frontendIpConfigurations: [{
+ *         name: "primary",
+ *         publicIpAddressId: azurerm_public_ip_test.id,
+ *     }],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-lb",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_lb_backend_address_pool_test = new azure.lb.BackendAddressPool("test", {
+ *     loadbalancerId: azurerm_lb_test.id,
+ *     name: "acctestpool",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_virtual_network_test = new azure.network.VirtualNetwork("test", {
+ *     addressSpaces: ["10.0.0.0/16"],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-network",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_subnet_test = new azure.network.Subnet("test", {
+ *     addressPrefix: "10.0.2.0/24",
+ *     name: "internal",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     virtualNetworkName: azurerm_virtual_network_test.name,
+ * });
+ * const azurerm_network_interface_test = new azure.network.NetworkInterface("test", {
+ *     ipConfigurations: [{
+ *         name: "testconfiguration1",
+ *         privateIpAddressAllocation: "dynamic",
+ *         subnetId: azurerm_subnet_test.id,
+ *     }],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-nic",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_network_interface_backend_address_pool_association_test = new azure.network.NetworkInterfaceBackendAddressPoolAssociation("test", {
+ *     backendAddressPoolId: azurerm_lb_backend_address_pool_test.id,
+ *     ipConfigurationName: "testconfiguration1",
+ *     networkInterfaceId: azurerm_network_interface_test.id,
+ * });
+ * ```
  */
 export class NetworkInterfaceBackendAddressPoolAssociation extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/network/networkInterfaceNatRuleAssociation.ts
+++ b/sdk/nodejs/network/networkInterfaceNatRuleAssociation.ts
@@ -6,6 +6,69 @@ import * as utilities from "../utilities";
 
 /**
  * Manages the association between a Network Interface and a Load Balancer's NAT Rule.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "example-resources",
+ * });
+ * const azurerm_public_ip_test = new azure.network.PublicIp("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-pip",
+ *     publicIpAddressAllocation: "static",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_lb_test = new azure.lb.LoadBalancer("test", {
+ *     frontendIpConfigurations: [{
+ *         name: "primary",
+ *         publicIpAddressId: azurerm_public_ip_test.id,
+ *     }],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-lb",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_lb_nat_rule_test = new azure.lb.NatRule("test", {
+ *     backendPort: 3389,
+ *     frontendIpConfigurationName: "primary",
+ *     frontendPort: 3389,
+ *     loadbalancerId: azurerm_lb_test.id,
+ *     name: "RDPAccess",
+ *     protocol: "Tcp",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_virtual_network_test = new azure.network.VirtualNetwork("test", {
+ *     addressSpaces: ["10.0.0.0/16"],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-network",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_subnet_test = new azure.network.Subnet("test", {
+ *     addressPrefix: "10.0.2.0/24",
+ *     name: "internal",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     virtualNetworkName: azurerm_virtual_network_test.name,
+ * });
+ * const azurerm_network_interface_test = new azure.network.NetworkInterface("test", {
+ *     ipConfigurations: [{
+ *         name: "testconfiguration1",
+ *         privateIpAddressAllocation: "dynamic",
+ *         subnetId: azurerm_subnet_test.id,
+ *     }],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-nic",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_network_interface_nat_rule_association_test = new azure.network.NetworkInterfaceNatRuleAssociation("test", {
+ *     ipConfigurationName: "testconfiguration1",
+ *     natRuleId: azurerm_lb_nat_rule_test.id,
+ *     networkInterfaceId: azurerm_network_interface_test.id,
+ * });
+ * ```
  */
 export class NetworkInterfaceNatRuleAssociation extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/network/networkSecurityGroup.ts
+++ b/sdk/nodejs/network/networkSecurityGroup.ts
@@ -7,9 +7,40 @@ import * as utilities from "../utilities";
 /**
  * Manages a network security group that contains a list of network security rules.  Network security groups enable inbound or outbound traffic to be enabled or denied.
  * 
- * ~> **NOTE on Network Security Groups and Network Security Rules:** Terraform currently
+ * > **NOTE on Network Security Groups and Network Security Rules:** Terraform currently
  * provides both a standalone Network Security Rule resource, and allows for Network Security Rules to be defined in-line within the Network Security Group resource.
  * At this time you cannot use a Network Security Group with in-line Network Security Rules in conjunction with any Network Security Rule resources. Doing so will cause a conflict of rule settings and will overwrite rules.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acceptanceTestResourceGroup1",
+ * });
+ * const azurerm_network_security_group_test = new azure.network.NetworkSecurityGroup("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "acceptanceTestSecurityGroup1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     securityRules: [{
+ *         access: "Allow",
+ *         destinationAddressPrefix: "*",
+ *         destinationPortRange: "*",
+ *         direction: "Inbound",
+ *         name: "test123",
+ *         priority: 100,
+ *         protocol: "Tcp",
+ *         sourceAddressPrefix: "*",
+ *         sourcePortRange: "*",
+ *     }],
+ *     tags: {
+ *         environment: "Production",
+ *     },
+ * });
+ * ```
  */
 export class NetworkSecurityGroup extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/network/networkSecurityRule.ts
+++ b/sdk/nodejs/network/networkSecurityRule.ts
@@ -7,9 +7,39 @@ import * as utilities from "../utilities";
 /**
  * Manages a Network Security Rule.
  * 
- * ~> **NOTE on Network Security Groups and Network Security Rules:** Terraform currently
+ * > **NOTE on Network Security Groups and Network Security Rules:** Terraform currently
  * provides both a standalone Network Security Rule resource, and allows for Network Security Rules to be defined in-line within the Network Security Group resource.
  * At this time you cannot use a Network Security Group with in-line Network Security Rules in conjunction with any Network Security Rule resources. Doing so will cause a conflict of rule settings and will overwrite rules.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acceptanceTestResourceGroup1",
+ * });
+ * const azurerm_network_security_group_test = new azure.network.NetworkSecurityGroup("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "acceptanceTestSecurityGroup1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_network_security_rule_test = new azure.network.NetworkSecurityRule("test", {
+ *     access: "Allow",
+ *     destinationAddressPrefix: "*",
+ *     destinationPortRange: "*",
+ *     direction: "Outbound",
+ *     name: "test123",
+ *     networkSecurityGroupName: azurerm_network_security_group_test.name,
+ *     priority: 100,
+ *     protocol: "Tcp",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sourceAddressPrefix: "*",
+ *     sourcePortRange: "*",
+ * });
+ * ```
  */
 export class NetworkSecurityRule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/network/networkWatcher.ts
+++ b/sdk/nodejs/network/networkWatcher.ts
@@ -6,6 +6,23 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Network Watcher.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "production-nwwatcher",
+ * });
+ * const azurerm_network_watcher_test = new azure.network.NetworkWatcher("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "production-nwwatcher",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * ```
  */
 export class NetworkWatcher extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/network/packetCapture.ts
+++ b/sdk/nodejs/network/packetCapture.ts
@@ -6,6 +6,100 @@ import * as utilities from "../utilities";
 
 /**
  * Configures Packet Capturing against a Virtual Machine using a Network Watcher.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "packet-capture-rg",
+ * });
+ * const azurerm_virtual_network_test = new azure.network.VirtualNetwork("test", {
+ *     addressSpaces: ["10.0.0.0/16"],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "production-network",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_subnet_test = new azure.network.Subnet("test", {
+ *     addressPrefix: "10.0.2.0/24",
+ *     name: "internal",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     virtualNetworkName: azurerm_virtual_network_test.name,
+ * });
+ * const azurerm_network_interface_test = new azure.network.NetworkInterface("test", {
+ *     ipConfigurations: [{
+ *         name: "testconfiguration1",
+ *         privateIpAddressAllocation: "dynamic",
+ *         subnetId: azurerm_subnet_test.id,
+ *     }],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "pctest-nic",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_network_watcher_test = new azure.network.NetworkWatcher("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "network-watcher",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_storage_account_test = new azure.storage.Account("test", {
+ *     accountReplicationType: "LRS",
+ *     accountTier: "Standard",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "pctestsa",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_virtual_machine_test = new azure.compute.VirtualMachine("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "pctest-vm",
+ *     networkInterfaceIds: [azurerm_network_interface_test.id],
+ *     osProfile: {
+ *         adminPassword: "Password1234!",
+ *         adminUsername: "testadmin",
+ *         computerName: "pctest-vm",
+ *     },
+ *     osProfileLinuxConfig: {
+ *         disablePasswordAuthentication: false,
+ *     },
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     storageImageReference: {
+ *         offer: "UbuntuServer",
+ *         publisher: "Canonical",
+ *         sku: "16.04-LTS",
+ *         version: "latest",
+ *     },
+ *     storageOsDisk: {
+ *         caching: "ReadWrite",
+ *         createOption: "FromImage",
+ *         managedDiskType: "Standard_LRS",
+ *         name: "osdisk",
+ *     },
+ *     vmSize: "Standard_F2",
+ * });
+ * const azurerm_virtual_machine_extension_test = new azure.compute.Extension("test", {
+ *     autoUpgradeMinorVersion: true,
+ *     location: azurerm_resource_group_test.location,
+ *     name: "network-watcher",
+ *     publisher: "Microsoft.Azure.NetworkWatcher",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     type: "NetworkWatcherAgentLinux",
+ *     typeHandlerVersion: "1.4",
+ *     virtualMachineName: azurerm_virtual_machine_test.name,
+ * });
+ * const azurerm_packet_capture_test = new azure.network.PacketCapture("test", {
+ *     name: "pctestcapture",
+ *     networkWatcherName: azurerm_network_watcher_test.name,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     storageLocation: {
+ *         storageAccountId: azurerm_storage_account_test.id,
+ *     },
+ *     targetResourceId: azurerm_virtual_machine_test.id,
+ * }, {dependsOn: [azurerm_virtual_machine_extension_test]});
+ * ```
+ * > **NOTE:** This Resource requires that [the Network Watcher Virtual Machine Extension](https://docs.microsoft.com/azure/network-watcher/network-watcher-packet-capture-manage-portal#before-you-begin) is installed on the Virtual Machine before capturing can be enabled which can be installed via the `azurerm_virtual_machine_extension` resource.
+ * 
  */
 export class PacketCapture extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/network/publicIp.ts
+++ b/sdk/nodejs/network/publicIp.ts
@@ -6,6 +6,27 @@ import * as utilities from "../utilities";
 
 /**
  * Manage a Public IP Address.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "resourceGroup1",
+ * });
+ * const azurerm_public_ip_test = new azure.network.PublicIp("test", {
+ *     location: "West US",
+ *     name: "acceptanceTestPublicIp1",
+ *     publicIpAddressAllocation: "static",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         environment: "Production",
+ *     },
+ * });
+ * ```
  */
 export class PublicIp extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/network/route.ts
+++ b/sdk/nodejs/network/route.ts
@@ -6,6 +6,30 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Route within a Route Table.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acceptanceTestResourceGroup1",
+ * });
+ * const azurerm_route_table_test = new azure.network.RouteTable("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "acceptanceTestRouteTable1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_route_test = new azure.network.Route("test", {
+ *     addressPrefix: "10.1.0.0/16",
+ *     name: "acceptanceTestRoute1",
+ *     nextHopType: "vnetlocal",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     routeTableName: azurerm_route_table_test.name,
+ * });
+ * ```
  */
 export class Route extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/network/routeTable.ts
+++ b/sdk/nodejs/network/routeTable.ts
@@ -6,6 +6,32 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Route Table
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acceptanceTestResourceGroup1",
+ * });
+ * const azurerm_route_table_test = new azure.network.RouteTable("test", {
+ *     disableBgpRoutePropagation: false,
+ *     location: azurerm_resource_group_test.location,
+ *     name: "acceptanceTestSecurityGroup1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     routes: [{
+ *         addressPrefix: "10.1.0.0/16",
+ *         name: "route1",
+ *         nextHopType: "vnetlocal",
+ *     }],
+ *     tags: {
+ *         environment: "Production",
+ *     },
+ * });
+ * ```
  */
 export class RouteTable extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/network/subnet.ts
+++ b/sdk/nodejs/network/subnet.ts
@@ -7,9 +7,33 @@ import * as utilities from "../utilities";
 /**
  * Manages a subnet. Subnets represent network segments within the IP space defined by the virtual network.
  * 
- * ~> **NOTE on Virtual Networks and Subnet's:** Terraform currently
+ * > **NOTE on Virtual Networks and Subnet's:** Terraform currently
  * provides both a standalone Subnet resource, and allows for Subnets to be defined in-line within the Virtual Network resource.
  * At this time you cannot use a Virtual Network with in-line Subnets in conjunction with any Subnet resources. Doing so will cause a conflict of Subnet configurations and will overwrite Subnet's.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acceptanceTestResourceGroup1",
+ * });
+ * const azurerm_virtual_network_test = new azure.network.VirtualNetwork("test", {
+ *     addressSpaces: ["10.0.0.0/16"],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "acceptanceTestVirtualNetwork1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_subnet_test = new azure.network.Subnet("test", {
+ *     addressPrefix: "10.0.1.0/24",
+ *     name: "testsubnet",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     virtualNetworkName: azurerm_virtual_network_test.name,
+ * });
+ * ```
  */
 export class Subnet extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/network/subnetNetworkSecurityGroupAssociation.ts
+++ b/sdk/nodejs/network/subnetNetworkSecurityGroupAssociation.ts
@@ -8,6 +8,51 @@ import * as utilities from "../utilities";
  * Associates a Network Security Group with a Subnet within a Virtual Network.
  * 
  * -> **NOTE:** Subnet `<->` Network Security Group associations currently need to be configured on both this resource and using the `network_security_group_id` field on the `azurerm_subnet` resource. The next major version of the AzureRM Provider (2.0) will remove the `network_security_group_id` field from the `azurerm_subnet` resource such that this resource is used to link resources in future.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "example-resources",
+ * });
+ * const azurerm_network_security_group_test = new azure.network.NetworkSecurityGroup("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-nsg",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     securityRules: [{
+ *         access: "Allow",
+ *         destinationAddressPrefix: "*",
+ *         destinationPortRange: "*",
+ *         direction: "Inbound",
+ *         name: "test123",
+ *         priority: 100,
+ *         protocol: "Tcp",
+ *         sourceAddressPrefix: "*",
+ *         sourcePortRange: "*",
+ *     }],
+ * });
+ * const azurerm_virtual_network_test = new azure.network.VirtualNetwork("test", {
+ *     addressSpaces: ["10.0.0.0/16"],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-network",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_subnet_test = new azure.network.Subnet("test", {
+ *     addressPrefix: "10.0.2.0/24",
+ *     name: "frontend",
+ *     networkSecurityGroupId: azurerm_network_security_group_test.id,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     virtualNetworkName: azurerm_virtual_network_test.name,
+ * });
+ * const azurerm_subnet_network_security_group_association_test = new azure.network.SubnetNetworkSecurityGroupAssociation("test", {
+ *     networkSecurityGroupId: azurerm_network_security_group_test.id,
+ *     subnetId: azurerm_subnet_test.id,
+ * });
+ * ```
  */
 export class SubnetNetworkSecurityGroupAssociation extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/network/subnetRouteTableAssociation.ts
+++ b/sdk/nodejs/network/subnetRouteTableAssociation.ts
@@ -8,6 +8,46 @@ import * as utilities from "../utilities";
  * Associates a Route Table with a Subnet within a Virtual Network.
  * 
  * -> **NOTE:** Subnet `<->` Route Table associations currently need to be configured on both this resource and using the `route_table_id` field on the `azurerm_subnet` resource. The next major version of the AzureRM Provider (2.0) will remove the `route_table_id` field from the `azurerm_subnet` resource such that this resource is used to link resources in future.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "example-resources",
+ * });
+ * const azurerm_route_table_test = new azure.network.RouteTable("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-routetable",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     routes: [{
+ *         addressPrefix: "10.100.0.0/14",
+ *         name: "example",
+ *         nextHopInIpAddress: "10.10.1.1",
+ *         nextHopType: "VirtualAppliance",
+ *     }],
+ * });
+ * const azurerm_virtual_network_test = new azure.network.VirtualNetwork("test", {
+ *     addressSpaces: ["10.0.0.0/16"],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-network",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_subnet_test = new azure.network.Subnet("test", {
+ *     addressPrefix: "10.0.2.0/24",
+ *     name: "frontend",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     routeTableId: azurerm_route_table_test.id,
+ *     virtualNetworkName: azurerm_virtual_network_test.name,
+ * });
+ * const azurerm_subnet_route_table_association_test = new azure.network.SubnetRouteTableAssociation("test", {
+ *     routeTableId: azurerm_route_table_test.id,
+ *     subnetId: azurerm_subnet_test.id,
+ * });
+ * ```
  */
 export class SubnetRouteTableAssociation extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/network/virtualNetwork.ts
+++ b/sdk/nodejs/network/virtualNetwork.ts
@@ -8,9 +8,54 @@ import * as utilities from "../utilities";
  * Manages a virtual network including any configured subnets. Each subnet can
  * optionally be configured with a security group to be associated with the subnet.
  * 
- * ~> **NOTE on Virtual Networks and Subnet's:** Terraform currently
+ * > **NOTE on Virtual Networks and Subnet's:** Terraform currently
  * provides both a standalone Subnet resource, and allows for Subnets to be defined in-line within the Virtual Network resource.
  * At this time you cannot use a Virtual Network with in-line Subnets in conjunction with any Subnet resources. Doing so will cause a conflict of Subnet configurations and will overwrite Subnet's.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acceptanceTestResourceGroup1",
+ * });
+ * const azurerm_network_security_group_test = new azure.network.NetworkSecurityGroup("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "acceptanceTestSecurityGroup1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_virtual_network_test = new azure.network.VirtualNetwork("test", {
+ *     addressSpaces: ["10.0.0.0/16"],
+ *     dnsServers: [
+ *         "10.0.0.4",
+ *         "10.0.0.5",
+ *     ],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "virtualNetwork1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     subnets: [
+ *         {
+ *             addressPrefix: "10.0.1.0/24",
+ *             name: "subnet1",
+ *         },
+ *         {
+ *             addressPrefix: "10.0.2.0/24",
+ *             name: "subnet2",
+ *         },
+ *         {
+ *             addressPrefix: "10.0.3.0/24",
+ *             name: "subnet3",
+ *             securityGroup: azurerm_network_security_group_test.id,
+ *         },
+ *     ],
+ *     tags: {
+ *         environment: "Production",
+ *     },
+ * });
+ * ```
  */
 export class VirtualNetwork extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/network/virtualNetworkGateway.ts
+++ b/sdk/nodejs/network/virtualNetworkGateway.ts
@@ -8,6 +8,63 @@ import * as utilities from "../utilities";
  * Manages a Virtual Network Gateway to establish secure, cross-premises connectivity.
  * 
  * -> **Note:** Please be aware that provisioning a Virtual Network Gateway takes a long time (between 30 minutes and 1 hour)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "test",
+ * });
+ * const azurerm_public_ip_test = new azure.network.PublicIp("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "test",
+ *     publicIpAddressAllocation: "Dynamic",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_virtual_network_test = new azure.network.VirtualNetwork("test", {
+ *     addressSpaces: ["10.0.0.0/16"],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "test",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_subnet_test = new azure.network.Subnet("test", {
+ *     addressPrefix: "10.0.1.0/24",
+ *     name: "GatewaySubnet",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     virtualNetworkName: azurerm_virtual_network_test.name,
+ * });
+ * const azurerm_virtual_network_gateway_test = new azure.network.VirtualNetworkGateway("test", {
+ *     activeActive: false,
+ *     enableBgp: false,
+ *     ipConfigurations: [{
+ *         name: "vnetGatewayConfig",
+ *         privateIpAddressAllocation: "Dynamic",
+ *         publicIpAddressId: azurerm_public_ip_test.id,
+ *         subnetId: azurerm_subnet_test.id,
+ *     }],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "test",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: "Basic",
+ *     type: "Vpn",
+ *     vpnClientConfiguration: {
+ *         addressSpaces: ["10.2.0.0/24"],
+ *         revokedCertificates: [{
+ *             name: "Verizon-Global-Root-CA",
+ *             thumbprint: "912198EEF23DCAC40939312FEE97DD560BAE49B1",
+ *         }],
+ *         rootCertificates: [{
+ *             name: "DigiCert-Federated-ID-Root-CA",
+ *             publicCertData: "MIIDuzCCAqOgAwIBAgIQCHTZWCM+IlfFIRXIvyKSrjANBgkqhkiG9w0BAQsFADBn\nMQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3\nd3cuZGlnaWNlcnQuY29tMSYwJAYDVQQDEx1EaWdpQ2VydCBGZWRlcmF0ZWQgSUQg\nUm9vdCBDQTAeFw0xMzAxMTUxMjAwMDBaFw0zMzAxMTUxMjAwMDBaMGcxCzAJBgNV\nBAYTAlVTMRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdp\nY2VydC5jb20xJjAkBgNVBAMTHURpZ2lDZXJ0IEZlZGVyYXRlZCBJRCBSb290IENB\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvAEB4pcCqnNNOWE6Ur5j\nQPUH+1y1F9KdHTRSza6k5iDlXq1kGS1qAkuKtw9JsiNRrjltmFnzMZRBbX8Tlfl8\nzAhBmb6dDduDGED01kBsTkgywYPxXVTKec0WxYEEF0oMn4wSYNl0lt2eJAKHXjNf\nGTwiibdP8CUR2ghSM2sUTI8Nt1Omfc4SMHhGhYD64uJMbX98THQ/4LMGuYegou+d\nGTiahfHtjn7AboSEknwAMJHCh5RlYZZ6B1O4QbKJ+34Q0eKgnI3X6Vc9u0zf6DH8\nDk+4zQDYRRTqTnVO3VT8jzqDlCRuNtq6YvryOWN74/dq8LQhUnXHvFyrsdMaE1X2\nDwIDAQABo2MwYTAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjAdBgNV\nHQ4EFgQUGRdkFnbGt1EWjKwbUne+5OaZvRYwHwYDVR0jBBgwFoAUGRdkFnbGt1EW\njKwbUne+5OaZvRYwDQYJKoZIhvcNAQELBQADggEBAHcqsHkrjpESqfuVTRiptJfP\n9JbdtWqRTmOf6uJi2c8YVqI6XlKXsD8C1dUUaaHKLUJzvKiazibVuBwMIT84AyqR\nQELn3e0BtgEymEygMU569b01ZPxoFSnNXc7qDZBDef8WfqAV/sxkTi8L9BkmFYfL\nuGLOhRJOFprPdoDIUBB+tmCl3oDcBy3vnUeOEioz8zAkprcb3GHwHAK+vHmmfgcn\nWsfMLH4JCLa/tRYL+Rw/N3ybCkDp00s0WUZ+AoDywSl0Q/ZEnNY0MsFiw6LyIdbq\nM/s/1JRtO3bDSzD9TazRVzn2oBqzSa8VgIo5C1nOnoAKJTlsClJKvIhnRlaLQqk=\n",
+ *         }],
+ *     },
+ *     vpnType: "RouteBased",
+ * });
+ * ```
  */
 export class VirtualNetworkGateway extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/network/virtualNetworkGatewayConnection.ts
+++ b/sdk/nodejs/network/virtualNetworkGatewayConnection.ts
@@ -6,6 +6,170 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a connection in an existing Virtual Network Gateway.
+ * 
+ * ## Example Usage
+ * 
+ * ### Site-to-Site connection
+ * 
+ * The following example shows a connection between an Azure virtual network
+ * and an on-premises VPN device and network.
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "test",
+ * });
+ * const azurerm_local_network_gateway_onpremise = new azure.network.LocalNetworkGateway("onpremise", {
+ *     addressSpaces: ["10.1.1.0/24"],
+ *     gatewayAddress: "168.62.225.23",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "onpremise",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_public_ip_test = new azure.network.PublicIp("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "test",
+ *     publicIpAddressAllocation: "Dynamic",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_virtual_network_test = new azure.network.VirtualNetwork("test", {
+ *     addressSpaces: ["10.0.0.0/16"],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "test",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_subnet_test = new azure.network.Subnet("test", {
+ *     addressPrefix: "10.0.1.0/24",
+ *     name: "GatewaySubnet",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     virtualNetworkName: azurerm_virtual_network_test.name,
+ * });
+ * const azurerm_virtual_network_gateway_test = new azure.network.VirtualNetworkGateway("test", {
+ *     activeActive: false,
+ *     enableBgp: false,
+ *     ipConfigurations: [{
+ *         privateIpAddressAllocation: "Dynamic",
+ *         publicIpAddressId: azurerm_public_ip_test.id,
+ *         subnetId: azurerm_subnet_test.id,
+ *     }],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "test",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: "Basic",
+ *     type: "Vpn",
+ *     vpnType: "RouteBased",
+ * });
+ * const azurerm_virtual_network_gateway_connection_onpremise = new azure.network.VirtualNetworkGatewayConnection("onpremise", {
+ *     localNetworkGatewayId: azurerm_local_network_gateway_onpremise.id,
+ *     location: azurerm_resource_group_test.location,
+ *     name: "onpremise",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sharedKey: "4-v3ry-53cr37-1p53c-5h4r3d-k3y",
+ *     type: "IPsec",
+ *     virtualNetworkGatewayId: azurerm_virtual_network_gateway_test.id,
+ * });
+ * ```
+ * ### VNet-to-VNet connection
+ * 
+ * The following example shows a connection between two Azure virtual network
+ * in different locations/regions.
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_europe = new azure.core.ResourceGroup("europe", {
+ *     location: "West Europe",
+ *     name: "europe",
+ * });
+ * const azurerm_resource_group_us = new azure.core.ResourceGroup("us", {
+ *     location: "East US",
+ *     name: "us",
+ * });
+ * const azurerm_public_ip_europe = new azure.network.PublicIp("europe", {
+ *     location: azurerm_resource_group_europe.location,
+ *     name: "europe",
+ *     publicIpAddressAllocation: "Dynamic",
+ *     resourceGroupName: azurerm_resource_group_europe.name,
+ * });
+ * const azurerm_public_ip_us = new azure.network.PublicIp("us", {
+ *     location: azurerm_resource_group_us.location,
+ *     name: "us",
+ *     publicIpAddressAllocation: "Dynamic",
+ *     resourceGroupName: azurerm_resource_group_us.name,
+ * });
+ * const azurerm_virtual_network_europe = new azure.network.VirtualNetwork("europe", {
+ *     addressSpaces: ["10.1.0.0/16"],
+ *     location: azurerm_resource_group_europe.location,
+ *     name: "europe",
+ *     resourceGroupName: azurerm_resource_group_europe.name,
+ * });
+ * const azurerm_subnet_europe_gateway = new azure.network.Subnet("europe_gateway", {
+ *     addressPrefix: "10.1.1.0/24",
+ *     name: "GatewaySubnet",
+ *     resourceGroupName: azurerm_resource_group_europe.name,
+ *     virtualNetworkName: azurerm_virtual_network_europe.name,
+ * });
+ * const azurerm_virtual_network_us = new azure.network.VirtualNetwork("us", {
+ *     addressSpaces: ["10.0.0.0/16"],
+ *     location: azurerm_resource_group_us.location,
+ *     name: "us",
+ *     resourceGroupName: azurerm_resource_group_us.name,
+ * });
+ * const azurerm_subnet_us_gateway = new azure.network.Subnet("us_gateway", {
+ *     addressPrefix: "10.0.1.0/24",
+ *     name: "GatewaySubnet",
+ *     resourceGroupName: azurerm_resource_group_us.name,
+ *     virtualNetworkName: azurerm_virtual_network_us.name,
+ * });
+ * const azurerm_virtual_network_gateway_europe = new azure.network.VirtualNetworkGateway("europe", {
+ *     ipConfigurations: [{
+ *         privateIpAddressAllocation: "Dynamic",
+ *         publicIpAddressId: azurerm_public_ip_europe.id,
+ *         subnetId: azurerm_subnet_europe_gateway.id,
+ *     }],
+ *     location: azurerm_resource_group_europe.location,
+ *     name: "europe-gateway",
+ *     resourceGroupName: azurerm_resource_group_europe.name,
+ *     sku: "Basic",
+ *     type: "Vpn",
+ *     vpnType: "RouteBased",
+ * });
+ * const azurerm_virtual_network_gateway_us = new azure.network.VirtualNetworkGateway("us", {
+ *     ipConfigurations: [{
+ *         privateIpAddressAllocation: "Dynamic",
+ *         publicIpAddressId: azurerm_public_ip_us.id,
+ *         subnetId: azurerm_subnet_us_gateway.id,
+ *     }],
+ *     location: azurerm_resource_group_us.location,
+ *     name: "us-gateway",
+ *     resourceGroupName: azurerm_resource_group_us.name,
+ *     sku: "Basic",
+ *     type: "Vpn",
+ *     vpnType: "RouteBased",
+ * });
+ * const azurerm_virtual_network_gateway_connection_europe_to_us = new azure.network.VirtualNetworkGatewayConnection("europe_to_us", {
+ *     location: azurerm_resource_group_europe.location,
+ *     name: "europe-to-us",
+ *     peerVirtualNetworkGatewayId: azurerm_virtual_network_gateway_us.id,
+ *     resourceGroupName: azurerm_resource_group_europe.name,
+ *     sharedKey: "4-v3ry-53cr37-1p53c-5h4r3d-k3y",
+ *     type: "Vnet2Vnet",
+ *     virtualNetworkGatewayId: azurerm_virtual_network_gateway_europe.id,
+ * });
+ * const azurerm_virtual_network_gateway_connection_us_to_europe = new azure.network.VirtualNetworkGatewayConnection("us_to_europe", {
+ *     location: azurerm_resource_group_us.location,
+ *     name: "us-to-europe",
+ *     peerVirtualNetworkGatewayId: azurerm_virtual_network_gateway_europe.id,
+ *     resourceGroupName: azurerm_resource_group_us.name,
+ *     sharedKey: "4-v3ry-53cr37-1p53c-5h4r3d-k3y",
+ *     type: "Vnet2Vnet",
+ *     virtualNetworkGatewayId: azurerm_virtual_network_gateway_us.id,
+ * });
+ * ```
  */
 export class VirtualNetworkGatewayConnection extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/network/virtualNetworkPeering.ts
+++ b/sdk/nodejs/network/virtualNetworkPeering.ts
@@ -7,6 +7,100 @@ import * as utilities from "../utilities";
 /**
  * Manages a virtual network peering which allows resources to access other
  * resources in the linked virtual network.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "peeredvnets-rg",
+ * });
+ * const azurerm_virtual_network_test1 = new azure.network.VirtualNetwork("test1", {
+ *     addressSpaces: ["10.0.1.0/24"],
+ *     location: "West US",
+ *     name: "peternetwork1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_virtual_network_test2 = new azure.network.VirtualNetwork("test2", {
+ *     addressSpaces: ["10.0.2.0/24"],
+ *     location: "West US",
+ *     name: "peternetwork2",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_virtual_network_peering_test1 = new azure.network.VirtualNetworkPeering("test1", {
+ *     name: "peer1to2",
+ *     remoteVirtualNetworkId: azurerm_virtual_network_test2.id,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     virtualNetworkName: azurerm_virtual_network_test1.name,
+ * });
+ * const azurerm_virtual_network_peering_test2 = new azure.network.VirtualNetworkPeering("test2", {
+ *     name: "peer2to1",
+ *     remoteVirtualNetworkId: azurerm_virtual_network_test1.id,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     virtualNetworkName: azurerm_virtual_network_test2.name,
+ * });
+ * ```
+ * 
+ * ## Example Usage (Global virtual network peering)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const config = new pulumi.Config();
+ * const var_location = config.get("location") || [
+ *     "uksouth",
+ *     "southeastasia",
+ * ];
+ * const var_vnet_address_space = config.get("vnetAddressSpace") || [
+ *     "10.0.0.0/16",
+ *     "10.1.0.0/16",
+ * ];
+ * 
+ * const azurerm_resource_group_vnet: azure.core.ResourceGroup[] = [];
+ * for (let i = 0; i < var_location.length; i++) {
+ *     azurerm_resource_group_vnet.push(new azure.core.ResourceGroup(`vnet-${i}`, {
+ *         location: var_location[i],
+ *         name: `rg-global-vnet-peering-${i}`,
+ *     }));
+ * }
+ * const azurerm_virtual_network_vnet: azure.network.VirtualNetwork[] = [];
+ * for (let i = 0; i < var_location.length; i++) {
+ *     azurerm_virtual_network_vnet.push(new azure.network.VirtualNetwork(`vnet-${i}`, {
+ *         addressSpaces: [var_vnet_address_space[i]],
+ *         location: pulumi.all(azurerm_resource_group_vnet.map(v => v.location)).apply(__arg0 => __arg0.map(v => v)[i]),
+ *         name: `vnet-${i}`,
+ *         resourceGroupName: pulumi.all(azurerm_resource_group_vnet.map(v => v.name)).apply(__arg0 => __arg0.map(v => v)[i]),
+ *     }));
+ * }
+ * const azurerm_subnet_nva: azure.network.Subnet[] = [];
+ * for (let i = 0; i < var_location.length; i++) {
+ *     azurerm_subnet_nva.push(new azure.network.Subnet(`nva-${i}`, {
+ *         addressPrefix: pulumi.all(azurerm_virtual_network_vnet.map(v => v.addressSpaces)).apply(__arg0 => (() => {
+ *             throw "tf2pulumi error: NYI: call to cidrsubnet";
+ *             return (() => { throw "NYI: call to cidrsubnet"; })();
+ *         })()),
+ *         name: "nva",
+ *         resourceGroupName: pulumi.all(azurerm_resource_group_vnet.map(v => v.name)).apply(__arg0 => __arg0.map(v => v)[i]),
+ *         virtualNetworkName: pulumi.all(azurerm_virtual_network_vnet.map(v => v.name)).apply(__arg0 => __arg0.map(v => v)[i]),
+ *     }));
+ * }
+ * const azurerm_virtual_network_peering_peering: azure.network.VirtualNetworkPeering[] = [];
+ * for (let i = 0; i < var_location.length; i++) {
+ *     azurerm_virtual_network_peering_peering.push(new azure.network.VirtualNetworkPeering(`peering-${i}`, {
+ *         allowForwardedTraffic: true,
+ *         allowGatewayTransit: false,
+ *         allowVirtualNetworkAccess: true,
+ *         name: pulumi.all(azurerm_virtual_network_vnet.map(v => v.name)).apply(__arg0 => `peering-to-${__arg0.map(v => v)[(1 - i)]}`),
+ *         remoteVirtualNetworkId: pulumi.all(azurerm_virtual_network_vnet.map(v => v.id)).apply(__arg0 => __arg0.map(v => v)[(1 - i)]),
+ *         resourceGroupName: pulumi.all(azurerm_resource_group_vnet.map(v => v.name)).apply(__arg0 => __arg0.map(v => v)[i]),
+ *         virtualNetworkName: pulumi.all(azurerm_virtual_network_vnet.map(v => v.name)).apply(__arg0 => __arg0.map(v => v)[i]),
+ *     }));
+ * }
+ * ```
  */
 export class VirtualNetworkPeering extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/notificationhub/authorizationRule.ts
+++ b/sdk/nodejs/notificationhub/authorizationRule.ts
@@ -6,6 +6,42 @@ import * as utilities from "../utilities";
 
 /**
  * Manages an Authorization Rule associated with a Notification Hub within a Notification Hub Namespace.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "Australia East",
+ *     name: "notificationhub-resources",
+ * });
+ * const azurerm_notification_hub_namespace_test = new azure.notificationhub.Namespace("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "myappnamespace",
+ *     namespaceType: "NotificationHub",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         name: "Free",
+ *     },
+ * });
+ * const azurerm_notification_hub_test = new azure.notificationhub.Hub("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "mynotificationhub",
+ *     namespaceName: azurerm_notification_hub_namespace_test.name,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_notification_hub_authorization_rule_test = new azure.notificationhub.AuthorizationRule("test", {
+ *     listen: true,
+ *     manage: true,
+ *     name: "management-auth-rule",
+ *     namespaceName: azurerm_notification_hub_namespace_test.name,
+ *     notificationHubName: azurerm_notification_hub_test.name,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     send: true,
+ * });
+ * ```
  */
 export class AuthorizationRule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/notificationhub/getHub.ts
+++ b/sdk/nodejs/notificationhub/getHub.ts
@@ -6,6 +6,21 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing Notification Hub within a Notification Hub Namespace.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_notification_hub_test = pulumi.output(azure.notificationhub.getHub({
+ *     name: "notification-hub",
+ *     namespaceName: "namespace-name",
+ *     resourceGroupName: "resource-group-name",
+ * }));
+ * 
+ * export const id = azurerm_notification_hub_test.apply(__arg0 => __arg0.id);
+ * ```
  */
 export function getHub(args: GetHubArgs, opts?: pulumi.InvokeOptions): Promise<GetHubResult> {
     return pulumi.runtime.invoke("azure:notificationhub/getHub:getHub", {

--- a/sdk/nodejs/notificationhub/getNamespace.ts
+++ b/sdk/nodejs/notificationhub/getNamespace.ts
@@ -6,6 +6,20 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing Notification Hub Namespace.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_notification_hub_namespace_test = pulumi.output(azure.notificationhub.getNamespace({
+ *     name: "my-namespace",
+ *     resourceGroupName: "my-resource-group",
+ * }));
+ * 
+ * export const servicebusEndpoint = azurerm_notification_hub_namespace_test.apply(__arg0 => __arg0.servicebusEndpoint);
+ * ```
  */
 export function getNamespace(args: GetNamespaceArgs, opts?: pulumi.InvokeOptions): Promise<GetNamespaceResult> {
     return pulumi.runtime.invoke("azure:notificationhub/getNamespace:getNamespace", {

--- a/sdk/nodejs/notificationhub/hub.ts
+++ b/sdk/nodejs/notificationhub/hub.ts
@@ -6,6 +6,33 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Notification Hub within a Notification Hub Namespace.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "Australia East",
+ *     name: "notificationhub-resources",
+ * });
+ * const azurerm_notification_hub_namespace_test = new azure.notificationhub.Namespace("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "myappnamespace",
+ *     namespaceType: "NotificationHub",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         name: "Free",
+ *     },
+ * });
+ * const azurerm_notification_hub_test = new azure.notificationhub.Hub("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "mynotificationhub",
+ *     namespaceName: azurerm_notification_hub_namespace_test.name,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * ```
  */
 export class Hub extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/notificationhub/namespace.ts
+++ b/sdk/nodejs/notificationhub/namespace.ts
@@ -6,6 +6,27 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Notification Hub Namespace.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "Australia East",
+ *     name: "notificationhub-resources",
+ * });
+ * const azurerm_notification_hub_namespace_test = new azure.notificationhub.Namespace("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "myappnamespace",
+ *     namespaceType: "NotificationHub",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         name: "Free",
+ *     },
+ * });
+ * ```
  */
 export class Namespace extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/operationalinsights/analyticsSolution.ts
+++ b/sdk/nodejs/operationalinsights/analyticsSolution.ts
@@ -6,6 +6,42 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Log Analytics (formally Operational Insights) Solution.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * import * as random from "@pulumi/random";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "westeurope",
+ *     name: "k8s-log-analytics-test",
+ * });
+ * const random_id_workspace = new random.RandomId("workspace", {
+ *     byteLength: 8,
+ *     keepers: {
+ *         group_name: azurerm_resource_group_test.name,
+ *     },
+ * });
+ * const azurerm_log_analytics_workspace_test = new azure.operationalinsights.AnalyticsWorkspace("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: random_id_workspace.hex.apply(__arg0 => `k8s-workspace-${__arg0}`),
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: "PerGB2018",
+ * });
+ * const azurerm_log_analytics_solution_test = new azure.operationalinsights.AnalyticsSolution("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     plan: {
+ *         product: "OMSGallery/ContainerInsights",
+ *         publisher: "Microsoft",
+ *     },
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     solutionName: "ContainerInsights",
+ *     workspaceName: azurerm_log_analytics_workspace_test.name,
+ *     workspaceResourceId: azurerm_log_analytics_workspace_test.id,
+ * });
+ * ```
  */
 export class AnalyticsSolution extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/operationalinsights/analyticsWorkspace.ts
+++ b/sdk/nodejs/operationalinsights/analyticsWorkspace.ts
@@ -6,6 +6,25 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Log Analytics (formally Operational Insights) Workspace.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "East US",
+ *     name: "acctestRG-01",
+ * });
+ * const azurerm_log_analytics_workspace_test = new azure.operationalinsights.AnalyticsWorkspace("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "acctest-01",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     retentionInDays: 30,
+ *     sku: "PerGB2018",
+ * });
+ * ```
  */
 export class AnalyticsWorkspace extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/operationalinsights/analyticsWorkspaceLinkedService.ts
+++ b/sdk/nodejs/operationalinsights/analyticsWorkspaceLinkedService.ts
@@ -6,6 +6,43 @@ import * as utilities from "../utilities";
 
 /**
  * Links a Log Analytics (formally Operational Insights) Workspace to another resource. The (currently) only linkable service is an Azure Automation Account.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "resourcegroup-01",
+ * });
+ * const azurerm_automation_account_test = new azure.automation.Account("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "automation-01",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         name: "Basic",
+ *     },
+ *     tags: {
+ *         environment: "development",
+ *     },
+ * });
+ * const azurerm_log_analytics_workspace_test = new azure.operationalinsights.AnalyticsWorkspace("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "workspace-01",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     retentionInDays: 30,
+ *     sku: "PerGB2018",
+ * });
+ * const azurerm_log_analytics_workspace_linked_service_test = new azure.operationalinsights.AnalyticsWorkspaceLinkedService("test", {
+ *     linkedServiceProperties: {
+ *         resource_id: azurerm_automation_account_test.id,
+ *     },
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     workspaceName: azurerm_log_analytics_workspace_test.name,
+ * });
+ * ```
  */
 export class AnalyticsWorkspaceLinkedService extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/operationalinsights/getAnalyticsWorkspace.ts
+++ b/sdk/nodejs/operationalinsights/getAnalyticsWorkspace.ts
@@ -6,6 +6,20 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing Log Analytics (formally Operational Insights) Workspace.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_log_analytics_workspace_test = pulumi.output(azure.operationalinsights.getAnalyticsWorkspace({
+ *     name: "acctest-01",
+ *     resourceGroupName: "acctest",
+ * }));
+ * 
+ * export const logAnalyticsWorkspaceId = azurerm_log_analytics_workspace_test.apply(__arg0 => __arg0.workspaceId);
+ * ```
  */
 export function getAnalyticsWorkspace(args: GetAnalyticsWorkspaceArgs, opts?: pulumi.InvokeOptions): Promise<GetAnalyticsWorkspaceResult> {
     return pulumi.runtime.invoke("azure:operationalinsights/getAnalyticsWorkspace:getAnalyticsWorkspace", {

--- a/sdk/nodejs/policy/assignment.ts
+++ b/sdk/nodejs/policy/assignment.ts
@@ -6,6 +6,34 @@ import * as utilities from "../utilities";
 
 /**
  * Configures the specified Policy Definition at the specified Scope.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_policy_definition_test = new azure.policy.Definition("test", {
+ *     displayName: "acctestpol-%d",
+ *     mode: "All",
+ *     name: "my-policy-definition",
+ *     parameters: "\t{\n    \"allowedLocations\": {\n      \"type\": \"Array\",\n      \"metadata\": {\n        \"description\": \"The list of allowed locations for resources.\",\n        \"displayName\": \"Allowed locations\",\n        \"strongType\": \"location\"\n      }\n    }\n  }\n",
+ *     policyRule: "\t{\n    \"if\": {\n      \"not\": {\n        \"field\": \"location\",\n        \"in\": \"[parameters('allowedLocations')]\"\n      }\n    },\n    \"then\": {\n      \"effect\": \"audit\"\n    }\n  }\n",
+ *     policyType: "Custom",
+ * });
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "test-resources",
+ * });
+ * const azurerm_policy_assignment_test = new azure.policy.Assignment("test", {
+ *     description: "Policy Assignment created via an Acceptance Test",
+ *     displayName: "Acceptance Test Run %d",
+ *     name: "example-policy-assignment",
+ *     parameters: "{\n  \"allowedLocations\": {\n    \"value\": [ \"West Europe\" ]\n  }\n}\n",
+ *     policyDefinitionId: azurerm_policy_definition_test.id,
+ *     scope: azurerm_resource_group_test.id,
+ * });
+ * ```
  */
 export class Assignment extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/policy/definition.ts
+++ b/sdk/nodejs/policy/definition.ts
@@ -6,6 +6,22 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a policy rule definition. Policy definitions do not take effect until they are assigned to a scope using a Policy Assignment.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_policy_definition_policy = new azure.policy.Definition("policy", {
+ *     displayName: "acceptance test policy definition",
+ *     mode: "Indexed",
+ *     name: "accTestPolicy",
+ *     parameters: "\t{\n    \"allowedLocations\": {\n      \"type\": \"Array\",\n      \"metadata\": {\n        \"description\": \"The list of allowed locations for resources.\",\n        \"displayName\": \"Allowed locations\",\n        \"strongType\": \"location\"\n      }\n    }\n  }\n",
+ *     policyRule: "\t{\n    \"if\": {\n      \"not\": {\n        \"field\": \"location\",\n        \"in\": \"[parameters('allowedLocations')]\"\n      }\n    },\n    \"then\": {\n      \"effect\": \"audit\"\n    }\n  }\n",
+ *     policyType: "Custom",
+ * });
+ * ```
  */
 export class Definition extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/postgresql/configuration.ts
+++ b/sdk/nodejs/postgresql/configuration.ts
@@ -6,6 +6,44 @@ import * as utilities from "../utilities";
 
 /**
  * Sets a PostgreSQL Configuration value on a PostgreSQL Server.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "api-rg-pro",
+ * });
+ * const azurerm_postgresql_server_test = new azure.postgresql.Server("test", {
+ *     administratorLogin: "psqladminun",
+ *     administratorLoginPassword: "H@Sh1CoR3!",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "postgresql-server-1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         capacity: 2,
+ *         family: "Gen4",
+ *         name: "B_Gen4_2",
+ *         tier: "Basic",
+ *     },
+ *     sslEnforcement: "Enabled",
+ *     storageProfile: {
+ *         backupRetentionDays: 7,
+ *         geoRedundantBackup: "Disabled",
+ *         storageMb: 5120,
+ *     },
+ *     version: "9.5",
+ * });
+ * const azurerm_postgresql_configuration_test = new azure.postgresql.Configuration("test", {
+ *     name: "backslash_quote",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     serverName: azurerm_postgresql_server_test.name,
+ *     value: "on",
+ * });
+ * ```
  */
 export class Configuration extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/postgresql/database.ts
+++ b/sdk/nodejs/postgresql/database.ts
@@ -6,6 +6,45 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a PostgreSQL Database within a PostgreSQL Server
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "api-rg-pro",
+ * });
+ * const azurerm_postgresql_server_test = new azure.postgresql.Server("test", {
+ *     administratorLogin: "psqladminun",
+ *     administratorLoginPassword: "H@Sh1CoR3!",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "postgresql-server-1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         capacity: 2,
+ *         family: "Gen4",
+ *         name: "B_Gen4_2",
+ *         tier: "Basic",
+ *     },
+ *     sslEnforcement: "Enabled",
+ *     storageProfile: {
+ *         backupRetentionDays: 7,
+ *         geoRedundantBackup: "Disabled",
+ *         storageMb: 5120,
+ *     },
+ *     version: "9.5",
+ * });
+ * const azurerm_postgresql_database_test = new azure.postgresql.Database("test", {
+ *     charset: "UTF8",
+ *     collation: "English_United States.1252",
+ *     name: "exampledb",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     serverName: azurerm_postgresql_server_test.name,
+ * });
+ * ```
  */
 export class Database extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/postgresql/firewallRule.ts
+++ b/sdk/nodejs/postgresql/firewallRule.ts
@@ -6,6 +6,46 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Firewall Rule for a PostgreSQL Server
+ * 
+ * ## Example Usage (Single IP Address)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_postgresql_server_test = new azure.postgresql.Server("test", {});
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "api-rg-pro",
+ * });
+ * const azurerm_postgresql_firewall_rule_test = new azure.postgresql.FirewallRule("test", {
+ *     endIpAddress: "40.112.8.12",
+ *     name: "office",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     serverName: azurerm_postgresql_server_test.name,
+ *     startIpAddress: "40.112.8.12",
+ * });
+ * ```
+ * 
+ * ## Example Usage (IP Range)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_postgresql_server_test = new azure.postgresql.Server("test", {});
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "api-rg-pro",
+ * });
+ * const azurerm_postgresql_firewall_rule_test = new azure.postgresql.FirewallRule("test", {
+ *     endIpAddress: "40.112.255.255",
+ *     name: "office",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     serverName: azurerm_postgresql_server_test.name,
+ *     startIpAddress: "40.112.0.0",
+ * });
+ * ```
  */
 export class FirewallRule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/postgresql/server.ts
+++ b/sdk/nodejs/postgresql/server.ts
@@ -6,6 +6,38 @@ import * as utilities from "../utilities";
 
 /**
  * Manage a PostgreSQL Server.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "api-rg-pro",
+ * });
+ * const azurerm_postgresql_server_test = new azure.postgresql.Server("test", {
+ *     administratorLogin: "psqladminun",
+ *     administratorLoginPassword: "H@Sh1CoR3!",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "postgresql-server-1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         capacity: 2,
+ *         family: "Gen4",
+ *         name: "B_Gen4_2",
+ *         tier: "Basic",
+ *     },
+ *     sslEnforcement: "Enabled",
+ *     storageProfile: {
+ *         backupRetentionDays: 7,
+ *         geoRedundantBackup: "Disabled",
+ *         storageMb: 5120,
+ *     },
+ *     version: "9.5",
+ * });
+ * ```
  */
 export class Server extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/postgresql/virtualNetworkRule.ts
+++ b/sdk/nodejs/postgresql/virtualNetworkRule.ts
@@ -8,6 +8,58 @@ import * as utilities from "../utilities";
  * Manages a PostgreSQL Virtual Network Rule.
  * 
  * -> **NOTE:** PostgreSQL Virtual Network Rules [can only be used with SKU Tiers of `GeneralPurpose` or `MemoryOptimized`](https://docs.microsoft.com/en-us/azure/postgresql/concepts-data-access-and-security-vnet)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "example-resources",
+ * });
+ * const azurerm_postgresql_server_test = new azure.postgresql.Server("test", {
+ *     administratorLogin: "psqladminun",
+ *     administratorLoginPassword: "H@Sh1CoR3!",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "postgresql-server-1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         capacity: 2,
+ *         family: "Gen5",
+ *         name: "GP_Gen5_2",
+ *         tier: "GeneralPurpose",
+ *     },
+ *     sslEnforcement: "Enabled",
+ *     storageProfile: {
+ *         backupRetentionDays: 7,
+ *         geoRedundantBackup: "Disabled",
+ *         storageMb: 5120,
+ *     },
+ *     version: "9.5",
+ * });
+ * const azurerm_virtual_network_test = new azure.network.VirtualNetwork("test", {
+ *     addressSpaces: ["10.7.29.0/29"],
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-vnet",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_subnet_internal = new azure.network.Subnet("internal", {
+ *     addressPrefix: "10.7.29.0/29",
+ *     name: "internal",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     serviceEndpoints: ["Microsoft.Sql"],
+ *     virtualNetworkName: azurerm_virtual_network_test.name,
+ * });
+ * const azurerm_postgresql_virtual_network_rule_test = new azure.postgresql.VirtualNetworkRule("test", {
+ *     ignoreMissingVnetServiceEndpoint: true,
+ *     name: "postgresql-vnet-rule",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     serverName: azurerm_postgresql_server_test.name,
+ *     subnetId: azurerm_subnet_internal.id,
+ * });
+ * ```
  */
 export class VirtualNetworkRule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -5,7 +5,10 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
- * The provider type for the azurerm package
+ * The provider type for the azurerm package. By default, resources use package-wide configuration
+ * settings, however an explicit `Provider` instance may be created and passed during resource
+ * construction to achieve fine-grained programmatic control over provider settings. See the
+ * [documentation](https://pulumi.io/reference/programming-model.html#providers) for more information.
  */
 export class Provider extends pulumi.ProviderResource {
 

--- a/sdk/nodejs/recoveryservices/getVault.ts
+++ b/sdk/nodejs/recoveryservices/getVault.ts
@@ -6,6 +6,18 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing Recovery Services Vault.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_recovery_services_vault_vault = pulumi.output(azure.recoveryservices.getVault({
+ *     name: "tfex-recovery_vault",
+ *     resourceGroupName: "tfex-resource_group",
+ * }));
+ * ```
  */
 export function getVault(args: GetVaultArgs, opts?: pulumi.InvokeOptions): Promise<GetVaultResult> {
     return pulumi.runtime.invoke("azure:recoveryservices/getVault:getVault", {

--- a/sdk/nodejs/recoveryservices/vault.ts
+++ b/sdk/nodejs/recoveryservices/vault.ts
@@ -6,6 +6,24 @@ import * as utilities from "../utilities";
 
 /**
  * Manage an Recovery Services Vault.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_rg = new azure.core.ResourceGroup("rg", {
+ *     location: "West US",
+ *     name: "tfex-recovery_vault",
+ * });
+ * const azurerm_recovery_services_vault_vault = new azure.recoveryservices.Vault("vault", {
+ *     location: azurerm_resource_group_rg.location,
+ *     name: "example_recovery_vault",
+ *     resourceGroupName: azurerm_resource_group_rg.name,
+ *     sku: "standard",
+ * });
+ * ```
  */
 export class Vault extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/redis/cache.ts
+++ b/sdk/nodejs/redis/cache.ts
@@ -6,6 +6,109 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Redis Cache.
+ * 
+ * ## Example Usage (Basic)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "redis-resources",
+ * });
+ * const azurerm_redis_cache_test = new azure.redis.Cache("test", {
+ *     capacity: 0,
+ *     enableNonSslPort: false,
+ *     family: "C",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "tf-redis-basic",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     skuName: "Basic",
+ * });
+ * ```
+ * 
+ * ## Example Usage (Standard)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "redis-resources",
+ * });
+ * const azurerm_redis_cache_test = new azure.redis.Cache("test", {
+ *     capacity: 2,
+ *     enableNonSslPort: false,
+ *     family: "C",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "tf-redis-standard",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     skuName: "Standard",
+ * });
+ * ```
+ * 
+ * ## Example Usage (Premium with Clustering)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "redis-resources",
+ * });
+ * const azurerm_redis_cache_test = new azure.redis.Cache("test", {
+ *     capacity: 1,
+ *     enableNonSslPort: false,
+ *     family: "P",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "tf-redis-premium",
+ *     redisConfiguration: {
+ *         maxmemoryDelta: 2,
+ *         maxmemoryPolicy: "allkeys-lru",
+ *         maxmemoryReserved: 2,
+ *     },
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     shardCount: 3,
+ *     skuName: "Premium",
+ * });
+ * ```
+ * 
+ * ## Example Usage (Premium with Backup)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "redis-resources",
+ * });
+ * const azurerm_storage_account_test = new azure.storage.Account("test", {
+ *     accountReplicationType: "GRS",
+ *     accountTier: "Standard",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "redissa",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_redis_cache_test = new azure.redis.Cache("test", {
+ *     capacity: 3,
+ *     enableNonSslPort: false,
+ *     family: "P",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "tf-redis-pbkup",
+ *     redisConfiguration: {
+ *         rdbBackupEnabled: true,
+ *         rdbBackupFrequency: 60,
+ *         rdbBackupMaxSnapshotCount: 1,
+ *         rdbStorageConnectionString: pulumi.all([azurerm_storage_account_test.primaryBlobEndpoint, azurerm_storage_account_test.name, azurerm_storage_account_test.primaryAccessKey]).apply(([__arg0, __arg1, __arg2]) => `DefaultEndpointsProtocol=https;BlobEndpoint=${__arg0};AccountName=${__arg1};AccountKey=${__arg2}`),
+ *     },
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     skuName: "Premium",
+ * });
+ * ```
  */
 export class Cache extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/redis/firewallRule.ts
+++ b/sdk/nodejs/redis/firewallRule.ts
@@ -6,6 +6,47 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Firewall Rule associated with a Redis Cache.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as random from "@pulumi/random";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "redis-resourcegroup",
+ * });
+ * const random_id_server = new random.RandomId("server", {
+ *     byteLength: 8,
+ *     keepers: {
+ *         azi_id: 1,
+ *     },
+ * });
+ * const azurerm_redis_cache_test = new azure.redis.Cache("test", {
+ *     capacity: 1,
+ *     enableNonSslPort: false,
+ *     family: "P",
+ *     location: azurerm_resource_group_test.location,
+ *     name: random_id_server.hex.apply(__arg0 => `redis${__arg0}`),
+ *     redisConfiguration: {
+ *         maxclients: 256,
+ *         maxmemoryDelta: 2,
+ *         maxmemoryPolicy: "allkeys-lru",
+ *         maxmemoryReserved: 2,
+ *     },
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     skuName: "Premium",
+ * });
+ * const azurerm_redis_firewall_rule_test = new azure.redis.FirewallRule("test", {
+ *     endIp: "2.3.4.5",
+ *     name: "someIPrange",
+ *     redisCacheName: azurerm_redis_cache_test.name,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     startIp: "1.2.3.4",
+ * });
+ * ```
  */
 export class FirewallRule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/relay/namespace.ts
+++ b/sdk/nodejs/relay/namespace.ts
@@ -6,6 +6,29 @@ import * as utilities from "../utilities";
 
 /**
  * Manages an Azure Relay Namespace.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "example-resources",
+ * });
+ * const azurerm_relay_namespace_test = new azure.relay.Namespace("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "example-relay",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: {
+ *         name: "Standard",
+ *     },
+ *     tags: {
+ *         source: "terraform",
+ *     },
+ * });
+ * ```
  */
 export class Namespace extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/role/assignment.ts
+++ b/sdk/nodejs/role/assignment.ts
@@ -6,6 +6,73 @@ import * as utilities from "../utilities";
 
 /**
  * Assigns a given Principal (User or Application) to a given Role.
+ * 
+ * ## Example Usage (using a built-in Role)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_client_config_test = pulumi.output(azure.core.getClientConfig({}));
+ * const azurerm_subscription_primary = pulumi.output(azure.core.getSubscription({}));
+ * const azurerm_role_assignment_test = new azure.role.Assignment("test", {
+ *     principalId: azurerm_client_config_test.apply(__arg0 => __arg0.servicePrincipalObjectId),
+ *     roleDefinitionName: "Reader",
+ *     scope: azurerm_subscription_primary.apply(__arg0 => __arg0.id),
+ * });
+ * ```
+ * 
+ * ## Example Usage (Custom Role & Service Principal)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_client_config_test = pulumi.output(azure.core.getClientConfig({}));
+ * const azurerm_subscription_primary = pulumi.output(azure.core.getSubscription({}));
+ * const azurerm_role_definition_test = new azure.role.Definition("test", {
+ *     assignableScopes: [azurerm_subscription_primary.apply(__arg0 => __arg0.id)],
+ *     name: "my-custom-role-definition",
+ *     permissions: [{
+ *         actions: ["Microsoft.Resources/subscriptions/resourceGroups/read"],
+ *         notActions: [],
+ *     }],
+ *     roleDefinitionId: "00000000-0000-0000-0000-000000000000",
+ *     scope: azurerm_subscription_primary.apply(__arg0 => __arg0.id),
+ * });
+ * const azurerm_role_assignment_test = new azure.role.Assignment("test", {
+ *     name: "00000000-0000-0000-0000-000000000000",
+ *     principalId: azurerm_client_config_test.apply(__arg0 => __arg0.servicePrincipalObjectId),
+ *     roleDefinitionId: azurerm_role_definition_test.id,
+ *     scope: azurerm_subscription_primary.apply(__arg0 => __arg0.id),
+ * });
+ * ```
+ * 
+ * ## Example Usage (Custom Role & User)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_client_config_test = pulumi.output(azure.core.getClientConfig({}));
+ * const azurerm_subscription_primary = pulumi.output(azure.core.getSubscription({}));
+ * const azurerm_role_definition_test = new azure.role.Definition("test", {
+ *     assignableScopes: [azurerm_subscription_primary.apply(__arg0 => __arg0.id)],
+ *     name: "my-custom-role-definition",
+ *     permissions: [{
+ *         actions: ["Microsoft.Resources/subscriptions/resourceGroups/read"],
+ *         notActions: [],
+ *     }],
+ *     roleDefinitionId: "00000000-0000-0000-0000-000000000000",
+ *     scope: azurerm_subscription_primary.apply(__arg0 => __arg0.id),
+ * });
+ * const azurerm_role_assignment_test = new azure.role.Assignment("test", {
+ *     name: "00000000-0000-0000-0000-000000000000",
+ *     principalId: azurerm_client_config_test.apply(__arg0 => __arg0.clientId),
+ *     roleDefinitionId: azurerm_role_definition_test.id,
+ *     scope: azurerm_subscription_primary.apply(__arg0 => __arg0.id),
+ * });
+ * ```
  */
 export class Assignment extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/role/definition.ts
+++ b/sdk/nodejs/role/definition.ts
@@ -6,6 +6,25 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a custom Role Definition, used to assign Roles to Users/Principals. See ['Understand role definitions'](https://docs.microsoft.com/en-us/azure/role-based-access-control/role-definitions) in the Azure documentation for more details.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_subscription_primary = pulumi.output(azure.core.getSubscription({}));
+ * const azurerm_role_definition_test = new azure.role.Definition("test", {
+ *     assignableScopes: [azurerm_subscription_primary.apply(__arg0 => __arg0.id)],
+ *     description: "This is a custom role created via Terraform",
+ *     name: "my-custom-role",
+ *     permissions: [{
+ *         actions: ["*"],
+ *         notActions: [],
+ *     }],
+ *     scope: azurerm_subscription_primary.apply(__arg0 => __arg0.id),
+ * });
+ * ```
  */
 export class Definition extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/role/getBuiltinRoleDefinition.ts
+++ b/sdk/nodejs/role/getBuiltinRoleDefinition.ts
@@ -6,6 +6,19 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about a built-in Role Definition. To access information about a custom Role Definition, please see the `azurerm_role_definition` data source instead.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_builtin_role_definition_contributor = pulumi.output(azure.role.getBuiltinRoleDefinition({
+ *     name: "Contributor",
+ * }));
+ * 
+ * export const contributorRoleDefinitionId = azurerm_builtin_role_definition_contributor.apply(__arg0 => __arg0.id);
+ * ```
  */
 export function getBuiltinRoleDefinition(args: GetBuiltinRoleDefinitionArgs, opts?: pulumi.InvokeOptions): Promise<GetBuiltinRoleDefinitionResult> {
     return pulumi.runtime.invoke("azure:role/getBuiltinRoleDefinition:getBuiltinRoleDefinition", {

--- a/sdk/nodejs/role/getRoleDefinition.ts
+++ b/sdk/nodejs/role/getRoleDefinition.ts
@@ -6,6 +6,21 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing Custom Role Definition. To access information about a built-in Role Definition, please see the `azurerm_builtin_role_definition` data source instead.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_subscription_primary = pulumi.output(azure.core.getSubscription({}));
+ * const azurerm_role_definition_custom = pulumi.output(azure.role.getRoleDefinition({
+ *     roleDefinitionId: "00000000-0000-0000-0000-000000000000",
+ *     scope: azurerm_subscription_primary.apply(__arg0 => __arg0.id),
+ * }));
+ * 
+ * export const customRoleDefinitionId = azurerm_role_definition_custom.apply(__arg0 => __arg0.id);
+ * ```
  */
 export function getRoleDefinition(args: GetRoleDefinitionArgs, opts?: pulumi.InvokeOptions): Promise<GetRoleDefinitionResult> {
     return pulumi.runtime.invoke("azure:role/getRoleDefinition:getRoleDefinition", {

--- a/sdk/nodejs/scheduler/getJobCollection.ts
+++ b/sdk/nodejs/scheduler/getJobCollection.ts
@@ -7,7 +7,7 @@ import * as utilities from "../utilities";
 /**
  * Use this data source to access information about an existing Scheduler Job Collection.
  * 
- * ~> **NOTE:** Support for Scheduler Job Collections has been deprecated by Microsoft in favour of Logic Apps ([more information can be found at this link](https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps)) - as such we plan to remove support for this data source as a part of version 2.0 of the AzureRM Provider.
+ * > **NOTE:** Support for Scheduler Job Collections has been deprecated by Microsoft in favour of Logic Apps ([more information can be found at this link](https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps)) - as such we plan to remove support for this data source as a part of version 2.0 of the AzureRM Provider.
  */
 export function getJobCollection(args: GetJobCollectionArgs, opts?: pulumi.InvokeOptions): Promise<GetJobCollectionResult> {
     return pulumi.runtime.invoke("azure:scheduler/getJobCollection:getJobCollection", {

--- a/sdk/nodejs/scheduler/job.ts
+++ b/sdk/nodejs/scheduler/job.ts
@@ -7,7 +7,7 @@ import * as utilities from "../utilities";
 /**
  * Manages a Scheduler Job.
  * 
- * ~> **NOTE:** Support for Scheduler Job has been deprecated by Microsoft in favour of Logic Apps ([more information can be found at this link](https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps)) - as such we plan to remove support for this resource as a part of version 2.0 of the AzureRM Provider.
+ * > **NOTE:** Support for Scheduler Job has been deprecated by Microsoft in favour of Logic Apps ([more information can be found at this link](https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps)) - as such we plan to remove support for this resource as a part of version 2.0 of the AzureRM Provider.
  */
 export class Job extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/scheduler/jobCollection.ts
+++ b/sdk/nodejs/scheduler/jobCollection.ts
@@ -7,7 +7,31 @@ import * as utilities from "../utilities";
 /**
  * Manages a Scheduler Job Collection.
  * 
- * ~> **NOTE:** Support for Scheduler Job Collections has been deprecated by Microsoft in favour of Logic Apps ([more information can be found at this link](https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps)) - as such we plan to remove support for this resource as a part of version 2.0 of the AzureRM Provider.
+ * > **NOTE:** Support for Scheduler Job Collections has been deprecated by Microsoft in favour of Logic Apps ([more information can be found at this link](https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps)) - as such we plan to remove support for this resource as a part of version 2.0 of the AzureRM Provider.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_rg = new azure.core.ResourceGroup("rg", {
+ *     location: "West US",
+ *     name: "tfex-job_collection",
+ * });
+ * const azurerm_scheduler_job_collection_jobs = new azure.scheduler.JobCollection("jobs", {
+ *     location: azurerm_resource_group_rg.location,
+ *     name: "example_job_collection",
+ *     quota: {
+ *         maxJobCount: 5,
+ *         maxRecurrenceFrequency: "hour",
+ *         maxRecurrenceInterval: 24,
+ *     },
+ *     resourceGroupName: azurerm_resource_group_rg.name,
+ *     sku: "free",
+ *     state: "enabled",
+ * });
+ * ```
  */
 export class JobCollection extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/search/service.ts
+++ b/sdk/nodejs/search/service.ts
@@ -6,6 +6,28 @@ import * as utilities from "../utilities";
 
 /**
  * Allows you to manage an Azure Search Service.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acceptanceTestResourceGroup1",
+ * });
+ * const azurerm_search_service_test = new azure.search.Service("test", {
+ *     location: azurerm_resource_group_test.location,
+ *     name: "acceptanceTestSearchService1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     sku: "standard",
+ *     tags: {
+ *         database: "test",
+ *         environment: "staging",
+ *     },
+ * });
+ * ```
  */
 export class Service extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/securitycenter/contact.ts
+++ b/sdk/nodejs/securitycenter/contact.ts
@@ -7,7 +7,21 @@ import * as utilities from "../utilities";
 /**
  * Manages the subscription's Security Center Contact.
  * 
- * ~> **NOTE:** Owner access permission is required. 
+ * > **NOTE:** Owner access permission is required. 
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_security_center_contact_example = new azure.securitycenter.Contact("example", {
+ *     alertNotifications: true,
+ *     alertsToAdmins: true,
+ *     email: "contact@example.com",
+ *     phone: "+1-555-555-5555",
+ * });
+ * ```
  */
 export class Contact extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/securitycenter/subscriptionPricing.ts
+++ b/sdk/nodejs/securitycenter/subscriptionPricing.ts
@@ -7,9 +7,20 @@ import * as utilities from "../utilities";
 /**
  * Manages the Pricing Tier for Azure Security Center in the current subscription.
  * 
- * ~> **NOTE:** This resource requires the `Owner` permission on the Subscription.
+ * > **NOTE:** This resource requires the `Owner` permission on the Subscription.
  * 
- * ~> **NOTE:** Deletion of this resource does not change or reset the pricing tier to `Free`
+ * > **NOTE:** Deletion of this resource does not change or reset the pricing tier to `Free`
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_security_center_subscription_pricing_example = new azure.securitycenter.SubscriptionPricing("example", {
+ *     tier: "Standard",
+ * });
+ * ```
  */
 export class SubscriptionPricing extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/securitycenter/workspace.ts
+++ b/sdk/nodejs/securitycenter/workspace.ts
@@ -7,9 +7,31 @@ import * as utilities from "../utilities";
 /**
  * Manages the subscription's Security Center Workspace.
  * 
- * ~> **NOTE:** Owner access permission is required.
+ * > **NOTE:** Owner access permission is required.
  * 
- * ~> **NOTE:** The subscription's pricing model can not be `Free` for this to have any affect.
+ * > **NOTE:** The subscription's pricing model can not be `Free` for this to have any affect.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_example = new azure.core.ResourceGroup("example", {
+ *     location: "westus",
+ *     name: "tfex-security-workspace",
+ * });
+ * const azurerm_log_analytics_workspace_example = new azure.operationalinsights.AnalyticsWorkspace("example", {
+ *     location: azurerm_resource_group_example.location,
+ *     name: "tfex-security-workspace",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     sku: "PerGB2018",
+ * });
+ * const azurerm_security_center_workspace_example = new azure.securitycenter.Workspace("example", {
+ *     scope: "/subscriptions/00000000-0000-0000-0000-000000000000",
+ *     workspaceId: azurerm_log_analytics_workspace_example.id,
+ * });
+ * ```
  */
 export class Workspace extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/servicefabric/cluster.ts
+++ b/sdk/nodejs/servicefabric/cluster.ts
@@ -6,6 +6,35 @@ import * as utilities from "../utilities";
 
 /**
  * Manage a Service Fabric Cluster.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West Europe",
+ *     name: "example-resources",
+ * });
+ * const azurerm_service_fabric_cluster_test = new azure.servicefabric.Cluster("test", {
+ *     clusterCodeVersion: "6.3.176.9494",
+ *     location: azurerm_resource_group_test.location,
+ *     managementEndpoint: "https://example:80",
+ *     name: "example-servicefabric",
+ *     nodeTypes: [{
+ *         clientEndpointPort: 2020,
+ *         httpEndpointPort: 80,
+ *         instanceCount: 3,
+ *         isPrimary: true,
+ *         name: "first",
+ *     }],
+ *     reliabilityLevel: "Bronze",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     upgradeMode: "Manual",
+ *     vmImage: "Windows",
+ * });
+ * ```
  */
 export class Cluster extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/signalr/service.ts
+++ b/sdk/nodejs/signalr/service.ts
@@ -4,6 +4,29 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_example = new azure.core.ResourceGroup("example", {
+ *     location: "West US",
+ *     name: "terraform-signalr",
+ * });
+ * const azurerm_signalr_service_example = new azure.signalr.Service("example", {
+ *     location: azurerm_resource_group_example.location,
+ *     name: "tfex-signalr",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     sku: {
+ *         capacity: 1,
+ *         name: "Free_F1",
+ *     },
+ * });
+ * ```
+ */
 export class Service extends pulumi.CustomResource {
     /**
      * Get an existing Service resource's state with the given name, ID, and optional extra

--- a/sdk/nodejs/sql/activeDirectoryAdministrator.ts
+++ b/sdk/nodejs/sql/activeDirectoryAdministrator.ts
@@ -6,6 +6,34 @@ import * as utilities from "../utilities";
 
 /**
  * Allows you to set a user or group as the AD administrator for an Azure SQL server
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acceptanceTestResourceGroup1",
+ * });
+ * const azurerm_client_config_current = pulumi.output(azure.core.getClientConfig({}));
+ * const azurerm_sql_server_test = new azure.sql.SqlServer("test", {
+ *     administratorLogin: "4dm1n157r470r",
+ *     administratorLoginPassword: "4-v3ry-53cr37-p455w0rd",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "mysqlserver",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     version: "12.0",
+ * });
+ * const azurerm_sql_active_directory_administrator_test = new azure.sql.ActiveDirectoryAdministrator("test", {
+ *     login: "sqladmin",
+ *     objectId: azurerm_client_config_current.apply(__arg0 => __arg0.servicePrincipalObjectId),
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     serverName: azurerm_sql_server_test.name,
+ *     tenantId: azurerm_client_config_current.apply(__arg0 => __arg0.tenantId),
+ * });
+ * ```
  */
 export class ActiveDirectoryAdministrator extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/sql/database.ts
+++ b/sdk/nodejs/sql/database.ts
@@ -6,6 +6,35 @@ import * as utilities from "../utilities";
 
 /**
  * Allows you to manage an Azure SQL Database
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acceptanceTestResourceGroup1",
+ * });
+ * const azurerm_sql_server_test = new azure.sql.SqlServer("test", {
+ *     administratorLogin: "4dm1n157r470r",
+ *     administratorLoginPassword: "4-v3ry-53cr37-p455w0rd",
+ *     location: "West US",
+ *     name: "mysqlserver",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     version: "12.0",
+ * });
+ * const azurerm_sql_database_test = new azure.sql.Database("test", {
+ *     location: "West US",
+ *     name: "mysqldatabase",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     serverName: azurerm_sql_server_test.name,
+ *     tags: {
+ *         environment: "production",
+ *     },
+ * });
+ * ```
  */
 export class Database extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/sql/elasticPool.ts
+++ b/sdk/nodejs/sql/elasticPool.ts
@@ -7,7 +7,40 @@ import * as utilities from "../utilities";
 /**
  * Allows you to manage an Azure SQL Elastic Pool.
  * 
- * ~> **NOTE:** -  This version of the `Elasticpool` resource is being **deprecated** and should no longer be used. Please use the azurerm_mssql_elasticpool version instead.
+ * > **NOTE:** -  This version of the `Elasticpool` resource is being **deprecated** and should no longer be used. Please use the azurerm_mssql_elasticpool version instead.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "my-resource-group",
+ * });
+ * const azurerm_sql_server_test = new azure.sql.SqlServer("test", {
+ *     administratorLogin: "4dm1n157r470r",
+ *     administratorLoginPassword: "4-v3ry-53cr37-p455w0rd",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "my-sql-server",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     version: "12.0",
+ * });
+ * const azurerm_sql_elasticpool_test = new azure.sql.ElasticPool("test", {
+ *     dbDtuMax: 5,
+ *     dbDtuMin: 0,
+ *     dtu: 50,
+ *     edition: "Basic",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "test",
+ *     poolSize: 5000,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     serverName: azurerm_sql_server_test.name,
+ * });
+ * ```
+ * > **NOTE on `azurerm_sql_elasticpool`:** -  The values of `edition`, `dtu`, and `pool_size` must be consistent with the [Azure SQL Database Service Tiers](https://docs.microsoft.com/en-gb/azure/sql-database/sql-database-service-tiers#elastic-pool-service-tiers-and-performance-in-edtus). Any inconsistent argument configuration will be rejected.
+ * 
  */
 export class ElasticPool extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/sql/firewallRule.ts
+++ b/sdk/nodejs/sql/firewallRule.ts
@@ -6,6 +6,33 @@ import * as utilities from "../utilities";
 
 /**
  * Allows you to manage an Azure SQL Firewall Rule
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "acceptanceTestResourceGroup1",
+ * });
+ * const azurerm_sql_server_test = new azure.sql.SqlServer("test", {
+ *     administratorLogin: "4dm1n157r470r",
+ *     administratorLoginPassword: "4-v3ry-53cr37-p455w0rd",
+ *     location: "West US",
+ *     name: "mysqlserver",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     version: "12.0",
+ * });
+ * const azurerm_sql_firewall_rule_test = new azure.sql.FirewallRule("test", {
+ *     endIpAddress: "10.0.17.62",
+ *     name: "FirewallRule1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     serverName: azurerm_sql_server_test.name,
+ *     startIpAddress: "10.0.17.62",
+ * });
+ * ```
  */
 export class FirewallRule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/sql/sqlServer.ts
+++ b/sdk/nodejs/sql/sqlServer.ts
@@ -7,8 +7,31 @@ import * as utilities from "../utilities";
 /**
  * Manages a SQL Azure Database Server.
  * 
- * ~> **Note:** All arguments including the administrator login and password will be stored in the raw state as plain-text.
+ * > **Note:** All arguments including the administrator login and password will be stored in the raw state as plain-text.
  * [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "database-rg",
+ * });
+ * const azurerm_sql_server_test = new azure.sql.SqlServer("test", {
+ *     administratorLogin: "mradministrator",
+ *     administratorLoginPassword: "thisIsDog11",
+ *     location: azurerm_resource_group_test.location,
+ *     name: "mysqlserver",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         environment: "production",
+ *     },
+ *     version: "12.0",
+ * });
+ * ```
  */
 export class SqlServer extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/sql/virtualNetworkRule.ts
+++ b/sdk/nodejs/sql/virtualNetworkRule.ts
@@ -6,6 +6,45 @@ import * as utilities from "../utilities";
 
 /**
  * Allows you to add, update, or remove an Azure SQL server to a subnet of a virtual network.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_example = new azure.core.ResourceGroup("example", {
+ *     location: "West US",
+ *     name: "example-sql-server-vnet-rule",
+ * });
+ * const azurerm_sql_server_sqlserver = new azure.sql.SqlServer("sqlserver", {
+ *     administratorLogin: "4dm1n157r470r",
+ *     administratorLoginPassword: "4-v3ry-53cr37-p455w0rd",
+ *     location: azurerm_resource_group_example.location,
+ *     name: "unqiueazuresqlserver",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     version: "12.0",
+ * });
+ * const azurerm_virtual_network_vnet = new azure.network.VirtualNetwork("vnet", {
+ *     addressSpaces: ["10.7.29.0/29"],
+ *     location: azurerm_resource_group_example.location,
+ *     name: "example-vnet",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ * });
+ * const azurerm_subnet_subnet = new azure.network.Subnet("subnet", {
+ *     addressPrefix: "10.7.29.0/29",
+ *     name: "example-subnet",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     serviceEndpoints: ["Microsoft.Sql"],
+ *     virtualNetworkName: azurerm_virtual_network_vnet.name,
+ * });
+ * const azurerm_sql_virtual_network_rule_sqlvnetrule = new azure.sql.VirtualNetworkRule("sqlvnetrule", {
+ *     name: "sql-vnet-rule",
+ *     resourceGroupName: azurerm_resource_group_example.name,
+ *     serverName: azurerm_sql_server_sqlserver.name,
+ *     subnetId: azurerm_subnet_subnet.id,
+ * });
+ * ```
  */
 export class VirtualNetworkRule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/storage/account.ts
+++ b/sdk/nodejs/storage/account.ts
@@ -6,6 +6,70 @@ import * as utilities from "../utilities";
 
 /**
  * Manage an Azure Storage Account.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_testrg = new azure.core.ResourceGroup("testrg", {
+ *     location: "westus",
+ *     name: "resourceGroupName",
+ * });
+ * const azurerm_storage_account_testsa = new azure.storage.Account("testsa", {
+ *     accountReplicationType: "GRS",
+ *     accountTier: "Standard",
+ *     location: "westus",
+ *     name: "storageaccountname",
+ *     resourceGroupName: azurerm_resource_group_testrg.name,
+ *     tags: {
+ *         environment: "staging",
+ *     },
+ * });
+ * ```
+ * 
+ * ## Example Usage with Network Rules
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_testrg = new azure.core.ResourceGroup("testrg", {
+ *     location: "westus",
+ *     name: "resourceGroupName",
+ * });
+ * const azurerm_virtual_network_test = new azure.network.VirtualNetwork("test", {
+ *     addressSpaces: ["10.0.0.0/16"],
+ *     location: azurerm_resource_group_testrg.location,
+ *     name: "virtnetname",
+ *     resourceGroupName: azurerm_resource_group_testrg.name,
+ * });
+ * const azurerm_subnet_test = new azure.network.Subnet("test", {
+ *     addressPrefix: "10.0.2.0/24",
+ *     name: "subnetname",
+ *     resourceGroupName: azurerm_resource_group_testrg.name,
+ *     serviceEndpoints: [
+ *         "Microsoft.Sql",
+ *         "Microsoft.Storage",
+ *     ],
+ *     virtualNetworkName: azurerm_virtual_network_test.name,
+ * });
+ * const azurerm_storage_account_testsa = new azure.storage.Account("testsa", {
+ *     accountReplicationType: "LRS",
+ *     accountTier: "Standard",
+ *     location: azurerm_resource_group_testrg.location,
+ *     name: "storageaccountname",
+ *     networkRules: {
+ *         ipRules: ["127.0.0.1"],
+ *         virtualNetworkSubnetIds: [azurerm_subnet_test.id],
+ *     },
+ *     resourceGroupName: azurerm_resource_group_testrg.name,
+ *     tags: {
+ *         environment: "staging",
+ *     },
+ * });
+ * ```
  */
 export class Account extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/storage/blob.ts
+++ b/sdk/nodejs/storage/blob.ts
@@ -6,6 +6,39 @@ import * as utilities from "../utilities";
 
 /**
  * Manage an Azure Storage Blob.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "westus",
+ *     name: "acctestRG-d",
+ * });
+ * const azurerm_storage_account_test = new azure.storage.Account("test", {
+ *     accountReplicationType: "LRS",
+ *     accountTier: "Standard",
+ *     location: "westus",
+ *     name: "acctestaccs",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_storage_container_test = new azure.storage.Container("test", {
+ *     containerAccessType: "private",
+ *     name: "vhds",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     storageAccountName: azurerm_storage_account_test.name,
+ * });
+ * const azurerm_storage_blob_testsb = new azure.storage.Blob("testsb", {
+ *     name: "sample.vhd",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     size: 5120,
+ *     storageAccountName: azurerm_storage_account_test.name,
+ *     storageContainerName: azurerm_storage_container_test.name,
+ *     type: "page",
+ * });
+ * ```
  */
 export class Blob extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/storage/container.ts
+++ b/sdk/nodejs/storage/container.ts
@@ -6,6 +6,34 @@ import * as utilities from "../utilities";
 
 /**
  * Manage an Azure Storage Container.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "westus",
+ *     name: "acctestRG",
+ * });
+ * const azurerm_storage_account_test = new azure.storage.Account("test", {
+ *     accountReplicationType: "LRS",
+ *     accountTier: "Standard",
+ *     location: "westus",
+ *     name: "accteststorageaccount",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         environment: "staging",
+ *     },
+ * });
+ * const azurerm_storage_container_test = new azure.storage.Container("test", {
+ *     containerAccessType: "private",
+ *     name: "vhds",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     storageAccountName: azurerm_storage_account_test.name,
+ * });
+ * ```
  */
 export class Container extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/storage/getAccount.ts
+++ b/sdk/nodejs/storage/getAccount.ts
@@ -6,6 +6,20 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access information about an existing Storage Account.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_storage_account_test = pulumi.output(azure.storage.getAccount({
+ *     name: "packerimages",
+ *     resourceGroupName: "packer-storage",
+ * }));
+ * 
+ * export const storageAccountTier = azurerm_storage_account_test.apply(__arg0 => __arg0.accountTier);
+ * ```
  */
 export function getAccount(args: GetAccountArgs, opts?: pulumi.InvokeOptions): Promise<GetAccountResult> {
     return pulumi.runtime.invoke("azure:storage/getAccount:getAccount", {

--- a/sdk/nodejs/storage/getAccountSAS.ts
+++ b/sdk/nodejs/storage/getAccountSAS.ts
@@ -11,6 +11,57 @@ import * as utilities from "../utilities";
  * 
  * Note that this is an [Account SAS](https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-an-account-sas)
  * and *not* a [Service SAS](https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_testrg = new azure.core.ResourceGroup("testrg", {
+ *     location: "westus",
+ *     name: "resourceGroupName",
+ * });
+ * const azurerm_storage_account_testsa = new azure.storage.Account("testsa", {
+ *     accountReplicationType: "GRS",
+ *     accountTier: "Standard",
+ *     location: "westus",
+ *     name: "storageaccountname",
+ *     resourceGroupName: azurerm_resource_group_testrg.name,
+ *     tags: {
+ *         environment: "staging",
+ *     },
+ * });
+ * const azurerm_storage_account_sas_test = pulumi.output(azure.storage.getAccountSAS({
+ *     connectionString: azurerm_storage_account_testsa.primaryConnectionString,
+ *     expiry: "2020-03-21",
+ *     httpsOnly: true,
+ *     permissions: {
+ *         add: true,
+ *         create: true,
+ *         delete: false,
+ *         list: false,
+ *         process: false,
+ *         read: true,
+ *         update: false,
+ *         write: true,
+ *     },
+ *     resourceTypes: {
+ *         container: false,
+ *         object: false,
+ *         service: true,
+ *     },
+ *     services: {
+ *         blob: true,
+ *         file: false,
+ *         queue: false,
+ *         table: false,
+ *     },
+ *     start: "2018-03-21",
+ * }));
+ * 
+ * export const sasUrlQueryString = azurerm_storage_account_sas_test.apply(__arg0 => __arg0.sas);
+ * ```
  */
 export function getAccountSAS(args: GetAccountSASArgs, opts?: pulumi.InvokeOptions): Promise<GetAccountSASResult> {
     return pulumi.runtime.invoke("azure:storage/getAccountSAS:getAccountSAS", {

--- a/sdk/nodejs/storage/queue.ts
+++ b/sdk/nodejs/storage/queue.ts
@@ -6,6 +6,30 @@ import * as utilities from "../utilities";
 
 /**
  * Manage an Azure Storage Queue.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "westus",
+ *     name: "acctestRG-%d",
+ * });
+ * const azurerm_storage_account_test = new azure.storage.Account("test", {
+ *     accountReplicationType: "LRS",
+ *     accountTier: "Standard",
+ *     location: "westus",
+ *     name: "acctestacc%s",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_storage_queue_test = new azure.storage.Queue("test", {
+ *     name: "mysamplequeue",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     storageAccountName: azurerm_storage_account_test.name,
+ * });
+ * ```
  */
 export class Queue extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/storage/share.ts
+++ b/sdk/nodejs/storage/share.ts
@@ -6,6 +6,31 @@ import * as utilities from "../utilities";
 
 /**
  * Manage an Azure Storage File Share.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "westus",
+ *     name: "azuretest",
+ * });
+ * const azurerm_storage_account_test = new azure.storage.Account("test", {
+ *     accountReplicationType: "LRS",
+ *     accountTier: "Standard",
+ *     location: "westus",
+ *     name: "azureteststorage",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_storage_share_testshare = new azure.storage.Share("testshare", {
+ *     name: "sharename",
+ *     quota: 50,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     storageAccountName: azurerm_storage_account_test.name,
+ * });
+ * ```
  */
 export class Share extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/storage/table.ts
+++ b/sdk/nodejs/storage/table.ts
@@ -6,6 +6,30 @@ import * as utilities from "../utilities";
 
 /**
  * Manage an Azure Storage Table.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "westus",
+ *     name: "azuretest",
+ * });
+ * const azurerm_storage_account_test = new azure.storage.Account("test", {
+ *     accountReplicationType: "LRS",
+ *     accountTier: "Standard",
+ *     location: "westus",
+ *     name: "azureteststorage1",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ * });
+ * const azurerm_storage_table_test = new azure.storage.Table("test", {
+ *     name: "mysampletable",
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     storageAccountName: azurerm_storage_account_test.name,
+ * });
+ * ```
  */
 export class Table extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/trafficmanager/endpoint.ts
+++ b/sdk/nodejs/trafficmanager/endpoint.ts
@@ -6,6 +6,50 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Traffic Manager Endpoint.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as random from "@pulumi/random";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "trafficmanagerendpointTest",
+ * });
+ * const random_id_server = new random.RandomId("server", {
+ *     byteLength: 8,
+ *     keepers: {
+ *         azi_id: 1,
+ *     },
+ * });
+ * const azurerm_traffic_manager_profile_test = new azure.trafficmanager.Profile("test", {
+ *     dnsConfigs: [{
+ *         relativeName: random_id_server.hex,
+ *         ttl: 100,
+ *     }],
+ *     monitorConfigs: [{
+ *         path: "/",
+ *         port: 80,
+ *         protocol: "http",
+ *     }],
+ *     name: random_id_server.hex,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         environment: "Production",
+ *     },
+ *     trafficRoutingMethod: "Weighted",
+ * });
+ * const azurerm_traffic_manager_endpoint_test = new azure.trafficmanager.Endpoint("test", {
+ *     name: random_id_server.hex,
+ *     profileName: azurerm_traffic_manager_profile_test.name,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     target: "terraform.io",
+ *     type: "externalEndpoints",
+ *     weight: 100,
+ * });
+ * ```
  */
 export class Endpoint extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/trafficmanager/getGeographicalLocation.ts
+++ b/sdk/nodejs/trafficmanager/getGeographicalLocation.ts
@@ -6,6 +6,19 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access the ID of a specified Traffic Manager Geographical Location within the Geographical Hierarchy.
+ * 
+ * ## Example Usage (World)
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * 
+ * const azurerm_traffic_manager_geographical_location_test = pulumi.output(azure.trafficmanager.getGeographicalLocation({
+ *     name: "World",
+ * }));
+ * 
+ * export const locationCode = azurerm_traffic_manager_geographical_location_test.apply(__arg0 => __arg0.id);
+ * ```
  */
 export function getGeographicalLocation(args: GetGeographicalLocationArgs, opts?: pulumi.InvokeOptions): Promise<GetGeographicalLocationResult> {
     return pulumi.runtime.invoke("azure:trafficmanager/getGeographicalLocation:getGeographicalLocation", {

--- a/sdk/nodejs/trafficmanager/profile.ts
+++ b/sdk/nodejs/trafficmanager/profile.ts
@@ -6,6 +6,43 @@ import * as utilities from "../utilities";
 
 /**
  * Manages a Traffic Manager Profile to which multiple endpoints can be attached.
+ * 
+ * ## Example Usage
+ * 
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ * import * as random from "@pulumi/random";
+ * 
+ * const azurerm_resource_group_test = new azure.core.ResourceGroup("test", {
+ *     location: "West US",
+ *     name: "trafficmanagerProfile",
+ * });
+ * const random_id_server = new random.RandomId("server", {
+ *     byteLength: 8,
+ *     keepers: {
+ *         azi_id: 1,
+ *     },
+ * });
+ * const azurerm_traffic_manager_profile_test = new azure.trafficmanager.Profile("test", {
+ *     dnsConfigs: [{
+ *         relativeName: random_id_server.hex,
+ *         ttl: 100,
+ *     }],
+ *     monitorConfigs: [{
+ *         path: "/",
+ *         port: 80,
+ *         protocol: "http",
+ *     }],
+ *     name: random_id_server.hex,
+ *     resourceGroupName: azurerm_resource_group_test.name,
+ *     tags: {
+ *         environment: "Production",
+ *     },
+ *     trafficRoutingMethod: "Weighted",
+ * });
+ * ```
  */
 export class Profile extends pulumi.CustomResource {
     /**

--- a/sdk/python/pulumi_azure/compute/data_disk_attachment.py
+++ b/sdk/python/pulumi_azure/compute/data_disk_attachment.py
@@ -10,7 +10,7 @@ class DataDiskAttachment(pulumi.CustomResource):
     """
     Manages attaching a Disk to a Virtual Machine.
     
-    ~> **NOTE:** Data Disks can be attached either directly on the `azurerm_virtual_machine` resource, or using the `azurerm_virtual_machine_data_disk_attachment` resource - but the two cannot be used together. If both are used against the same Virtual Machine, spurious changes will occur.
+    > **NOTE:** Data Disks can be attached either directly on the `azurerm_virtual_machine` resource, or using the `azurerm_virtual_machine_data_disk_attachment` resource - but the two cannot be used together. If both are used against the same Virtual Machine, spurious changes will occur.
     
     -> **Please Note:** only Managed Disks are supported via this separate resource, Unmanaged Disks can be attached using the `storage_data_disk` block in the `azurerm_virtual_machine` resource.
     """

--- a/sdk/python/pulumi_azure/compute/extension.py
+++ b/sdk/python/pulumi_azure/compute/extension.py
@@ -11,7 +11,7 @@ class Extension(pulumi.CustomResource):
     Manages a Virtual Machine Extension to provide post deployment configuration
     and run automated tasks.
     
-    ~> **NOTE:** Custom Script Extensions for Linux & Windows require that the `commandToExecute` returns a `0` exit code to be classified as successfully deployed. You can achieve this by appending `exit 0` to the end of your `commandToExecute`.
+    > **NOTE:** Custom Script Extensions for Linux & Windows require that the `commandToExecute` returns a `0` exit code to be classified as successfully deployed. You can achieve this by appending `exit 0` to the end of your `commandToExecute`.
     
     -> **NOTE:** Custom Script Extensions require that the Azure Virtual Machine Guest Agent is running on the Virtual Machine.
     """

--- a/sdk/python/pulumi_azure/compute/scale_set.py
+++ b/sdk/python/pulumi_azure/compute/scale_set.py
@@ -10,7 +10,7 @@ class ScaleSet(pulumi.CustomResource):
     """
     Manage a virtual machine scale set.
     
-    ~> **Note:** All arguments including the administrator login and password will be stored in the raw state as plain-text.
+    > **Note:** All arguments including the administrator login and password will be stored in the raw state as plain-text.
     [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
     """
     def __init__(__self__, __name__, __opts__=None, automatic_os_upgrade=None, boot_diagnostics=None, eviction_policy=None, extensions=None, health_probe_id=None, identity=None, license_type=None, location=None, name=None, network_profiles=None, os_profile=None, os_profile_linux_config=None, os_profile_secrets=None, os_profile_windows_config=None, overprovision=None, plan=None, priority=None, resource_group_name=None, rolling_upgrade_policy=None, single_placement_group=None, sku=None, storage_profile_data_disks=None, storage_profile_image_reference=None, storage_profile_os_disk=None, tags=None, upgrade_policy_mode=None, zones=None):

--- a/sdk/python/pulumi_azure/compute/virtual_machine.py
+++ b/sdk/python/pulumi_azure/compute/virtual_machine.py
@@ -10,7 +10,7 @@ class VirtualMachine(pulumi.CustomResource):
     """
     Manages a Virtual Machine.
     
-    ~> **NOTE:** Data Disks can be attached either directly on the `azurerm_virtual_machine` resource, or using the `azurerm_virtual_machine_data_disk_attachment` resource - but the two cannot be used together. If both are used against the same Virtual Machine, spurious changes will occur.
+    > **NOTE:** Data Disks can be attached either directly on the `azurerm_virtual_machine` resource, or using the `azurerm_virtual_machine_data_disk_attachment` resource - but the two cannot be used together. If both are used against the same Virtual Machine, spurious changes will occur.
     """
     def __init__(__self__, __name__, __opts__=None, availability_set_id=None, boot_diagnostics=None, delete_data_disks_on_termination=None, delete_os_disk_on_termination=None, identity=None, license_type=None, location=None, name=None, network_interface_ids=None, os_profile=None, os_profile_linux_config=None, os_profile_secrets=None, os_profile_windows_config=None, plan=None, primary_network_interface_id=None, resource_group_name=None, storage_data_disks=None, storage_image_reference=None, storage_os_disk=None, tags=None, vm_size=None, zones=None):
         """Create a VirtualMachine resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_azure/containerservice/get_kubernetes_cluster.py
+++ b/sdk/python/pulumi_azure/containerservice/get_kubernetes_cluster.py
@@ -118,7 +118,7 @@ async def get_kubernetes_cluster(name=None, resource_group_name=None):
     """
     Use this data source to access information about an existing Managed Kubernetes Cluster (AKS).
     
-    ~> **Note:** All arguments including the client secret will be stored in the raw state as plain-text.
+    > **Note:** All arguments including the client secret will be stored in the raw state as plain-text.
     [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
     """
     __args__ = dict()

--- a/sdk/python/pulumi_azure/containerservice/kubernetes_cluster.py
+++ b/sdk/python/pulumi_azure/containerservice/kubernetes_cluster.py
@@ -10,7 +10,7 @@ class KubernetesCluster(pulumi.CustomResource):
     """
     Manages a Managed Kubernetes Cluster (also known as AKS / Azure Kubernetes Service)
     
-    ~> **Note:** All arguments including the client secret will be stored in the raw state as plain-text. [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
+    > **Note:** All arguments including the client secret will be stored in the raw state as plain-text. [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
     """
     def __init__(__self__, __name__, __opts__=None, addon_profile=None, agent_pool_profile=None, dns_prefix=None, kubernetes_version=None, linux_profile=None, location=None, name=None, network_profile=None, resource_group_name=None, role_based_access_control=None, service_principal=None, tags=None):
         """Create a KubernetesCluster resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_azure/containerservice/registry.py
+++ b/sdk/python/pulumi_azure/containerservice/registry.py
@@ -10,7 +10,7 @@ class Registry(pulumi.CustomResource):
     """
     Manages an Azure Container Registry.
     
-    ~> **Note:** All arguments including the access key will be stored in the raw state as plain-text.
+    > **Note:** All arguments including the access key will be stored in the raw state as plain-text.
     [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
     """
     def __init__(__self__, __name__, __opts__=None, admin_enabled=None, georeplication_locations=None, location=None, name=None, resource_group_name=None, sku=None, storage_account=None, storage_account_id=None, tags=None):

--- a/sdk/python/pulumi_azure/containerservice/service.py
+++ b/sdk/python/pulumi_azure/containerservice/service.py
@@ -10,10 +10,10 @@ class Service(pulumi.CustomResource):
     """
     Manages an Azure Container Service Instance
     
-    ~> **NOTE:** All arguments including the client secret will be stored in the raw state as plain-text.
+    > **NOTE:** All arguments including the client secret will be stored in the raw state as plain-text.
     [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
     
-    ~> **DEPRECATED:** [Azure Container Service (ACS) has been deprecated by Azure in favour of Azure (Managed) Kubernetes Service (AKS)](https://azure.microsoft.com/en-us/updates/azure-container-service-will-retire-on-january-31-2020/). Support for ACS will be removed in the next major version of the AzureRM Provider (2.0) - and we **strongly recommend** you consider using Azure Kubernetes Service (AKS) for new deployments.
+    > **DEPRECATED:** [Azure Container Service (ACS) has been deprecated by Azure in favour of Azure (Managed) Kubernetes Service (AKS)](https://azure.microsoft.com/en-us/updates/azure-container-service-will-retire-on-january-31-2020/). Support for ACS will be removed in the next major version of the AzureRM Provider (2.0) - and we **strongly recommend** you consider using Azure Kubernetes Service (AKS) for new deployments.
     
     ## Example Usage (DCOS)
     

--- a/sdk/python/pulumi_azure/core/template_deployment.py
+++ b/sdk/python/pulumi_azure/core/template_deployment.py
@@ -10,7 +10,7 @@ class TemplateDeployment(pulumi.CustomResource):
     """
     Manage a template deployment of resources
     
-    ~> **Note on ARM Template Deployments:** Due to the way the underlying Azure API is designed, Terraform can only manage the deployment of the ARM Template - and not any resources which are created by it.
+    > **Note on ARM Template Deployments:** Due to the way the underlying Azure API is designed, Terraform can only manage the deployment of the ARM Template - and not any resources which are created by it.
     This means that when deleting the `azurerm_template_deployment` resource, Terraform will only remove the reference to the deployment, whilst leaving any resources created by that ARM Template Deployment.
     One workaround for this is to use a unique Resource Group for each ARM Template Deployment, which means deleting the Resource Group would contain any resources created within it - however this isn't ideal. [More information](https://docs.microsoft.com/en-us/rest/api/resources/deployments#Deployments_Delete).
     """

--- a/sdk/python/pulumi_azure/datalake/store_file.py
+++ b/sdk/python/pulumi_azure/datalake/store_file.py
@@ -10,7 +10,7 @@ class StoreFile(pulumi.CustomResource):
     """
     Manage a Azure Data Lake Store File.
     
-    ~> **Note:** If you want to change the data in the remote file without changing the `local_file_path`, then 
+    > **Note:** If you want to change the data in the remote file without changing the `local_file_path`, then 
     taint the resource so the `azurerm_data_lake_store_file` gets recreated with the new data.
     """
     def __init__(__self__, __name__, __opts__=None, account_name=None, local_file_path=None, remote_file_path=None):

--- a/sdk/python/pulumi_azure/eventhub/event_grid_topic.py
+++ b/sdk/python/pulumi_azure/eventhub/event_grid_topic.py
@@ -10,7 +10,7 @@ class EventGridTopic(pulumi.CustomResource):
     """
     Manages an EventGrid Topic
     
-    ~> **Note:** at this time EventGrid Topic's are only available in a limited number of regions.
+    > **Note:** at this time EventGrid Topic's are only available in a limited number of regions.
     """
     def __init__(__self__, __name__, __opts__=None, location=None, name=None, resource_group_name=None, tags=None):
         """Create a EventGridTopic resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_azure/keyvault/access_policy.py
+++ b/sdk/python/pulumi_azure/keyvault/access_policy.py
@@ -10,7 +10,7 @@ class AccessPolicy(pulumi.CustomResource):
     """
     Manages a Key Vault Access Policy.
     
-    ~> **NOTE:** It's possible to define Key Vault Access Policies both within the `azurerm_key_vault` resource via the `access_policy` block and by using the `azurerm_key_vault_access_policy` resource. However it's not possible to use both methods to manage Access Policies within a KeyVault, since there'll be conflicts.
+    > **NOTE:** It's possible to define Key Vault Access Policies both within the `azurerm_key_vault` resource via the `access_policy` block and by using the `azurerm_key_vault_access_policy` resource. However it's not possible to use both methods to manage Access Policies within a KeyVault, since there'll be conflicts.
     
     -> **NOTE:** Azure permits a maximum of 16 Access Policies per Key Vault - [more information can be found in this document](https://docs.microsoft.com/en-us/azure/key-vault/key-vault-secure-your-key-vault#data-plane-access-control).
     """

--- a/sdk/python/pulumi_azure/keyvault/get_key.py
+++ b/sdk/python/pulumi_azure/keyvault/get_key.py
@@ -64,7 +64,7 @@ async def get_key(name=None, vault_uri=None):
     """
     Use this data source to access information about an existing Key Vault Key.
     
-    ~> **Note:** All arguments including the secret value will be stored in the raw state as plain-text.
+    > **Note:** All arguments including the secret value will be stored in the raw state as plain-text.
     [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
     """
     __args__ = dict()

--- a/sdk/python/pulumi_azure/keyvault/get_secret.py
+++ b/sdk/python/pulumi_azure/keyvault/get_secret.py
@@ -46,7 +46,7 @@ async def get_secret(name=None, vault_uri=None):
     """
     Use this data source to access information about an existing Key Vault Secret.
     
-    ~> **Note:** All arguments including the secret value will be stored in the raw state as plain-text.
+    > **Note:** All arguments including the secret value will be stored in the raw state as plain-text.
     [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
     """
     __args__ = dict()

--- a/sdk/python/pulumi_azure/keyvault/key_vault.py
+++ b/sdk/python/pulumi_azure/keyvault/key_vault.py
@@ -10,7 +10,7 @@ class KeyVault(pulumi.CustomResource):
     """
     Manages a Key Vault.
     
-    ~> **NOTE:** It's possible to define Key Vault Access Policies both within the `azurerm_key_vault` resource via the `access_policy` block and by using the `azurerm_key_vault_access_policy` resource. However it's not possible to use both methods to manage Access Policies within a KeyVault, since there'll be conflicts.
+    > **NOTE:** It's possible to define Key Vault Access Policies both within the `azurerm_key_vault` resource via the `access_policy` block and by using the `azurerm_key_vault_access_policy` resource. However it's not possible to use both methods to manage Access Policies within a KeyVault, since there'll be conflicts.
     """
     def __init__(__self__, __name__, __opts__=None, access_policies=None, enabled_for_deployment=None, enabled_for_disk_encryption=None, enabled_for_template_deployment=None, location=None, name=None, network_acls=None, resource_group_name=None, sku=None, tags=None, tenant_id=None):
         """Create a KeyVault resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_azure/keyvault/secret.py
+++ b/sdk/python/pulumi_azure/keyvault/secret.py
@@ -10,7 +10,7 @@ class Secret(pulumi.CustomResource):
     """
     Manages a Key Vault Secret.
     
-    ~> **Note:** All arguments including the secret value will be stored in the raw state as plain-text.
+    > **Note:** All arguments including the secret value will be stored in the raw state as plain-text.
     [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
     """
     def __init__(__self__, __name__, __opts__=None, content_type=None, name=None, tags=None, value=None, vault_uri=None):

--- a/sdk/python/pulumi_azure/lb/backend_address_pool.py
+++ b/sdk/python/pulumi_azure/lb/backend_address_pool.py
@@ -10,7 +10,7 @@ class BackendAddressPool(pulumi.CustomResource):
     """
     Manage a Load Balancer Backend Address Pool.
     
-    ~> **NOTE:** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
+    > **NOTE:** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
     """
     def __init__(__self__, __name__, __opts__=None, loadbalancer_id=None, location=None, name=None, resource_group_name=None):
         """Create a BackendAddressPool resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_azure/lb/nat_pool.py
+++ b/sdk/python/pulumi_azure/lb/nat_pool.py
@@ -10,7 +10,7 @@ class NatPool(pulumi.CustomResource):
     """
     Manages a Load Balancer NAT pool.
     
-    ~> **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
+    > **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
     """
     def __init__(__self__, __name__, __opts__=None, backend_port=None, frontend_ip_configuration_name=None, frontend_port_end=None, frontend_port_start=None, loadbalancer_id=None, location=None, name=None, protocol=None, resource_group_name=None):
         """Create a NatPool resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_azure/lb/nat_rule.py
+++ b/sdk/python/pulumi_azure/lb/nat_rule.py
@@ -10,7 +10,7 @@ class NatRule(pulumi.CustomResource):
     """
     Manages a Load Balancer NAT Rule.
     
-    ~> **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
+    > **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
     """
     def __init__(__self__, __name__, __opts__=None, backend_port=None, enable_floating_ip=None, frontend_ip_configuration_name=None, frontend_port=None, loadbalancer_id=None, location=None, name=None, protocol=None, resource_group_name=None):
         """Create a NatRule resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_azure/lb/probe.py
+++ b/sdk/python/pulumi_azure/lb/probe.py
@@ -10,7 +10,7 @@ class Probe(pulumi.CustomResource):
     """
     Manages a LoadBalancer Probe Resource.
     
-    ~> **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
+    > **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
     """
     def __init__(__self__, __name__, __opts__=None, interval_in_seconds=None, loadbalancer_id=None, location=None, name=None, number_of_probes=None, port=None, protocol=None, request_path=None, resource_group_name=None):
         """Create a Probe resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_azure/lb/rule.py
+++ b/sdk/python/pulumi_azure/lb/rule.py
@@ -10,7 +10,7 @@ class Rule(pulumi.CustomResource):
     """
     Manages a Load Balancer Rule.
     
-    ~> **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
+    > **NOTE** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
     """
     def __init__(__self__, __name__, __opts__=None, backend_address_pool_id=None, backend_port=None, enable_floating_ip=None, frontend_ip_configuration_name=None, frontend_port=None, idle_timeout_in_minutes=None, load_distribution=None, loadbalancer_id=None, location=None, name=None, probe_id=None, protocol=None, resource_group_name=None):
         """Create a Rule resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_azure/network/network_security_group.py
+++ b/sdk/python/pulumi_azure/network/network_security_group.py
@@ -10,7 +10,7 @@ class NetworkSecurityGroup(pulumi.CustomResource):
     """
     Manages a network security group that contains a list of network security rules.  Network security groups enable inbound or outbound traffic to be enabled or denied.
     
-    ~> **NOTE on Network Security Groups and Network Security Rules:** Terraform currently
+    > **NOTE on Network Security Groups and Network Security Rules:** Terraform currently
     provides both a standalone Network Security Rule resource, and allows for Network Security Rules to be defined in-line within the Network Security Group resource.
     At this time you cannot use a Network Security Group with in-line Network Security Rules in conjunction with any Network Security Rule resources. Doing so will cause a conflict of rule settings and will overwrite rules.
     """

--- a/sdk/python/pulumi_azure/network/network_security_rule.py
+++ b/sdk/python/pulumi_azure/network/network_security_rule.py
@@ -10,7 +10,7 @@ class NetworkSecurityRule(pulumi.CustomResource):
     """
     Manages a Network Security Rule.
     
-    ~> **NOTE on Network Security Groups and Network Security Rules:** Terraform currently
+    > **NOTE on Network Security Groups and Network Security Rules:** Terraform currently
     provides both a standalone Network Security Rule resource, and allows for Network Security Rules to be defined in-line within the Network Security Group resource.
     At this time you cannot use a Network Security Group with in-line Network Security Rules in conjunction with any Network Security Rule resources. Doing so will cause a conflict of rule settings and will overwrite rules.
     """

--- a/sdk/python/pulumi_azure/network/subnet.py
+++ b/sdk/python/pulumi_azure/network/subnet.py
@@ -10,7 +10,7 @@ class Subnet(pulumi.CustomResource):
     """
     Manages a subnet. Subnets represent network segments within the IP space defined by the virtual network.
     
-    ~> **NOTE on Virtual Networks and Subnet's:** Terraform currently
+    > **NOTE on Virtual Networks and Subnet's:** Terraform currently
     provides both a standalone Subnet resource, and allows for Subnets to be defined in-line within the Virtual Network resource.
     At this time you cannot use a Virtual Network with in-line Subnets in conjunction with any Subnet resources. Doing so will cause a conflict of Subnet configurations and will overwrite Subnet's.
     """

--- a/sdk/python/pulumi_azure/network/virtual_network.py
+++ b/sdk/python/pulumi_azure/network/virtual_network.py
@@ -11,7 +11,7 @@ class VirtualNetwork(pulumi.CustomResource):
     Manages a virtual network including any configured subnets. Each subnet can
     optionally be configured with a security group to be associated with the subnet.
     
-    ~> **NOTE on Virtual Networks and Subnet's:** Terraform currently
+    > **NOTE on Virtual Networks and Subnet's:** Terraform currently
     provides both a standalone Subnet resource, and allows for Subnets to be defined in-line within the Virtual Network resource.
     At this time you cannot use a Virtual Network with in-line Subnets in conjunction with any Subnet resources. Doing so will cause a conflict of Subnet configurations and will overwrite Subnet's.
     """

--- a/sdk/python/pulumi_azure/scheduler/get_job_collection.py
+++ b/sdk/python/pulumi_azure/scheduler/get_job_collection.py
@@ -52,7 +52,7 @@ async def get_job_collection(name=None, resource_group_name=None):
     """
     Use this data source to access information about an existing Scheduler Job Collection.
     
-    ~> **NOTE:** Support for Scheduler Job Collections has been deprecated by Microsoft in favour of Logic Apps ([more information can be found at this link](https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps)) - as such we plan to remove support for this data source as a part of version 2.0 of the AzureRM Provider.
+    > **NOTE:** Support for Scheduler Job Collections has been deprecated by Microsoft in favour of Logic Apps ([more information can be found at this link](https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps)) - as such we plan to remove support for this data source as a part of version 2.0 of the AzureRM Provider.
     """
     __args__ = dict()
 

--- a/sdk/python/pulumi_azure/scheduler/job.py
+++ b/sdk/python/pulumi_azure/scheduler/job.py
@@ -10,7 +10,7 @@ class Job(pulumi.CustomResource):
     """
     Manages a Scheduler Job.
     
-    ~> **NOTE:** Support for Scheduler Job has been deprecated by Microsoft in favour of Logic Apps ([more information can be found at this link](https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps)) - as such we plan to remove support for this resource as a part of version 2.0 of the AzureRM Provider.
+    > **NOTE:** Support for Scheduler Job has been deprecated by Microsoft in favour of Logic Apps ([more information can be found at this link](https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps)) - as such we plan to remove support for this resource as a part of version 2.0 of the AzureRM Provider.
     """
     def __init__(__self__, __name__, __opts__=None, action_storage_queue=None, action_web=None, error_action_storage_queue=None, error_action_web=None, job_collection_name=None, name=None, recurrence=None, resource_group_name=None, retry=None, start_time=None, state=None):
         """Create a Job resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_azure/scheduler/job_collection.py
+++ b/sdk/python/pulumi_azure/scheduler/job_collection.py
@@ -10,7 +10,7 @@ class JobCollection(pulumi.CustomResource):
     """
     Manages a Scheduler Job Collection.
     
-    ~> **NOTE:** Support for Scheduler Job Collections has been deprecated by Microsoft in favour of Logic Apps ([more information can be found at this link](https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps)) - as such we plan to remove support for this resource as a part of version 2.0 of the AzureRM Provider.
+    > **NOTE:** Support for Scheduler Job Collections has been deprecated by Microsoft in favour of Logic Apps ([more information can be found at this link](https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps)) - as such we plan to remove support for this resource as a part of version 2.0 of the AzureRM Provider.
     """
     def __init__(__self__, __name__, __opts__=None, location=None, name=None, quota=None, resource_group_name=None, sku=None, state=None, tags=None):
         """Create a JobCollection resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_azure/securitycenter/contact.py
+++ b/sdk/python/pulumi_azure/securitycenter/contact.py
@@ -10,7 +10,7 @@ class Contact(pulumi.CustomResource):
     """
     Manages the subscription's Security Center Contact.
     
-    ~> **NOTE:** Owner access permission is required. 
+    > **NOTE:** Owner access permission is required. 
     """
     def __init__(__self__, __name__, __opts__=None, alert_notifications=None, alerts_to_admins=None, email=None, phone=None):
         """Create a Contact resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_azure/securitycenter/subscription_pricing.py
+++ b/sdk/python/pulumi_azure/securitycenter/subscription_pricing.py
@@ -10,9 +10,9 @@ class SubscriptionPricing(pulumi.CustomResource):
     """
     Manages the Pricing Tier for Azure Security Center in the current subscription.
     
-    ~> **NOTE:** This resource requires the `Owner` permission on the Subscription.
+    > **NOTE:** This resource requires the `Owner` permission on the Subscription.
     
-    ~> **NOTE:** Deletion of this resource does not change or reset the pricing tier to `Free`
+    > **NOTE:** Deletion of this resource does not change or reset the pricing tier to `Free`
     """
     def __init__(__self__, __name__, __opts__=None, tier=None):
         """Create a SubscriptionPricing resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_azure/securitycenter/workspace.py
+++ b/sdk/python/pulumi_azure/securitycenter/workspace.py
@@ -10,9 +10,9 @@ class Workspace(pulumi.CustomResource):
     """
     Manages the subscription's Security Center Workspace.
     
-    ~> **NOTE:** Owner access permission is required.
+    > **NOTE:** Owner access permission is required.
     
-    ~> **NOTE:** The subscription's pricing model can not be `Free` for this to have any affect.
+    > **NOTE:** The subscription's pricing model can not be `Free` for this to have any affect.
     """
     def __init__(__self__, __name__, __opts__=None, scope=None, workspace_id=None):
         """Create a Workspace resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_azure/sql/elastic_pool.py
+++ b/sdk/python/pulumi_azure/sql/elastic_pool.py
@@ -10,7 +10,7 @@ class ElasticPool(pulumi.CustomResource):
     """
     Allows you to manage an Azure SQL Elastic Pool.
     
-    ~> **NOTE:** -  This version of the `Elasticpool` resource is being **deprecated** and should no longer be used. Please use the azurerm_mssql_elasticpool version instead.
+    > **NOTE:** -  This version of the `Elasticpool` resource is being **deprecated** and should no longer be used. Please use the azurerm_mssql_elasticpool version instead.
     """
     def __init__(__self__, __name__, __opts__=None, db_dtu_max=None, db_dtu_min=None, dtu=None, edition=None, location=None, name=None, pool_size=None, resource_group_name=None, server_name=None, tags=None):
         """Create a ElasticPool resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_azure/sql/sql_server.py
+++ b/sdk/python/pulumi_azure/sql/sql_server.py
@@ -10,7 +10,7 @@ class SqlServer(pulumi.CustomResource):
     """
     Manages a SQL Azure Database Server.
     
-    ~> **Note:** All arguments including the administrator login and password will be stored in the raw state as plain-text.
+    > **Note:** All arguments including the administrator login and password will be stored in the raw state as plain-text.
     [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
     """
     def __init__(__self__, __name__, __opts__=None, administrator_login=None, administrator_login_password=None, location=None, name=None, resource_group_name=None, tags=None, version=None):


### PR DESCRIPTION
This ingests the latest Terraform code-gen, bringing in the
ability to convert HCL examples to Pulumi in the API docs.

Notes on metrics:

- 461 docs sections ignored
- 22 code blocks failed to convert
- 246 code blocks successfully converted