### PR TITLE
Update Gopkg.{lock,template.toml,toml} for dep 0.5

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,11 +2,14 @@
 
 
 [[projects]]
+  digest = "1:d9c7a9e4dcfb8e57fe0fee666853c3901c229ceee750bf8909b57e231e88be32"
   name = "contrib.go.opencensus.io/exporter/ocagent"
   packages = ["."]
+  pruneopts = ""
   revision = "0758abcb21781452e3f21b8d7944e0da2a16d736"
 
 [[projects]]
+  digest = "1:b14cc2e6024388041a76e0ae27ca54d8e0ae7408256c5fbbbcb9935398fde1a4"
   name = "github.com/Azure/azure-sdk-for-go"
   packages = [
     "profiles/2017-03-09/resources/mgmt/resources",
@@ -67,21 +70,25 @@
     "services/trafficmanager/mgmt/2017-05-01/trafficmanager",
     "services/web/mgmt/2018-02-01/web",
     "storage",
-    "version"
+    "version",
   ]
+  pruneopts = ""
   revision = "1951233eb944a49aa5f7278cba8e3e32a8c958af"
   version = "v24.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:6978a38432a017763a148afbc7ce6491734b54292af7d3e969d84d2e9dd242e2"
   name = "github.com/Azure/go-ansiterm"
   packages = [
     ".",
-    "winterm"
+    "winterm",
   ]
+  pruneopts = ""
   revision = "d6e3b3328b783f23731bc4d058875b0371ff8109"
 
 [[projects]]
+  digest = "1:2034a827d81a693fbd70e8dd31e302580b26604bd721f0c8adc62305b4f1b382"
   name = "github.com/Azure/go-autorest"
   packages = [
     "autorest",
@@ -92,44 +99,58 @@
     "autorest/to",
     "autorest/validation",
     "logger",
-    "tracing"
+    "tracing",
   ]
+  pruneopts = ""
   revision = "f401b1ccc8eb505927fae7a0c7f6406d37ca1c7e"
   version = "v11.2.8"
 
 [[projects]]
+  digest = "1:33f920ba428942560c22c0e145127dc09a52c52d64eac284daea6b0926fab0d1"
   name = "github.com/Nvveen/Gotty"
   packages = ["."]
+  pruneopts = ""
   revision = "a8b993ba6abdb0e0c12b0125c603323a71c7790c"
   source = "https://github.com/ijc25/Gotty"
 
 [[projects]]
+  digest = "1:9a3c631555e0351fdc4e696577bb63afd90c399d782a8462dba9d100d7021db3"
   name = "github.com/Sirupsen/logrus"
   packages = ["."]
+  pruneopts = ""
   revision = "e1e72e9de974bd926e5c56f83753fba2df402ce5"
   version = "v1.3.0"
 
 [[projects]]
+  digest = "1:61c24bdb660a326b420d5422c4fd124041b4aac88e212c6ac75f3a57b0b9cada"
   name = "github.com/agext/levenshtein"
   packages = ["."]
+  pruneopts = ""
   revision = "5f10fee965225ac1eecdc234c09daf5cd9e7f7b6"
 
 [[projects]]
+  digest = "1:a93eae425b2bb209ecba9f76a8e513bb11c67fc46aba4d7465c0d35a7d94ace3"
   name = "github.com/apparentlymart/go-cidr"
   packages = ["cidr"]
+  pruneopts = ""
   revision = "7e4b007599d4e2076d9a81be723b3912852dda2c"
 
 [[projects]]
+  digest = "1:ee5a076f487c362d53eacd9442ee2f6656ff3e0739256043d96fac4fccf7b9a2"
   name = "github.com/apparentlymart/go-textseg"
   packages = ["textseg"]
+  pruneopts = ""
   revision = "b836f5c4d331d1945a2fead7188db25432d73b69"
 
 [[projects]]
+  digest = "1:2a1e6af234d7de1ccf4504f397cf7cfa82922ee59b29252e3c34cb38d0b91989"
   name = "github.com/armon/go-radix"
   packages = ["."]
+  pruneopts = ""
   revision = "1fca145dffbcaa8fe914309b1ec0cfc67500fe61"
 
 [[projects]]
+  digest = "1:ee9c5ca7855f933908f0da4aae9aa47cc56390983bbe6b19cdb9f8b755e6741a"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -159,27 +180,35 @@
     "private/protocol/xml/xmlutil",
     "service/cloudwatchlogs",
     "service/s3",
-    "service/sts"
+    "service/sts",
   ]
+  pruneopts = ""
   revision = "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3"
   version = "v1.8.34"
 
 [[projects]]
+  digest = "1:98e84060475ed245c3b355042afd43a74aa7d32efe50658f4f995977916f9fc3"
   name = "github.com/bgentry/go-netrc"
   packages = ["netrc"]
+  pruneopts = ""
   revision = "9fd32a8b3d3d3f9d43c341bfe098430e07609480"
 
 [[projects]]
+  digest = "1:15ceb8ca7a71db4c426d8aef1909ea074f6840efa163490bb2798f475624e4ae"
   name = "github.com/bgentry/speakeasy"
   packages = ["."]
+  pruneopts = ""
   revision = "4aabc24848ce5fd31929f7d1e4ea74d3709c14cd"
 
 [[projects]]
