### PR TITLE
Explicitly map name of use32BitWorkerProcess in AppService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 0.17.2 (Unreleased)
 
-### Improvements
-
 - Updated to v1.23.0 of the AzureRM Terraform Provider.
+
+- Fixed a bug where AppService or FunctionApp could not be created with `use32BitWorkerProcess` set to `true`.
 
 ## 0.17.1 (Released March 6, 2019)
 

--- a/resources.go
+++ b/resources.go
@@ -235,6 +235,15 @@ func Provider() tfbridge.ProviderInfo {
 					// Max length of a functionapp name is 60.
 					// This was discovered directly through the portal.
 					azureName: AutoNameWithMaxLength(azureName, 60),
+					"site_config": {
+						Elem: &tfbridge.SchemaInfo{
+							Fields: map[string]*tfbridge.SchemaInfo{
+								"use_32_bit_worker_process": {
+									Name: "use32BitWorkerProcess",
+								},
+							},
+						},
+					},
 				}},
 			// Automation
 			"azurerm_automation_account":               {Tok: azureResource(azureAutomation, "Account")},

--- a/resources.go
+++ b/resources.go
@@ -205,7 +205,20 @@ func Provider() tfbridge.ProviderInfo {
 			"azurerm_application_insights_api_key": {Tok: azureResource(azureAppInsights, "ApiKey")},
 
 			// App Service
-			"azurerm_app_service":                         {Tok: azureResource(azureAppService, "AppService")},
+			"azurerm_app_service": {
+				Tok: azureResource(azureAppService, "AppService"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"site_config": {
+						Elem: &tfbridge.SchemaInfo{
+							Fields: map[string]*tfbridge.SchemaInfo{
+								"use_32_bit_worker_process": {
+									Name: "use32BitWorkerProcess",
+								},
+							},
+						},
+					},
+				},
+			},
 			"azurerm_app_service_custom_hostname_binding": {Tok: azureResource(azureAppService, "CustomHostnameBinding")},
 			"azurerm_app_service_plan": {
 				Tok: azureResource(azureAppService, "Plan"),


### PR DESCRIPTION
The use32BitWorkerProcess property does not resolve correctly using the default name mangling rules (producing "use32_bit_worker_process" instead of adding a _ between "use" and "32"), and changing the rules is likely a source of latent bugs (see discussion on pulumi/pulumi-terraform#350).

Instead, we map this field explicitly.

Fixes #157.

With this fix applied, the following program runs correctly:

```typescript
import * as azure from "@pulumi/azure";

// Create an Azure Resource Group
const resourceGroup = new azure.core.ResourceGroup("resourceGroup", {
    location: "West Europe",
});

const appServicePlan = new azure.appservice.Plan("test", {
    location: resourceGroup.location,
    resourceGroupName: resourceGroup.name,

    sku: {
        tier: "Standard",
        size: "S1"
    }
});

const appService = new azure.appservice.AppService("test", {
    location: resourceGroup.location,
    resourceGroupName: resourceGroup.name,
    appServicePlanId: appServicePlan.id,

    siteConfig: {
        dotnetFrameworkVersion: "v4.0",
        use32BitWorkerProcess: true,
        scmType: "LocalGit",
    },

    appSettings: {
        "SOMEKEY": "SomeValue",
    }
});
```