+  digest = "1:79421244ba5848aae4b0a5c41e633a04e4894cb0b164a219dc8c15ec7facb7f1"
   name = "github.com/blang/semver"
   packages = ["."]
+  pruneopts = ""
   revision = "2ee87856327ba09384cabd113bc6b5d174e9ec0f"
 
 [[projects]]
+  digest = "1:f050a19b5943d0ab8caf21f1d1177823bd00d23bd244cdcbdaae16d2bb61f4f2"
   name = "github.com/census-instrumentation/opencensus-proto"
   packages = [
     "gen-go/agent/common/v1",
@@ -187,56 +216,72 @@
     "gen-go/agent/trace/v1",
     "gen-go/metrics/v1",
     "gen-go/resource/v1",
-    "gen-go/trace/v1"
+    "gen-go/trace/v1",
   ]
+  pruneopts = ""
   revision = "ba49f56771b83cff7bea7f34d1236fc139dbc471"
 
 [[projects]]
   branch = "master"
+  digest = "1:c46fd324e7902268373e1b337436a6377c196e2dbd7b35624c6256d29d494e78"
   name = "github.com/codahale/hdrhistogram"
   packages = ["."]
+  pruneopts = ""
   revision = "3a0bb77429bd3a61596f5e8a3172445844342120"
 
 [[projects]]
+  digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = ""
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
 
 [[projects]]
+  digest = "1:5bf490e81a967812c53eee5df49b52cb25bb5882167a655fb3580679d0bc3a5e"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
+  pruneopts = ""
   revision = "f0777076321ab64f6efc15a82d9d23b98539b943"
 
 [[projects]]
+  digest = "1:654ac9799e7a8a586d8690bb2229a4f3408bbfe2c5494bf4dfe043053eeb5496"
   name = "github.com/dimchansky/utfbom"
   packages = ["."]
+  pruneopts = ""
   revision = "6c6132ff69f0f6c088739067407b5d32c52e1d0f"
 
 [[projects]]
+  digest = "1:82d115eea49c038ccbcd74608c4815e7addc2f30ce861544d725d2770900c280"
   name = "github.com/djherbis/times"
   packages = ["."]
+  pruneopts = ""
   revision = "847c5208d8924cea0acea3376ff62aede93afe39"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:a60acfb78bd12ce7b2101f0cc0bca8cd83db6aa60bf1e6ddfd33e83013083ddf"
   name = "github.com/docker/docker"
   packages = [
     "pkg/term",
-    "pkg/term/windows"
+    "pkg/term/windows",
   ]
+  pruneopts = ""
   revision = "092cba3727bb9b4a2f0e922cd6c0f93ea270e363"
   version = "v1.13.1"
 
 [[projects]]
+  digest = "1:f1a75a8e00244e5ea77ff274baa9559eb877437b240ee7b278f3fc560d9f08bf"
   name = "github.com/dustin/go-humanize"
   packages = [
     ".",
-    "english"
+    "english",
   ]
+  pruneopts = ""
   revision = "9f541cc9db5d55bce703bd99987c9d5cb8eea45e"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:f21c1a68814ffc02db479adbd973c710e0ece6150ddc0726655c0a2048299152"
   name = "github.com/emirpasic/gods"
   packages = [
     "containers",
@@ -244,34 +289,52 @@
     "lists/arraylist",
     "trees",
     "trees/binaryheap",
-    "utils"
+    "utils",
   ]
+  pruneopts = ""
   revision = "1615341f118ae12f353cc8a983f35b584342c9b3"
   version = "v1.12.0"
 
 [[projects]]
+  digest = "1:eeba285fdc8e024e3305d5efd2a85e9e46097172873f9c841ae575527e6affbe"
   name = "github.com/fatih/color"
   packages = ["."]
+  pruneopts = ""
   revision = "3f9d52f7176a6927daacff70a3e8d1dc2025c53e"
 
 [[projects]]
   branch = "master"
+  digest = "1:f406e345c8ef92f06e3e02f72dec4415c6f0721da43bc7f47ecd65899a417e2f"
   name = "github.com/gedex/inflector"
   packages = ["."]
+  pruneopts = ""
   revision = "16278e9db8130ac7ec405dc174cfb94344f16325"
 
 [[projects]]
+  digest = "1:1434108d6ac56a79973d5ec37d9ceadac25af1a20cebe3bf4b841d38559f04bb"
   name = "github.com/go-ini/ini"
   packages = ["."]
+  pruneopts = ""
   revision = "766e555c68dc8bda90d197ee8946c37519c19409"
 
 [[projects]]
+  digest = "1:ac02823572830fb544c7a94152465ca7833aaf1f186aeb4445ce9d34aacfcc4a"
+  name = "github.com/gofrs/flock"
+  packages = ["."]
+  pruneopts = ""
+  revision = "7f43ea2e6a643ad441fc12d0ecc0d3388b300c53"
+  version = "v0.7.0"
+
+[[projects]]
   branch = "master"
+  digest = "1:107b233e45174dbab5b1324201d092ea9448e58243ab9f039e4c0f332e121e3a"
   name = "github.com/golang/glog"
   packages = ["."]
+  pruneopts = ""
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
+  digest = "1:66c4f0faff05a23bbb921be3f21838d7d58e69f4d102e23347ea8080675d1efa"
   name = "github.com/golang/protobuf"
   packages = [
     "jsonpb",
@@ -286,76 +349,97 @@
     "ptypes/empty",
     "ptypes/struct",
     "ptypes/timestamp",
-    "ptypes/wrappers"
+    "ptypes/wrappers",
   ]
-  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
-  version = "v1.2.0"
+  pruneopts = ""
+  revision = "1d3f30b51784bec5aad268e59fd3c2fc1c2fe73f"
 
 [[projects]]
+  digest = "1:0f2e8eeeeb9bac0fd1d405dddd3d15cc9053a6c8fcceead6764b88d43c87963e"
   name = "github.com/google/uuid"
   packages = ["."]
+  pruneopts = ""
   revision = "7e072fc3a7be179aee6d3359e46015aa8c995314"
 
 [[projects]]
+  digest = "1:67fa7fe174716264688b0d1c69ee4bfa75191d311ff8080f4b06caffbcc17ba6"
   name = "github.com/grpc-ecosystem/grpc-gateway"
   packages = [
     "runtime",
     "runtime/internal",
-    "utilities"
+    "utilities",
   ]
+  pruneopts = ""
   revision = "719aaadb1a4f7b11606d454e266fe5c5f789796f"
 
 [[projects]]
   branch = "master"
+  digest = "1:0c93b4970c254d3f8f76c3e8eb72571d6f24a15415f9c418ecb0801ba5765a90"
   name = "github.com/grpc-ecosystem/grpc-opentracing"
   packages = ["go/otgrpc"]
+  pruneopts = ""
   revision = "8e809c8a86450a29b90dcc9efbf062d0fe6d9746"
 
 [[projects]]
+  digest = "1:4fe55793760295fbef367890352b720784243e0ad19b5ee242519a4682bb9ef8"
   name = "github.com/hashicorp/errwrap"
   packages = ["."]
+  pruneopts = ""
   revision = "d6c0cd88035724dd42e0f335ae30161c20575ecc"
 
 [[projects]]
+  digest = "1:1536cc1581aa126330ce8cbd52ad94458f3933c4b7a522ffc52625a3be36af39"
   name = "github.com/hashicorp/go-azure-helpers"
   packages = [
     "authentication",
     "resourceproviders",
     "response",
-    "storage"
+    "storage",
   ]
+  pruneopts = ""
   revision = "38db96513363e6bd8832cae8918dbdf27b8af21d"
   version = "0.3.1"
 
 [[projects]]
+  digest = "1:ae263e6b149fb7aadfc0f2284a8891cc3b9d2700e58b9a613fecf70fcc6e495d"
   name = "github.com/hashicorp/go-cleanhttp"
   packages = ["."]
+  pruneopts = ""
   revision = "3573b8b52aa7b37b9358d966a898feb387f62437"
 
 [[projects]]
+  digest = "1:a85f7db008793246ec79867ca5f6a55c3f82a17d3c6b569743684ea4cf220568"
   name = "github.com/hashicorp/go-getter"
   packages = [
     ".",
-    "helper/url"
+    "helper/url",
   ]
+  pruneopts = ""
   revision = "64040d90d4ab861e7e833d689dc76a0f176d8dec"
 
 [[projects]]
+  digest = "1:2eec3384eaeed0ce9282113b0745f3ebecc7dcd6fc24db4c8b0274436483bf79"
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
+  pruneopts = ""
   revision = "d30f09973e19c1dfcd120b2d9c4f168e68d6b5d5"
 
 [[projects]]
+  digest = "1:c7d71f1c9043297e1e7a732c5fd3957d3bf54fab6d4b9168f616b7414f63986c"
   name = "github.com/hashicorp/go-uuid"
   packages = ["."]
+  pruneopts = ""
   revision = "36289988d83ca270bc07c234c36f364b0dd9c9a7"
 
 [[projects]]
+  digest = "1:91d67eb3c741f529114f8a66d7b329180bb9999e8e7633763e42972fe0235b5c"
   name = "github.com/hashicorp/go-version"
   packages = ["."]
+  pruneopts = ""
   revision = "e96d3840402619007766590ecea8dd7af1292276"
 
 [[projects]]
+  digest = "1:3987769d49296c4250c0e2311e62c3fe0ced8a46eca3f23eb3c242b53ec8ec27"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -366,11 +450,13 @@
     "hcl/token",
     "json/parser",
     "json/scanner",
-    "json/token"
+    "json/token",
   ]
+  pruneopts = ""
   revision = "a4b07c25de5ff55ad3b8936cea69a79a3d95a855"
 
 [[projects]]
+  digest = "1:528ad0f3a66f6ea32e417c787d46d14cb7d01c30b42513f74cb7307231b36648"
   name = "github.com/hashicorp/hcl2"
   packages = [
     "gohcl",
@@ -378,26 +464,32 @@
     "hcl/hclsyntax",
     "hcl/json",
     "hcldec",
-    "hclparse"
+    "hclparse",
   ]
+  pruneopts = ""
   revision = "998a3053e207853cf21b90e451772fbecfd1d1bc"
 
 [[projects]]
+  digest = "1:6bcbc684b1aa6c81f095535d2451ac72bfe504f0eee1e29d3af500bd4c608738"
   name = "github.com/hashicorp/hil"
   packages = [
     ".",
     "ast",
     "parser",
-    "scanner"
+    "scanner",
   ]
+  pruneopts = ""
   revision = "fac2259da677551de1fb92b844c4d020a38d8468"
 
 [[projects]]
+  digest = "1:8b7dd3b581147b44cf522c66894b9119ab845c346d8f124d83f77ab499cf7ca3"
   name = "github.com/hashicorp/logutils"
   packages = ["."]
+  pruneopts = ""
   revision = "0dc08b1671f34c4250ce212759ebd880f743d883"
 
 [[projects]]
+  digest = "1:65ba3993bb3bd77819b24bb49d753d00239016760d571dd3ed8e77328fa85a22"
   name = "github.com/hashicorp/terraform"
   packages = [
     "config",
@@ -426,153 +518,203 @@
     "svchost/disco",
     "terraform",
     "tfdiags",
-    "version"
+    "version",
   ]
+  pruneopts = ""
   revision = "4e44b41c8bc1b533d14f9939690adf09e3d2a2be"
   version = "v0.11.9"
 
 [[projects]]
+  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
+  pruneopts = ""
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:95abc4eba158a39873bd4fabdee576d0ae13826b550f8b710881d80ae4093a0f"
   name = "github.com/jbenet/go-context"
   packages = ["io"]
+  pruneopts = ""
   revision = "d14ea06fba99483203c19d92cfcd13ebe73135f4"
 
 [[projects]]
+  digest = "1:c4239c01bae2646fbc5d0120deb86b8cabc40d01bde261b9cea497fb6f8542ad"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
+  pruneopts = ""
   revision = "bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d"
 
 [[projects]]
   branch = "master"
+  digest = "1:63e7368fcf6b54804076eaec26fd9cf0c4466166b272393db4b93102e1e962df"
   name = "github.com/kballard/go-shellquote"
   packages = ["."]
+  pruneopts = ""
   revision = "95032a82bc518f77982ea72343cc1ade730072f0"
 
 [[projects]]
+  digest = "1:41e0bed5df4f9fd04c418bf9b6b7179b3671e416ad6175332601ca1c8dc74606"
   name = "github.com/kevinburke/ssh_config"
   packages = ["."]
+  pruneopts = ""
   revision = "81db2a75821ed34e682567d48be488a1c3121088"
   version = "0.5"
 
 [[projects]]
+  digest = "1:6a874e3ddfb9db2b42bd8c85b6875407c702fa868eed20634ff489bc896ccfd3"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
+  pruneopts = ""
   revision = "5c8c8bd35d3832f5d134ae1e1e375b69a4d25242"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:ef790a479b552a5489cda34f006c2b4f6df4f825fd0c24b733f106ef869b25c6"
   name = "github.com/marstr/guid"
   packages = ["."]
+  pruneopts = ""
   revision = "8bdf7d1a087ccc975cf37dd6507da50698fd19ca"
 
 [[projects]]
+  digest = "1:0f79867e9aac8a4e20bc1b0956d81f340da9ade9bcc00a4bfb1ebd738c152f7a"
   name = "github.com/mattn/go-colorable"
   packages = ["."]
+  pruneopts = ""
   revision = "efa589957cd060542a26d2dd7832fd6a6c6c3ade"
 
 [[projects]]
+  digest = "1:78229b46ddb7434f881390029bd1af7661294af31f6802e0e1bedaad4ab0af3c"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
+  pruneopts = ""
   revision = "a5cdd64afdee435007ee3e9f6ed4684af949d568"
 
 [[projects]]
   branch = "master"
+  digest = "1:50416da10e189bc201e122e20078fb8e680a439cbdd24aaece06c434b4415b60"
   name = "github.com/mgutz/ansi"
   packages = ["."]
+  pruneopts = ""
   revision = "9520e82c474b0a04dd04f8a40959027271bab992"
 
 [[projects]]
+  digest = "1:bb7613fa9de3f211f6f09630e6c0a493285c1d2a162abf0d617bd522c3dd622a"
   name = "github.com/mitchellh/cli"
   packages = ["."]
+  pruneopts = ""
   revision = "3d22a244be8aa6fb16ac24af0e195c08b7d973aa"
 
 [[projects]]
+  digest = "1:ddc46aaac89d6465fd0b5fd13ab1931d0ff5c2863937e9fccdbc14c991b50c06"
   name = "github.com/mitchellh/copystructure"
   packages = ["."]
-  revision = "d23ffcb85de31694d6ccaa23ccb4a03e55c1303f"
+  pruneopts = ""
+  revision = "9a1b6f44e8da0e0e374624fb0a825a231b00c537"
 
 [[projects]]
+  digest = "1:096a8a9182648da3d00ff243b88407838902b6703fc12657f76890e08d1899bf"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
+  pruneopts = ""
   revision = "ae18d6b8b3205b561c79e8e5f69bff09736185f4"
 
 [[projects]]
   branch = "master"
+  digest = "1:1dee6133ab829c8559a39031ad1e0e3538e4a7b34d3e0509d1fc247737e928c1"
   name = "github.com/mitchellh/go-ps"
   packages = ["."]
+  pruneopts = ""
   revision = "4fdf99ab29366514c69ccccddab5dc58b8d84062"
 
 [[projects]]
+  digest = "1:9adf43f9a17af07a6d587e3b493e2111ad8e07283d5cd58e44e70d23bf6dc644"
   name = "github.com/mitchellh/go-testing-interface"
   packages = ["."]
+  pruneopts = ""
   revision = "6d0b8010fcc857872e42fc6c931227569016843c"
 
 [[projects]]
+  digest = "1:713b341855f1480e4baca1e7c5434e1d266441340685ecbde32d59bdc065fb3f"
   name = "github.com/mitchellh/go-wordwrap"
   packages = ["."]
+  pruneopts = ""
   revision = "9e67c67572bc5dd02aef930e2b0ae3c02a4b5a5c"
 
 [[projects]]
+  digest = "1:387d79bfe8a4f0f300a22d65782108a94861eecfe652ffff30e8f91857ad81bb"
   name = "github.com/mitchellh/hashstructure"
   packages = ["."]
+  pruneopts = ""
   revision = "a38c50148365edc8df43c1580c48fb2b3a1e9cd7"
 
 [[projects]]
+  digest = "1:bcc46a0fbd9e933087bef394871256b5c60269575bb661935874729c65bbbf60"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
+  pruneopts = ""
   revision = "3536a929edddb9a5b34bd6861dc4a9647cb459fe"
 
 [[projects]]
+  digest = "1:5584c8fba4fbaac85a65c9b86320fdfb6fdd5ce86b3f8fd7ddb5082d20567bd3"
   name = "github.com/mitchellh/reflectwalk"
   packages = ["."]
-  revision = "63d60e9d0dbc60cf9164e6510889b0db6683d98c"
+  pruneopts = ""
+  revision = "eecee6c969c02c8cc2ae48e1e269843ae8590796"
 
 [[projects]]
+  digest = "1:78fb99d6011c2ae6c72f3293a83951311147b12b06a5ffa43abf750c4fab6ac5"
   name = "github.com/opentracing/opentracing-go"
   packages = [
     ".",
     "ext",
-    "log"
+    "log",
   ]
+  pruneopts = ""
   revision = "1949ddbfd147afd4d964a9f00b24eb291e0e7c38"
   version = "v1.0.2"
 
 [[projects]]
+  digest = "1:049b5bee78dfdc9628ee0e557219c41f683e5b06c5a5f20eaba0105ccc586689"
   name = "github.com/pelletier/go-buffruneio"
   packages = ["."]
+  pruneopts = ""
   revision = "c37440a7cf42ac63b919c752ca73a85067e05992"
   version = "v0.2.0"
 
 [[projects]]
+  digest = "1:1d7e1867c49a6dd9856598ef7c3123604ea3daabf5b83f303ff457bcbc410b1d"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = ""
   revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
   version = "v0.8.1"
 
 [[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = ""
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:34fd4f03cc427c62539128e8e15d59a8fb59e802a5342f0a30cada53dc433c5c"
   name = "github.com/posener/complete"
   packages = [
     ".",
     "cmd",
     "cmd/install",
-    "match"
+    "match",
   ]
+  pruneopts = ""
   revision = "88e59760adaddb8276c9b15511302890690e2dae"
 
 [[projects]]
   branch = "master"
+  digest = "1:988961f23131e2aa873e5433a4bb3f262bf40d930121b82233d906de54172c3e"
   name = "github.com/pulumi/pulumi"
   packages = [
     "pkg/apitype",
@@ -616,78 +758,100 @@
     "sdk/go/pulumi",
     "sdk/go/pulumi/asset",
     "sdk/go/pulumi/config",
-    "sdk/proto/go"
+    "sdk/proto/go",
   ]
-  revision = "3cf81c0b4ccdd64fbc07cc8ec7cf5fbb74cd7194"
+  pruneopts = ""
+  revision = "0b8fd47fb541a3ceae04b8661d8ad9ed642f711e"
 
 [[projects]]
   branch = "master"
+  digest = "1:06a35c7046592cb52f649451d9aa1649926011cd2863b3152aa64fa393184014"
   name = "github.com/pulumi/pulumi-terraform"
   packages = [
     "pkg/tfbridge",
-    "pkg/tfgen"
+    "pkg/tfgen",
   ]
-  revision = "9070bbff358bce84f8f8ba25297513256749db2d"
+  pruneopts = ""
+  revision = "b0770d37ae5ab50be1a2d316a6b5a7b41e8043cb"
 
 [[projects]]
   branch = "master"
+  digest = "1:5d372d623fca34e1bddf0ca733b47dbfad0220644753213ade88cc60be366710"
   name = "github.com/reconquest/loreley"
   packages = ["."]
+  pruneopts = ""
   revision = "2ab6b7470a54bfa9b5b0289f9b4e8fc4839838f7"
 
 [[projects]]
+  digest = "1:8f956d17662ac1b55d71d6cbb42d036905a637baf16d243a408690e8bb4df0b9"
   name = "github.com/satori/go.uuid"
   packages = ["."]
+  pruneopts = ""
   revision = "b061729afc07e77a8aa4fad0a2fd840958f1942a"
 
 [[projects]]
+  digest = "1:8f956d17662ac1b55d71d6cbb42d036905a637baf16d243a408690e8bb4df0b9"
   name = "github.com/satori/uuid"
   packages = ["."]
+  pruneopts = ""
   revision = "b061729afc07e77a8aa4fad0a2fd840958f1942a"
 
 [[projects]]
+  digest = "1:3962f553b77bf6c03fc07cd687a22dd3b00fe11aa14d31194f5505f5bb65cdc8"
   name = "github.com/sergi/go-diff"
   packages = ["diffmatchpatch"]
+  pruneopts = ""
   revision = "1744e2970ca51c86172c8190fadad617561ed6e7"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:ae3493c780092be9d576a1f746ab967293ec165e8473425631f06658b6212afc"
   name = "github.com/spf13/cast"
   packages = ["."]
+  pruneopts = ""
   revision = "8c9545af88b134710ab1cd196795e7f2388358d7"
   version = "v1.3.0"
 
 [[projects]]
+  digest = "1:a1403cc8a94b8d7956ee5e9694badef0e7b051af289caad1cf668331e3ffa4f6"
   name = "github.com/spf13/cobra"
   packages = ["."]
+  pruneopts = ""
   revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
   version = "v0.0.3"
 
 [[projects]]
+  digest = "1:cbaf13cdbfef0e4734ed8a7504f57fe893d471d62a35b982bf6fb3f036449a66"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = ""
   revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
   version = "v1.0.3"
 
 [[projects]]
+  digest = "1:740b31391e4c3e4d2b5a20e1cbf2c2f7765275ead23945acc7669c36c0b8095a"
   name = "github.com/src-d/gcfg"
   packages = [
     ".",
     "scanner",
     "token",
-    "types"
+    "types",
   ]
+  pruneopts = ""
   revision = "1ac3a1ac202429a54835fe8408a92880156b489d"
   version = "v1.4.0"
 
 [[projects]]
+  digest = "1:381bcbeb112a51493d9d998bbba207a529c73dbb49b3fd789e48c63fac1f192c"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
+  pruneopts = ""
   revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
   version = "v1.3.0"
 
 [[projects]]
   branch = "pulumi-master"
+  digest = "1:5f833703219bcb213ad0f96101a641dc27bc4dfd518fb8139dddbc25ca4a8dd5"
   name = "github.com/terraform-providers/terraform-provider-azurerm"
   packages = [
     "azurerm",
@@ -699,18 +863,22 @@
     "azurerm/helpers/tf",
     "azurerm/helpers/validate",
     "azurerm/utils",
-    "version"
+    "version",
   ]
+  pruneopts = ""
   revision = "b99293920c20a79d215c263e026412e8599dc018"
   source = "github.com/pulumi/terraform-provider-azurerm"
 
 [[projects]]
   branch = "master"
+  digest = "1:ff0671f12ff98386398469e4b44453369fe164563f48ddb6c6b8ce6963379f97"
   name = "github.com/texttheater/golang-levenshtein"
   packages = ["levenshtein"]
+  pruneopts = ""
   revision = "d188e65d659ef53fcdb0691c12f1bba64928b649"
 
 [[projects]]
+  digest = "1:941ab4973b3218a9a6d02d31734f5c762239eb538c0d702fff62d4037af8ab0a"
   name = "github.com/uber/jaeger-client-go"
   packages = [
     ".",
@@ -724,34 +892,42 @@
     "thrift-gen/sampling",
     "thrift-gen/zipkincore",
     "transport/zipkin",
-    "utils"
+    "utils",
   ]
+  pruneopts = ""
   revision = "1a782e2da844727691fef1757c72eb190c2909f0"
   version = "v2.15.0"
 
 [[projects]]
+  digest = "1:aa1598d34009b45ce74fdabdd25e4258d7923d1e1b418d4c98482e79607cb9b0"
   name = "github.com/uber/jaeger-lib"
   packages = ["metrics"]
+  pruneopts = ""
   revision = "ed3a127ec5fef7ae9ea95b01b542c47fbd999ce5"
   version = "v1.5.0"
 
 [[projects]]
+  digest = "1:ee723e6a1962a196eeba1b24f82af61a4f60f8821d7aa96d48e787f8337bcffc"
   name = "github.com/ulikunitz/xz"
   packages = [
     ".",
     "internal/hash",
     "internal/xlog",
-    "lzma"
+    "lzma",
   ]
+  pruneopts = ""
   revision = "0c6b41e72360850ca4f98dc341fd999726ea007f"
 
 [[projects]]
+  digest = "1:afc0b8068986a01e2d8f449917829753a54f6bd4d1265c2b4ad9cba75560020f"
   name = "github.com/xanzy/ssh-agent"
   packages = ["."]
+  pruneopts = ""
   revision = "640f0ab560aeb89d523bb6ac322b1244d5c3796c"
   version = "v0.2.0"
 
 [[projects]]
+  digest = "1:fcccc0b5bdfd6a279324dc9c1292f6d93e5653ca4e752aa9f3c6dd023e4f06e0"
   name = "github.com/zclconf/go-cty"
   packages = [
     "cty",
@@ -760,11 +936,13 @@
     "cty/function/stdlib",
     "cty/gocty",
     "cty/json",
-    "cty/set"
+    "cty/set",
   ]
+  pruneopts = ""
   revision = "7166230c635fa24bbe613c5a53e75ad15c42c059"
 
 [[projects]]
+  digest = "1:2b889e0f4f9966ea59be770b9a16aee358a720f0e2e7c81485c2b3de87c86e51"
   name = "go.opencensus.io"
   packages = [
     ".",
@@ -782,11 +960,13 @@
     "trace",
     "trace/internal",
     "trace/propagation",
-    "trace/tracestate"
+    "trace/tracestate",
   ]
+  pruneopts = ""
   revision = "950a67f393d867cfbe91414063b69e511f42fefb"
 
 [[projects]]
+  digest = "1:efb97ebbd73c3a7068579327f5d98a17c09f6d8caf1fa3212c506e8bb78126b5"
   name = "golang.org/x/crypto"
   packages = [
     "bcrypt",
@@ -810,11 +990,13 @@
     "ssh",
     "ssh/agent",
     "ssh/knownhosts",
-    "ssh/terminal"
+    "ssh/terminal",
   ]
+  pruneopts = ""
   revision = "4d3f4d9ffa16a13f451c3b2999e9c49e9750bf06"
 
 [[projects]]
+  digest = "1:35171304d8332a0cfac5f3bd9222467f036732ddde75c65278b16f65216e03ed"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -825,24 +1007,30 @@
     "idna",
     "internal/timeseries",
     "lex/httplex",
-    "trace"
+    "trace",
   ]
+  pruneopts = ""
   revision = "1c05540f6879653db88113bc4a2b70aec4bd491f"
 
 [[projects]]
+  digest = "1:814474ab808c5e04b9334d046f8a0060fc1724c2c02acfd00a7cc0008d675455"
   name = "golang.org/x/sync"
   packages = ["semaphore"]
+  pruneopts = ""
   revision = "37e7f081c4d4c64e13b10787722085407fe5d15f"
 
 [[projects]]
+  digest = "1:e6d1805ead5b8f2439808f76187f54042ed35ee26eb9ca63127259a0e612b119"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
+  pruneopts = ""
   revision = "b4a75ba826a64a70990f11a225237acd6ef35c9f"
 
 [[projects]]
+  digest = "1:6ffd50f330d82d5a92f109253f3831900ccb99f973fb7d614e54ceaf6a41dcec"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -858,24 +1046,30 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
   ]
+  pruneopts = ""
   revision = "1cbadb444a806fd9430d14ad08967ed91da4fa0a"
 
 [[projects]]
+  digest = "1:7873bd40db14885e3c790a4134341e998abf3d83d0872a93613f765025903026"
   name = "google.golang.org/api"
   packages = ["support/bundler"]
+  pruneopts = ""
   revision = "65a46cafb132eff435c7d1e0f439cc73c8eebb85"
 
 [[projects]]
+  digest = "1:8c7bf8f974d0b63a83834e83b6dd39c2b40d61d409d76172c81d67eba8fee4a8"
   name = "google.golang.org/genproto"
   packages = [
     "googleapis/rpc/status",
-    "protobuf/field_mask"
+    "protobuf/field_mask",
   ]
+  pruneopts = ""
   revision = "bd9b4fb69e2ffd37621a6caa54dcbead29b546f2"
 
 [[projects]]
+  digest = "1:894e80f47b2846ae4ab1839e703757e74b75dbfae0c355fb919588299a2089ea"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -910,33 +1104,39 @@
     "resolver/passthrough",
     "stats",
     "status",
-    "tap"
+    "tap",
   ]
+  pruneopts = ""
   revision = "25de51fc024f642d9ac888257b1485939a1d4a14"
 
 [[projects]]
+  digest = "1:8f5753fc4fe7f8bd23d5cf6b82b6cc8e2522d29bd176cb58874917cbd26431cb"
   name = "gopkg.in/AlecAivazis/survey.v1"
   packages = [
     ".",
     "core",
-    "terminal"
+    "terminal",
   ]
+  pruneopts = ""
   revision = "38cdfa1242b19e0eb8b6f33004bf8e89832b8743"
   version = "v1.8.0"
 
 [[projects]]
+  digest = "1:cc4fc94e3088593a2cde96c032e05d1e3c7d494147d7a7d707445ccc478bf4a0"
   name = "gopkg.in/src-d/go-billy.v4"
   packages = [
     ".",
     "helper/chroot",
     "helper/polyfill",
     "osfs",
-    "util"
+    "util",
   ]
+  pruneopts = ""
   revision = "982626487c60a5252e7d0b695ca23fb0fa2fd670"
   version = "v4.3.0"
 
 [[projects]]
+  digest = "1:2575e0987bd652097e3921a4713b886f786483fecac75ca0707cf7dad26424f3"
   name = "gopkg.in/src-d/go-git.v4"
   packages = [
     ".",
@@ -978,25 +1178,43 @@
     "utils/merkletrie/filesystem",
     "utils/merkletrie/index",
     "utils/merkletrie/internal/frame",
-    "utils/merkletrie/noder"
+    "utils/merkletrie/noder",
   ]
+  pruneopts = ""
   revision = "3dbfb89e0f5bce0008724e547b999fe3af9f60db"
   version = "v4.8.1"
 
 [[projects]]
+  digest = "1:ceec7e96590fb8168f36df4795fefe17051d4b0c2acc7ec4e260d8138c4dafac"
   name = "gopkg.in/warnings.v0"
   packages = ["."]
+  pruneopts = ""
   revision = "ec4a0fea49c7b46c2aeb0b51aac55779c607e52b"
   version = "v0.1.2"
 
 [[projects]]
+  digest = "1:5fe876313b07628905b2181e537faabe45032cb9c79c01b49b51c25a0a40040d"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "7f97868eec74b32b0982dd158a51a446d1da7eb5"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f1d99f19244c3cec9aa211e4156bffa80c7801cfc5b245fdba4f8c7586398adc"
+  input-imports = [
+    "github.com/hashicorp/terraform/helper/schema",
+    "github.com/pkg/errors",
+    "github.com/pulumi/pulumi-terraform/pkg/tfbridge",
+    "github.com/pulumi/pulumi-terraform/pkg/tfgen",
+    "github.com/pulumi/pulumi/pkg/resource",
+    "github.com/pulumi/pulumi/pkg/testing/integration",
+    "github.com/pulumi/pulumi/pkg/tokens",
+    "github.com/pulumi/pulumi/pkg/util/buildutil",
+    "github.com/pulumi/pulumi/sdk/go/pulumi",
+    "github.com/pulumi/pulumi/sdk/go/pulumi/config",
+    "github.com/stretchr/testify/assert",
+    "github.com/terraform-providers/terraform-provider-azurerm/azurerm",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.template.toml
+++ b/Gopkg.template.toml
@@ -6,15 +6,6 @@
   name = "github.com/pulumi/pulumi-terraform"
   branch = "master"
 
-# DO NOT REMOVE THESE [pulumi/pulumi-terraform#229]
-# These versions are required by tfbridge - we must build against them even if the provider requests an older version.
-[[override]]
-  name = "github.com/mitchellh/copystructure"
-  revision = "d23ffcb85de31694d6ccaa23ccb4a03e55c1303f"
-[[override]]
-  name = "github.com/mitchellh/reflectwalk"
-  revision = "63d60e9d0dbc60cf9164e6510889b0db6683d98c"
-
 [[constraint]]
   branch = "pulumi-master"
   name = "github.com/terraform-providers/terraform-provider-azurerm"
@@ -22,8 +13,3 @@
 
   [constraint.metadata]
     govendor-override = true
-    govendor-exclude-prefixes = [
-      "github.com/mitchellh/copystructure",
-      "github.com/mitchellh/reflectwalk",
-      "github.com/golang/protobuf",
-    ]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -12,16 +12,7 @@
   source = "github.com/pulumi/terraform-provider-azurerm"
 
   [constraint.metadata]
-    govendor-exclude-prefixes = ["github.com/mitchellh/copystructure","github.com/mitchellh/reflectwalk","github.com/golang/protobuf"]
     govendor-override = true
-
-[[override]]
-  name = "github.com/mitchellh/copystructure"
-  revision = "d23ffcb85de31694d6ccaa23ccb4a03e55c1303f"
-
-[[override]]
-  name = "github.com/mitchellh/reflectwalk"
-  revision = "63d60e9d0dbc60cf9164e6510889b0db6683d98c"
 
 # NOTE: the following overrides were injected by govendor-override. It may be necessary to
 # remove some of these overrides in order to produce a buildable vendor tree.
@@ -136,6 +127,12 @@
 [[override]]
   name = "github.com/go-ini/ini"
   revision = "766e555c68dc8bda90d197ee8946c37519c19409"
+  [override.metadata]
+    govendor-overridden=true
+
+[[override]]
+  name = "github.com/golang/protobuf"
+  revision = "1d3f30b51784bec5aad268e59fd3c2fc1c2fe73f"
   [override.metadata]
     govendor-overridden=true
 
@@ -272,6 +269,12 @@
     govendor-overridden=true
 
 [[override]]
+  name = "github.com/mitchellh/copystructure"
+  revision = "9a1b6f44e8da0e0e374624fb0a825a231b00c537"
+  [override.metadata]
+    govendor-overridden=true
+
+[[override]]
   name = "github.com/mitchellh/go-homedir"
   revision = "ae18d6b8b3205b561c79e8e5f69bff09736185f4"
   [override.metadata]
@@ -298,6 +301,12 @@
 [[override]]
   name = "github.com/mitchellh/mapstructure"
   revision = "3536a929edddb9a5b34bd6861dc4a9647cb459fe"
+  [override.metadata]
+    govendor-overridden=true
+
+[[override]]
+  name = "github.com/mitchellh/reflectwalk"
+  revision = "eecee6c969c02c8cc2ae48e1e269843ae8590796"
   [override.metadata]
     govendor-overridden=true
 


### PR DESCRIPTION
This PR updates us for dep 0.5 for the Azure provider.

The constraints needed modifying in order to allow a solve to complete, however the resulting set of dependencies looks correct (meeting the various minimum version constraints we previously had).

CI will fail since I reverted the script upgrade for 0.5.