### PR TITLE
Improve usability of "location" properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,36 @@
   5. You can subscribe to `azure.storage.Queue` events, invoking a FunctionApp containing
      the code you want, using `queue.onEvent(...)`.
 
-- Add support for `client_certificate_password`, `client_certificate_path` and `partner_id` as per the Terraform provider 
+- The location for each resource attached to a provider instance is now set as
+  part of the provider configuration. This means that the following code from
+  v0.18.0:
+
+  ```ts
+  const rg = new azure.core.ResourceGroup("rg", { location" EastUS" });
+  const sa = new azure.storage.Account("storage", {
+      resourceGroupName: rg.name,
+      location: "EastUS",
+  });
+  ```
+
+  Can now be written as:
+
+  ```ts
+  const rg = new azure.core.ResourceGroup("rg");
+  const sa = new azure.storage.Account("storage", {
+      resourceGroupName: rg.name,
+  });
+  ```
+
+  Location can then be set using the provider configuration block if using first
+  class providers, or, for the default provider, by running:
+
+  ```
+  pulumi config set azure:location EastUS
+  ```
+
+- Add support for `client_certificate_password`, `client_certificate_path` and
+  `partner_id` as per the Terraform provider
 
 ## 0.18.0 (Released April 22nd, 2019)
 

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/pelletier/go-toml v1.3.0 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/pulumi/pulumi v0.17.6-0.20190410045519-ef5e148a73c0
-	github.com/pulumi/pulumi-terraform v0.14.1-dev.0.20190410175858-788550dffb09
+	github.com/pulumi/pulumi-terraform v0.14.1-dev.0.20190430150945-0d5e2bb71dec
 	github.com/reconquest/loreley v0.0.0-20190408221007-9e95b93c818f // indirect
 	github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304 // indirect
 	github.com/spf13/cast v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -483,6 +483,8 @@ github.com/pulumi/pulumi v0.17.6-0.20190410045519-ef5e148a73c0 h1:NqGT9rxjyADqq2
 github.com/pulumi/pulumi v0.17.6-0.20190410045519-ef5e148a73c0/go.mod h1:RIy1gmz8Vyy7H5w2ffHJ23aZHCOggF2zk2c+KD1GMtY=
 github.com/pulumi/pulumi-terraform v0.14.1-dev.0.20190410175858-788550dffb09 h1:IK1V6YgNWMh4yMMJYCDyouLoNHWYJmuIjmz5aXpQl5s=
 github.com/pulumi/pulumi-terraform v0.14.1-dev.0.20190410175858-788550dffb09/go.mod h1:bJ2tsYQlSMzMCEDb2kP1rDHaadG3O7JUnBUYH/yx2Io=
+github.com/pulumi/pulumi-terraform v0.14.1-dev.0.20190430150945-0d5e2bb71dec h1:jTilwLDs9fmJcN6TZt50M+5r9FvERDvDetDUP/8nfkQ=
+github.com/pulumi/pulumi-terraform v0.14.1-dev.0.20190430150945-0d5e2bb71dec/go.mod h1:bJ2tsYQlSMzMCEDb2kP1rDHaadG3O7JUnBUYH/yx2Io=
 github.com/pulumi/pulumi-terraform v0.15.1 h1:y+Xh+lhj+fiPnHzfJb7ajkUuRH+vvwCy7bi304AAJig=
 github.com/pulumi/pulumi-terraform v0.15.1/go.mod h1:j1Hb86i+cujAPoQwDRPlZa6T6cMDrUz4aZ3hxv+IHS0=
 github.com/pulumi/terraform-provider-azurerm v0.0.0-20190411072213-10e8f9c34cd8 h1:YOfQ1P9DvJoi9JmXMiYkgwGCcOvlw2t3btEoU3q8sL0=

--- a/sdk/go/azure/apimanagement/service.go
+++ b/sdk/go/azure/apimanagement/service.go
@@ -16,9 +16,6 @@ type Service struct {
 // NewService registers a new resource with the given unique name, arguments, and options.
 func NewService(ctx *pulumi.Context,
 	name string, args *ServiceArgs, opts ...pulumi.ResourceOpt) (*Service, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.PublisherEmail == nil {
 		return nil, errors.New("missing required argument 'PublisherEmail'")
 	}

--- a/sdk/go/azure/appinsights/insights.go
+++ b/sdk/go/azure/appinsights/insights.go
@@ -19,9 +19,6 @@ func NewInsights(ctx *pulumi.Context,
 	if args == nil || args.ApplicationType == nil {
 		return nil, errors.New("missing required argument 'ApplicationType'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/appservice/appService.go
+++ b/sdk/go/azure/appservice/appService.go
@@ -21,9 +21,6 @@ func NewAppService(ctx *pulumi.Context,
 	if args == nil || args.AppServicePlanId == nil {
 		return nil, errors.New("missing required argument 'AppServicePlanId'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/appservice/functionApp.go
+++ b/sdk/go/azure/appservice/functionApp.go
@@ -19,9 +19,6 @@ func NewFunctionApp(ctx *pulumi.Context,
 	if args == nil || args.AppServicePlanId == nil {
 		return nil, errors.New("missing required argument 'AppServicePlanId'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/appservice/plan.go
+++ b/sdk/go/azure/appservice/plan.go
@@ -16,9 +16,6 @@ type Plan struct {
 // NewPlan registers a new resource with the given unique name, arguments, and options.
 func NewPlan(ctx *pulumi.Context,
 	name string, args *PlanArgs, opts ...pulumi.ResourceOpt) (*Plan, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/appservice/slot.go
+++ b/sdk/go/azure/appservice/slot.go
@@ -24,9 +24,6 @@ func NewSlot(ctx *pulumi.Context,
 	if args == nil || args.AppServicePlanId == nil {
 		return nil, errors.New("missing required argument 'AppServicePlanId'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/automation/account.go
+++ b/sdk/go/azure/automation/account.go
@@ -16,9 +16,6 @@ type Account struct {
 // NewAccount registers a new resource with the given unique name, arguments, and options.
 func NewAccount(ctx *pulumi.Context,
 	name string, args *AccountArgs, opts ...pulumi.ResourceOpt) (*Account, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/automation/dscConfiguration.go
+++ b/sdk/go/azure/automation/dscConfiguration.go
@@ -22,9 +22,6 @@ func NewDscConfiguration(ctx *pulumi.Context,
 	if args == nil || args.ContentEmbedded == nil {
 		return nil, errors.New("missing required argument 'ContentEmbedded'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/automation/runBook.go
+++ b/sdk/go/azure/automation/runBook.go
@@ -19,9 +19,6 @@ func NewRunBook(ctx *pulumi.Context,
 	if args == nil || args.AccountName == nil {
 		return nil, errors.New("missing required argument 'AccountName'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.LogProgress == nil {
 		return nil, errors.New("missing required argument 'LogProgress'")
 	}

--- a/sdk/go/azure/autoscale/setting.go
+++ b/sdk/go/azure/autoscale/setting.go
@@ -18,9 +18,6 @@ type Setting struct {
 // NewSetting registers a new resource with the given unique name, arguments, and options.
 func NewSetting(ctx *pulumi.Context,
 	name string, args *SettingArgs, opts ...pulumi.ResourceOpt) (*Setting, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.Profiles == nil {
 		return nil, errors.New("missing required argument 'Profiles'")
 	}

--- a/sdk/go/azure/batch/account.go
+++ b/sdk/go/azure/batch/account.go
@@ -16,9 +16,6 @@ type Account struct {
 // NewAccount registers a new resource with the given unique name, arguments, and options.
 func NewAccount(ctx *pulumi.Context,
 	name string, args *AccountArgs, opts ...pulumi.ResourceOpt) (*Account, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/cdn/endpoint.go
+++ b/sdk/go/azure/cdn/endpoint.go
@@ -16,9 +16,6 @@ type Endpoint struct {
 // NewEndpoint registers a new resource with the given unique name, arguments, and options.
 func NewEndpoint(ctx *pulumi.Context,
 	name string, args *EndpointArgs, opts ...pulumi.ResourceOpt) (*Endpoint, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.Origins == nil {
 		return nil, errors.New("missing required argument 'Origins'")
 	}

--- a/sdk/go/azure/cdn/profile.go
+++ b/sdk/go/azure/cdn/profile.go
@@ -16,9 +16,6 @@ type Profile struct {
 // NewProfile registers a new resource with the given unique name, arguments, and options.
 func NewProfile(ctx *pulumi.Context,
 	name string, args *ProfileArgs, opts ...pulumi.ResourceOpt) (*Profile, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/cognitive/account.go
+++ b/sdk/go/azure/cognitive/account.go
@@ -19,9 +19,6 @@ func NewAccount(ctx *pulumi.Context,
 	if args == nil || args.Kind == nil {
 		return nil, errors.New("missing required argument 'Kind'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/compute/availabilitySet.go
+++ b/sdk/go/azure/compute/availabilitySet.go
@@ -16,9 +16,6 @@ type AvailabilitySet struct {
 // NewAvailabilitySet registers a new resource with the given unique name, arguments, and options.
 func NewAvailabilitySet(ctx *pulumi.Context,
 	name string, args *AvailabilitySetArgs, opts ...pulumi.ResourceOpt) (*AvailabilitySet, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/compute/extension.go
+++ b/sdk/go/azure/compute/extension.go
@@ -21,9 +21,6 @@ type Extension struct {
 // NewExtension registers a new resource with the given unique name, arguments, and options.
 func NewExtension(ctx *pulumi.Context,
 	name string, args *ExtensionArgs, opts ...pulumi.ResourceOpt) (*Extension, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.Publisher == nil {
 		return nil, errors.New("missing required argument 'Publisher'")
 	}

--- a/sdk/go/azure/compute/image.go
+++ b/sdk/go/azure/compute/image.go
@@ -16,9 +16,6 @@ type Image struct {
 // NewImage registers a new resource with the given unique name, arguments, and options.
 func NewImage(ctx *pulumi.Context,
 	name string, args *ImageArgs, opts ...pulumi.ResourceOpt) (*Image, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/compute/managedDisk.go
+++ b/sdk/go/azure/compute/managedDisk.go
@@ -19,9 +19,6 @@ func NewManagedDisk(ctx *pulumi.Context,
 	if args == nil || args.CreateOption == nil {
 		return nil, errors.New("missing required argument 'CreateOption'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/compute/scaleSet.go
+++ b/sdk/go/azure/compute/scaleSet.go
@@ -19,9 +19,6 @@ type ScaleSet struct {
 // NewScaleSet registers a new resource with the given unique name, arguments, and options.
 func NewScaleSet(ctx *pulumi.Context,
 	name string, args *ScaleSetArgs, opts ...pulumi.ResourceOpt) (*ScaleSet, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.NetworkProfiles == nil {
 		return nil, errors.New("missing required argument 'NetworkProfiles'")
 	}

--- a/sdk/go/azure/compute/sharedImage.go
+++ b/sdk/go/azure/compute/sharedImage.go
@@ -24,9 +24,6 @@ func NewSharedImage(ctx *pulumi.Context,
 	if args == nil || args.Identifier == nil {
 		return nil, errors.New("missing required argument 'Identifier'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.OsType == nil {
 		return nil, errors.New("missing required argument 'OsType'")
 	}

--- a/sdk/go/azure/compute/sharedImageGallery.go
+++ b/sdk/go/azure/compute/sharedImageGallery.go
@@ -18,9 +18,6 @@ type SharedImageGallery struct {
 // NewSharedImageGallery registers a new resource with the given unique name, arguments, and options.
 func NewSharedImageGallery(ctx *pulumi.Context,
 	name string, args *SharedImageGalleryArgs, opts ...pulumi.ResourceOpt) (*SharedImageGallery, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/compute/sharedImageVersion.go
+++ b/sdk/go/azure/compute/sharedImageVersion.go
@@ -24,9 +24,6 @@ func NewSharedImageVersion(ctx *pulumi.Context,
 	if args == nil || args.ImageName == nil {
 		return nil, errors.New("missing required argument 'ImageName'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ManagedImageId == nil {
 		return nil, errors.New("missing required argument 'ManagedImageId'")
 	}

--- a/sdk/go/azure/compute/snapshot.go
+++ b/sdk/go/azure/compute/snapshot.go
@@ -19,9 +19,6 @@ func NewSnapshot(ctx *pulumi.Context,
 	if args == nil || args.CreateOption == nil {
 		return nil, errors.New("missing required argument 'CreateOption'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/compute/virtualMachine.go
+++ b/sdk/go/azure/compute/virtualMachine.go
@@ -18,9 +18,6 @@ type VirtualMachine struct {
 // NewVirtualMachine registers a new resource with the given unique name, arguments, and options.
 func NewVirtualMachine(ctx *pulumi.Context,
 	name string, args *VirtualMachineArgs, opts ...pulumi.ResourceOpt) (*VirtualMachine, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.NetworkInterfaceIds == nil {
 		return nil, errors.New("missing required argument 'NetworkInterfaceIds'")
 	}

--- a/sdk/go/azure/config/config.go
+++ b/sdk/go/azure/config/config.go
@@ -140,3 +140,14 @@ func GetUseMsi(ctx *pulumi.Context) bool {
 	}
 	return v
 }
+
+func GetLocation(ctx *pulumi.Context) string {
+	v, err := config.Try(ctx, "azure:location")
+	if err == nil {
+		return v
+	}
+	if dv, ok := getEnvOrDefault("", nil, "ARM_LOCATION").(string); ok {
+		return dv
+	}
+	return v
+}

--- a/sdk/go/azure/containerservice/group.go
+++ b/sdk/go/azure/containerservice/group.go
@@ -19,9 +19,6 @@ func NewGroup(ctx *pulumi.Context,
 	if args == nil || args.Containers == nil {
 		return nil, errors.New("missing required argument 'Containers'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.OsType == nil {
 		return nil, errors.New("missing required argument 'OsType'")
 	}

--- a/sdk/go/azure/containerservice/kubernetesCluster.go
+++ b/sdk/go/azure/containerservice/kubernetesCluster.go
@@ -24,9 +24,6 @@ func NewKubernetesCluster(ctx *pulumi.Context,
 	if args == nil || args.DnsPrefix == nil {
 		return nil, errors.New("missing required argument 'DnsPrefix'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/containerservice/registry.go
+++ b/sdk/go/azure/containerservice/registry.go
@@ -19,9 +19,6 @@ type Registry struct {
 // NewRegistry registers a new resource with the given unique name, arguments, and options.
 func NewRegistry(ctx *pulumi.Context,
 	name string, args *RegistryArgs, opts ...pulumi.ResourceOpt) (*Registry, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/containerservice/service.go
+++ b/sdk/go/azure/containerservice/service.go
@@ -32,9 +32,6 @@ func NewService(ctx *pulumi.Context,
 	if args == nil || args.LinuxProfile == nil {
 		return nil, errors.New("missing required argument 'LinuxProfile'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.MasterProfile == nil {
 		return nil, errors.New("missing required argument 'MasterProfile'")
 	}

--- a/sdk/go/azure/core/resourceGroup.go
+++ b/sdk/go/azure/core/resourceGroup.go
@@ -4,7 +4,6 @@
 package core
 
 import (
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
@@ -16,9 +15,6 @@ type ResourceGroup struct {
 // NewResourceGroup registers a new resource with the given unique name, arguments, and options.
 func NewResourceGroup(ctx *pulumi.Context,
 	name string, args *ResourceGroupArgs, opts ...pulumi.ResourceOpt) (*ResourceGroup, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	inputs := make(map[string]interface{})
 	if args == nil {
 		inputs["location"] = nil

--- a/sdk/go/azure/cosmosdb/account.go
+++ b/sdk/go/azure/cosmosdb/account.go
@@ -19,9 +19,6 @@ func NewAccount(ctx *pulumi.Context,
 	if args == nil || args.ConsistencyPolicy == nil {
 		return nil, errors.New("missing required argument 'ConsistencyPolicy'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.OfferType == nil {
 		return nil, errors.New("missing required argument 'OfferType'")
 	}

--- a/sdk/go/azure/databricks/workspace.go
+++ b/sdk/go/azure/databricks/workspace.go
@@ -16,9 +16,6 @@ type Workspace struct {
 // NewWorkspace registers a new resource with the given unique name, arguments, and options.
 func NewWorkspace(ctx *pulumi.Context,
 	name string, args *WorkspaceArgs, opts ...pulumi.ResourceOpt) (*Workspace, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/datafactory/factory.go
+++ b/sdk/go/azure/datafactory/factory.go
@@ -16,9 +16,6 @@ type Factory struct {
 // NewFactory registers a new resource with the given unique name, arguments, and options.
 func NewFactory(ctx *pulumi.Context,
 	name string, args *FactoryArgs, opts ...pulumi.ResourceOpt) (*Factory, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/datalake/analyticsAccount.go
+++ b/sdk/go/azure/datalake/analyticsAccount.go
@@ -19,9 +19,6 @@ func NewAnalyticsAccount(ctx *pulumi.Context,
 	if args == nil || args.DefaultStoreAccountName == nil {
 		return nil, errors.New("missing required argument 'DefaultStoreAccountName'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/datalake/store.go
+++ b/sdk/go/azure/datalake/store.go
@@ -16,9 +16,6 @@ type Store struct {
 // NewStore registers a new resource with the given unique name, arguments, and options.
 func NewStore(ctx *pulumi.Context,
 	name string, args *StoreArgs, opts ...pulumi.ResourceOpt) (*Store, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/ddosprotection/plan.go
+++ b/sdk/go/azure/ddosprotection/plan.go
@@ -20,9 +20,6 @@ type Plan struct {
 // NewPlan registers a new resource with the given unique name, arguments, and options.
 func NewPlan(ctx *pulumi.Context,
 	name string, args *PlanArgs, opts ...pulumi.ResourceOpt) (*Plan, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/devspace/controller.go
+++ b/sdk/go/azure/devspace/controller.go
@@ -19,9 +19,6 @@ func NewController(ctx *pulumi.Context,
 	if args == nil || args.HostSuffix == nil {
 		return nil, errors.New("missing required argument 'HostSuffix'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/devtest/lab.go
+++ b/sdk/go/azure/devtest/lab.go
@@ -16,9 +16,6 @@ type Lab struct {
 // NewLab registers a new resource with the given unique name, arguments, and options.
 func NewLab(ctx *pulumi.Context,
 	name string, args *LabArgs, opts ...pulumi.ResourceOpt) (*Lab, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/devtest/linuxVirtualMachine.go
+++ b/sdk/go/azure/devtest/linuxVirtualMachine.go
@@ -28,9 +28,6 @@ func NewLinuxVirtualMachine(ctx *pulumi.Context,
 	if args == nil || args.LabVirtualNetworkId == nil {
 		return nil, errors.New("missing required argument 'LabVirtualNetworkId'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/devtest/windowsVirtualMachine.go
+++ b/sdk/go/azure/devtest/windowsVirtualMachine.go
@@ -28,9 +28,6 @@ func NewWindowsVirtualMachine(ctx *pulumi.Context,
 	if args == nil || args.LabVirtualNetworkId == nil {
 		return nil, errors.New("missing required argument 'LabVirtualNetworkId'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.Password == nil {
 		return nil, errors.New("missing required argument 'Password'")
 	}

--- a/sdk/go/azure/eventhub/eventGridDomain.go
+++ b/sdk/go/azure/eventhub/eventGridDomain.go
@@ -16,9 +16,6 @@ type EventGridDomain struct {
 // NewEventGridDomain registers a new resource with the given unique name, arguments, and options.
 func NewEventGridDomain(ctx *pulumi.Context,
 	name string, args *EventGridDomainArgs, opts ...pulumi.ResourceOpt) (*EventGridDomain, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/eventhub/eventGridTopic.go
+++ b/sdk/go/azure/eventhub/eventGridTopic.go
@@ -18,9 +18,6 @@ type EventGridTopic struct {
 // NewEventGridTopic registers a new resource with the given unique name, arguments, and options.
 func NewEventGridTopic(ctx *pulumi.Context,
 	name string, args *EventGridTopicArgs, opts ...pulumi.ResourceOpt) (*EventGridTopic, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/eventhub/eventHubNamespace.go
+++ b/sdk/go/azure/eventhub/eventHubNamespace.go
@@ -16,9 +16,6 @@ type EventHubNamespace struct {
 // NewEventHubNamespace registers a new resource with the given unique name, arguments, and options.
 func NewEventHubNamespace(ctx *pulumi.Context,
 	name string, args *EventHubNamespaceArgs, opts ...pulumi.ResourceOpt) (*EventHubNamespace, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/eventhub/namespace.go
+++ b/sdk/go/azure/eventhub/namespace.go
@@ -16,9 +16,6 @@ type Namespace struct {
 // NewNamespace registers a new resource with the given unique name, arguments, and options.
 func NewNamespace(ctx *pulumi.Context,
 	name string, args *NamespaceArgs, opts ...pulumi.ResourceOpt) (*Namespace, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/hdinsight/hBaseCluster.go
+++ b/sdk/go/azure/hdinsight/hBaseCluster.go
@@ -25,9 +25,6 @@ func NewHBaseCluster(ctx *pulumi.Context,
 	if args == nil || args.Gateway == nil {
 		return nil, errors.New("missing required argument 'Gateway'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/hdinsight/hadoopCluster.go
+++ b/sdk/go/azure/hdinsight/hadoopCluster.go
@@ -25,9 +25,6 @@ func NewHadoopCluster(ctx *pulumi.Context,
 	if args == nil || args.Gateway == nil {
 		return nil, errors.New("missing required argument 'Gateway'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/hdinsight/interactiveQueryCluster.go
+++ b/sdk/go/azure/hdinsight/interactiveQueryCluster.go
@@ -25,9 +25,6 @@ func NewInteractiveQueryCluster(ctx *pulumi.Context,
 	if args == nil || args.Gateway == nil {
 		return nil, errors.New("missing required argument 'Gateway'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/hdinsight/kafkaCluster.go
+++ b/sdk/go/azure/hdinsight/kafkaCluster.go
@@ -25,9 +25,6 @@ func NewKafkaCluster(ctx *pulumi.Context,
 	if args == nil || args.Gateway == nil {
 		return nil, errors.New("missing required argument 'Gateway'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/hdinsight/mLServicesCluster.go
+++ b/sdk/go/azure/hdinsight/mLServicesCluster.go
@@ -22,9 +22,6 @@ func NewMLServicesCluster(ctx *pulumi.Context,
 	if args == nil || args.Gateway == nil {
 		return nil, errors.New("missing required argument 'Gateway'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/hdinsight/rServerCluster.go
+++ b/sdk/go/azure/hdinsight/rServerCluster.go
@@ -22,9 +22,6 @@ func NewRServerCluster(ctx *pulumi.Context,
 	if args == nil || args.Gateway == nil {
 		return nil, errors.New("missing required argument 'Gateway'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/hdinsight/sparkCluster.go
+++ b/sdk/go/azure/hdinsight/sparkCluster.go
@@ -25,9 +25,6 @@ func NewSparkCluster(ctx *pulumi.Context,
 	if args == nil || args.Gateway == nil {
 		return nil, errors.New("missing required argument 'Gateway'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/hdinsight/stormCluster.go
+++ b/sdk/go/azure/hdinsight/stormCluster.go
@@ -25,9 +25,6 @@ func NewStormCluster(ctx *pulumi.Context,
 	if args == nil || args.Gateway == nil {
 		return nil, errors.New("missing required argument 'Gateway'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/iot/ioTHub.go
+++ b/sdk/go/azure/iot/ioTHub.go
@@ -16,9 +16,6 @@ type IoTHub struct {
 // NewIoTHub registers a new resource with the given unique name, arguments, and options.
 func NewIoTHub(ctx *pulumi.Context,
 	name string, args *IoTHubArgs, opts ...pulumi.ResourceOpt) (*IoTHub, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/keyvault/keyVault.go
+++ b/sdk/go/azure/keyvault/keyVault.go
@@ -18,9 +18,6 @@ type KeyVault struct {
 // NewKeyVault registers a new resource with the given unique name, arguments, and options.
 func NewKeyVault(ctx *pulumi.Context,
 	name string, args *KeyVaultArgs, opts ...pulumi.ResourceOpt) (*KeyVault, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/lb/loadBalancer.go
+++ b/sdk/go/azure/lb/loadBalancer.go
@@ -16,9 +16,6 @@ type LoadBalancer struct {
 // NewLoadBalancer registers a new resource with the given unique name, arguments, and options.
 func NewLoadBalancer(ctx *pulumi.Context,
 	name string, args *LoadBalancerArgs, opts ...pulumi.ResourceOpt) (*LoadBalancer, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/logicapps/workflow.go
+++ b/sdk/go/azure/logicapps/workflow.go
@@ -16,9 +16,6 @@ type Workflow struct {
 // NewWorkflow registers a new resource with the given unique name, arguments, and options.
 func NewWorkflow(ctx *pulumi.Context,
 	name string, args *WorkflowArgs, opts ...pulumi.ResourceOpt) (*Workflow, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/mariadb/server.go
+++ b/sdk/go/azure/mariadb/server.go
@@ -24,9 +24,6 @@ func NewServer(ctx *pulumi.Context,
 	if args == nil || args.AdministratorLoginPassword == nil {
 		return nil, errors.New("missing required argument 'AdministratorLoginPassword'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/mediaservices/account.go
+++ b/sdk/go/azure/mediaservices/account.go
@@ -16,9 +16,6 @@ type Account struct {
 // NewAccount registers a new resource with the given unique name, arguments, and options.
 func NewAccount(ctx *pulumi.Context,
 	name string, args *AccountArgs, opts ...pulumi.ResourceOpt) (*Account, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/monitoring/alertRule.go
+++ b/sdk/go/azure/monitoring/alertRule.go
@@ -21,9 +21,6 @@ func NewAlertRule(ctx *pulumi.Context,
 	if args == nil || args.Aggregation == nil {
 		return nil, errors.New("missing required argument 'Aggregation'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.MetricName == nil {
 		return nil, errors.New("missing required argument 'MetricName'")
 	}

--- a/sdk/go/azure/monitoring/autoscaleSetting.go
+++ b/sdk/go/azure/monitoring/autoscaleSetting.go
@@ -16,9 +16,6 @@ type AutoscaleSetting struct {
 // NewAutoscaleSetting registers a new resource with the given unique name, arguments, and options.
 func NewAutoscaleSetting(ctx *pulumi.Context,
 	name string, args *AutoscaleSettingArgs, opts ...pulumi.ResourceOpt) (*AutoscaleSetting, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.Profiles == nil {
 		return nil, errors.New("missing required argument 'Profiles'")
 	}

--- a/sdk/go/azure/monitoring/metricAlertRule.go
+++ b/sdk/go/azure/monitoring/metricAlertRule.go
@@ -19,9 +19,6 @@ func NewMetricAlertRule(ctx *pulumi.Context,
 	if args == nil || args.Aggregation == nil {
 		return nil, errors.New("missing required argument 'Aggregation'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.MetricName == nil {
 		return nil, errors.New("missing required argument 'MetricName'")
 	}

--- a/sdk/go/azure/msi/userAssignedIdentity.go
+++ b/sdk/go/azure/msi/userAssignedIdentity.go
@@ -16,9 +16,6 @@ type UserAssignedIdentity struct {
 // NewUserAssignedIdentity registers a new resource with the given unique name, arguments, and options.
 func NewUserAssignedIdentity(ctx *pulumi.Context,
 	name string, args *UserAssignedIdentityArgs, opts ...pulumi.ResourceOpt) (*UserAssignedIdentity, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/mssql/elasticPool.go
+++ b/sdk/go/azure/mssql/elasticPool.go
@@ -16,9 +16,6 @@ type ElasticPool struct {
 // NewElasticPool registers a new resource with the given unique name, arguments, and options.
 func NewElasticPool(ctx *pulumi.Context,
 	name string, args *ElasticPoolArgs, opts ...pulumi.ResourceOpt) (*ElasticPool, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.PerDatabaseSettings == nil {
 		return nil, errors.New("missing required argument 'PerDatabaseSettings'")
 	}

--- a/sdk/go/azure/mysql/server.go
+++ b/sdk/go/azure/mysql/server.go
@@ -22,9 +22,6 @@ func NewServer(ctx *pulumi.Context,
 	if args == nil || args.AdministratorLoginPassword == nil {
 		return nil, errors.New("missing required argument 'AdministratorLoginPassword'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/network/applicationGateway.go
+++ b/sdk/go/azure/network/applicationGateway.go
@@ -34,9 +34,6 @@ func NewApplicationGateway(ctx *pulumi.Context,
 	if args == nil || args.HttpListeners == nil {
 		return nil, errors.New("missing required argument 'HttpListeners'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.RequestRoutingRules == nil {
 		return nil, errors.New("missing required argument 'RequestRoutingRules'")
 	}

--- a/sdk/go/azure/network/applicationSecurityGroup.go
+++ b/sdk/go/azure/network/applicationSecurityGroup.go
@@ -16,9 +16,6 @@ type ApplicationSecurityGroup struct {
 // NewApplicationSecurityGroup registers a new resource with the given unique name, arguments, and options.
 func NewApplicationSecurityGroup(ctx *pulumi.Context,
 	name string, args *ApplicationSecurityGroupArgs, opts ...pulumi.ResourceOpt) (*ApplicationSecurityGroup, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/network/connectionMonitor.go
+++ b/sdk/go/azure/network/connectionMonitor.go
@@ -21,9 +21,6 @@ func NewConnectionMonitor(ctx *pulumi.Context,
 	if args == nil || args.Destination == nil {
 		return nil, errors.New("missing required argument 'Destination'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.NetworkWatcherName == nil {
 		return nil, errors.New("missing required argument 'NetworkWatcherName'")
 	}

--- a/sdk/go/azure/network/expressRouteCircuit.go
+++ b/sdk/go/azure/network/expressRouteCircuit.go
@@ -19,9 +19,6 @@ func NewExpressRouteCircuit(ctx *pulumi.Context,
 	if args == nil || args.BandwidthInMbps == nil {
 		return nil, errors.New("missing required argument 'BandwidthInMbps'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.PeeringLocation == nil {
 		return nil, errors.New("missing required argument 'PeeringLocation'")
 	}

--- a/sdk/go/azure/network/firewall.go
+++ b/sdk/go/azure/network/firewall.go
@@ -19,9 +19,6 @@ func NewFirewall(ctx *pulumi.Context,
 	if args == nil || args.IpConfiguration == nil {
 		return nil, errors.New("missing required argument 'IpConfiguration'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/network/localNetworkGateway.go
+++ b/sdk/go/azure/network/localNetworkGateway.go
@@ -22,9 +22,6 @@ func NewLocalNetworkGateway(ctx *pulumi.Context,
 	if args == nil || args.GatewayAddress == nil {
 		return nil, errors.New("missing required argument 'GatewayAddress'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/network/networkInterface.go
+++ b/sdk/go/azure/network/networkInterface.go
@@ -19,9 +19,6 @@ func NewNetworkInterface(ctx *pulumi.Context,
 	if args == nil || args.IpConfigurations == nil {
 		return nil, errors.New("missing required argument 'IpConfigurations'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/network/networkSecurityGroup.go
+++ b/sdk/go/azure/network/networkSecurityGroup.go
@@ -20,9 +20,6 @@ type NetworkSecurityGroup struct {
 // NewNetworkSecurityGroup registers a new resource with the given unique name, arguments, and options.
 func NewNetworkSecurityGroup(ctx *pulumi.Context,
 	name string, args *NetworkSecurityGroupArgs, opts ...pulumi.ResourceOpt) (*NetworkSecurityGroup, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/network/networkWatcher.go
+++ b/sdk/go/azure/network/networkWatcher.go
@@ -16,9 +16,6 @@ type NetworkWatcher struct {
 // NewNetworkWatcher registers a new resource with the given unique name, arguments, and options.
 func NewNetworkWatcher(ctx *pulumi.Context,
 	name string, args *NetworkWatcherArgs, opts ...pulumi.ResourceOpt) (*NetworkWatcher, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/network/publicIp.go
+++ b/sdk/go/azure/network/publicIp.go
@@ -16,9 +16,6 @@ type PublicIp struct {
 // NewPublicIp registers a new resource with the given unique name, arguments, and options.
 func NewPublicIp(ctx *pulumi.Context,
 	name string, args *PublicIpArgs, opts ...pulumi.ResourceOpt) (*PublicIp, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/network/publicIpPrefix.go
+++ b/sdk/go/azure/network/publicIpPrefix.go
@@ -18,9 +18,6 @@ type PublicIpPrefix struct {
 // NewPublicIpPrefix registers a new resource with the given unique name, arguments, and options.
 func NewPublicIpPrefix(ctx *pulumi.Context,
 	name string, args *PublicIpPrefixArgs, opts ...pulumi.ResourceOpt) (*PublicIpPrefix, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/network/routeTable.go
+++ b/sdk/go/azure/network/routeTable.go
@@ -16,9 +16,6 @@ type RouteTable struct {
 // NewRouteTable registers a new resource with the given unique name, arguments, and options.
 func NewRouteTable(ctx *pulumi.Context,
 	name string, args *RouteTableArgs, opts ...pulumi.ResourceOpt) (*RouteTable, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/network/virtualNetwork.go
+++ b/sdk/go/azure/network/virtualNetwork.go
@@ -24,9 +24,6 @@ func NewVirtualNetwork(ctx *pulumi.Context,
 	if args == nil || args.AddressSpaces == nil {
 		return nil, errors.New("missing required argument 'AddressSpaces'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/network/virtualNetworkGateway.go
+++ b/sdk/go/azure/network/virtualNetworkGateway.go
@@ -21,9 +21,6 @@ func NewVirtualNetworkGateway(ctx *pulumi.Context,
 	if args == nil || args.IpConfigurations == nil {
 		return nil, errors.New("missing required argument 'IpConfigurations'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/network/virtualNetworkGatewayConnection.go
+++ b/sdk/go/azure/network/virtualNetworkGatewayConnection.go
@@ -16,9 +16,6 @@ type VirtualNetworkGatewayConnection struct {
 // NewVirtualNetworkGatewayConnection registers a new resource with the given unique name, arguments, and options.
 func NewVirtualNetworkGatewayConnection(ctx *pulumi.Context,
 	name string, args *VirtualNetworkGatewayConnectionArgs, opts ...pulumi.ResourceOpt) (*VirtualNetworkGatewayConnection, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/notificationhub/hub.go
+++ b/sdk/go/azure/notificationhub/hub.go
@@ -16,9 +16,6 @@ type Hub struct {
 // NewHub registers a new resource with the given unique name, arguments, and options.
 func NewHub(ctx *pulumi.Context,
 	name string, args *HubArgs, opts ...pulumi.ResourceOpt) (*Hub, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.NamespaceName == nil {
 		return nil, errors.New("missing required argument 'NamespaceName'")
 	}

--- a/sdk/go/azure/notificationhub/namespace.go
+++ b/sdk/go/azure/notificationhub/namespace.go
@@ -16,9 +16,6 @@ type Namespace struct {
 // NewNamespace registers a new resource with the given unique name, arguments, and options.
 func NewNamespace(ctx *pulumi.Context,
 	name string, args *NamespaceArgs, opts ...pulumi.ResourceOpt) (*Namespace, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.NamespaceType == nil {
 		return nil, errors.New("missing required argument 'NamespaceType'")
 	}

--- a/sdk/go/azure/operationalinsights/analyticsSolution.go
+++ b/sdk/go/azure/operationalinsights/analyticsSolution.go
@@ -16,9 +16,6 @@ type AnalyticsSolution struct {
 // NewAnalyticsSolution registers a new resource with the given unique name, arguments, and options.
 func NewAnalyticsSolution(ctx *pulumi.Context,
 	name string, args *AnalyticsSolutionArgs, opts ...pulumi.ResourceOpt) (*AnalyticsSolution, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.Plan == nil {
 		return nil, errors.New("missing required argument 'Plan'")
 	}

--- a/sdk/go/azure/operationalinsights/analyticsWorkspace.go
+++ b/sdk/go/azure/operationalinsights/analyticsWorkspace.go
@@ -16,9 +16,6 @@ type AnalyticsWorkspace struct {
 // NewAnalyticsWorkspace registers a new resource with the given unique name, arguments, and options.
 func NewAnalyticsWorkspace(ctx *pulumi.Context,
 	name string, args *AnalyticsWorkspaceArgs, opts ...pulumi.ResourceOpt) (*AnalyticsWorkspace, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/postgresql/server.go
+++ b/sdk/go/azure/postgresql/server.go
@@ -22,9 +22,6 @@ func NewServer(ctx *pulumi.Context,
 	if args == nil || args.AdministratorLoginPassword == nil {
 		return nil, errors.New("missing required argument 'AdministratorLoginPassword'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/recoveryservices/vault.go
+++ b/sdk/go/azure/recoveryservices/vault.go
@@ -16,9 +16,6 @@ type Vault struct {
 // NewVault registers a new resource with the given unique name, arguments, and options.
 func NewVault(ctx *pulumi.Context,
 	name string, args *VaultArgs, opts ...pulumi.ResourceOpt) (*Vault, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/redis/cache.go
+++ b/sdk/go/azure/redis/cache.go
@@ -45,9 +45,6 @@ func NewCache(ctx *pulumi.Context,
 	if args == nil || args.Family == nil {
 		return nil, errors.New("missing required argument 'Family'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.RedisConfiguration == nil {
 		return nil, errors.New("missing required argument 'RedisConfiguration'")
 	}

--- a/sdk/go/azure/relay/namespace.go
+++ b/sdk/go/azure/relay/namespace.go
@@ -16,9 +16,6 @@ type Namespace struct {
 // NewNamespace registers a new resource with the given unique name, arguments, and options.
 func NewNamespace(ctx *pulumi.Context,
 	name string, args *NamespaceArgs, opts ...pulumi.ResourceOpt) (*Namespace, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/scheduler/jobCollection.go
+++ b/sdk/go/azure/scheduler/jobCollection.go
@@ -18,9 +18,6 @@ type JobCollection struct {
 // NewJobCollection registers a new resource with the given unique name, arguments, and options.
 func NewJobCollection(ctx *pulumi.Context,
 	name string, args *JobCollectionArgs, opts ...pulumi.ResourceOpt) (*JobCollection, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/search/service.go
+++ b/sdk/go/azure/search/service.go
@@ -16,9 +16,6 @@ type Service struct {
 // NewService registers a new resource with the given unique name, arguments, and options.
 func NewService(ctx *pulumi.Context,
 	name string, args *ServiceArgs, opts ...pulumi.ResourceOpt) (*Service, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/servicefabric/cluster.go
+++ b/sdk/go/azure/servicefabric/cluster.go
@@ -16,9 +16,6 @@ type Cluster struct {
 // NewCluster registers a new resource with the given unique name, arguments, and options.
 func NewCluster(ctx *pulumi.Context,
 	name string, args *ClusterArgs, opts ...pulumi.ResourceOpt) (*Cluster, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ManagementEndpoint == nil {
 		return nil, errors.New("missing required argument 'ManagementEndpoint'")
 	}

--- a/sdk/go/azure/signalr/service.go
+++ b/sdk/go/azure/signalr/service.go
@@ -16,9 +16,6 @@ type Service struct {
 // NewService registers a new resource with the given unique name, arguments, and options.
 func NewService(ctx *pulumi.Context,
 	name string, args *ServiceArgs, opts ...pulumi.ResourceOpt) (*Service, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/sql/database.go
+++ b/sdk/go/azure/sql/database.go
@@ -16,9 +16,6 @@ type Database struct {
 // NewDatabase registers a new resource with the given unique name, arguments, and options.
 func NewDatabase(ctx *pulumi.Context,
 	name string, args *DatabaseArgs, opts ...pulumi.ResourceOpt) (*Database, error) {
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/sql/elasticPool.go
+++ b/sdk/go/azure/sql/elasticPool.go
@@ -24,9 +24,6 @@ func NewElasticPool(ctx *pulumi.Context,
 	if args == nil || args.Edition == nil {
 		return nil, errors.New("missing required argument 'Edition'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/sql/sqlServer.go
+++ b/sdk/go/azure/sql/sqlServer.go
@@ -25,9 +25,6 @@ func NewSqlServer(ctx *pulumi.Context,
 	if args == nil || args.AdministratorLoginPassword == nil {
 		return nil, errors.New("missing required argument 'AdministratorLoginPassword'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/storage/account.go
+++ b/sdk/go/azure/storage/account.go
@@ -22,9 +22,6 @@ func NewAccount(ctx *pulumi.Context,
 	if args == nil || args.AccountTier == nil {
 		return nil, errors.New("missing required argument 'AccountTier'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}

--- a/sdk/go/azure/streamanalytics/job.go
+++ b/sdk/go/azure/streamanalytics/job.go
@@ -31,9 +31,6 @@ func NewJob(ctx *pulumi.Context,
 	if args == nil || args.EventsOutOfOrderPolicy == nil {
 		return nil, errors.New("missing required argument 'EventsOutOfOrderPolicy'")
 	}
-	if args == nil || args.Location == nil {
-		return nil, errors.New("missing required argument 'Location'")
-	}
 	if args == nil || args.OutputErrorPolicy == nil {
 		return nil, errors.New("missing required argument 'OutputErrorPolicy'")
 	}

--- a/sdk/nodejs/apimanagement/service.ts
+++ b/sdk/nodejs/apimanagement/service.ts
@@ -168,9 +168,6 @@ export class Service extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as ServiceArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.publisherEmail === undefined) {
                 throw new Error("Missing required property 'publisherEmail'");
             }
@@ -327,7 +324,7 @@ export interface ServiceArgs {
     /**
      * The Azure location where the API Management Service exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name of the API Management Service. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/appinsights/insights.ts
+++ b/sdk/nodejs/appinsights/insights.ts
@@ -96,9 +96,6 @@ export class Insights extends pulumi.CustomResource {
             if (!args || args.applicationType === undefined) {
                 throw new Error("Missing required property 'applicationType'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -161,7 +158,7 @@ export interface InsightsArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Application Insights component. Changing this forces a
      * new resource to be created.

--- a/sdk/nodejs/appservice/appService.ts
+++ b/sdk/nodejs/appservice/appService.ts
@@ -171,9 +171,6 @@ export class AppService extends pulumi.CustomResource {
             if (!args || args.appServicePlanId === undefined) {
                 throw new Error("Missing required property 'appServicePlanId'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -317,7 +314,7 @@ export interface AppServiceArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the App Service. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/appservice/functionApp.ts
+++ b/sdk/nodejs/appservice/functionApp.ts
@@ -208,9 +208,6 @@ export class FunctionApp extends pulumi.CustomResource {
             if (!args || args.appServicePlanId === undefined) {
                 throw new Error("Missing required property 'appServicePlanId'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -367,7 +364,7 @@ export interface FunctionAppArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name of the Connection String.
      */

--- a/sdk/nodejs/appservice/plan.ts
+++ b/sdk/nodejs/appservice/plan.ts
@@ -155,9 +155,6 @@ export class Plan extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as PlanArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -242,7 +239,7 @@ export interface PlanArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the App Service Plan component. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/appservice/slot.ts
+++ b/sdk/nodejs/appservice/slot.ts
@@ -228,9 +228,6 @@ export class Slot extends pulumi.CustomResource {
             if (!args || args.appServicePlanId === undefined) {
                 throw new Error("Missing required property 'appServicePlanId'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -354,7 +351,7 @@ export interface SlotArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name of the Connection String.
      */

--- a/sdk/nodejs/automation/account.ts
+++ b/sdk/nodejs/automation/account.ts
@@ -98,9 +98,6 @@ export class Account extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as AccountArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -165,7 +162,7 @@ export interface AccountArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The SKU name of the account - only `Basic` is supported at this time. Defaults to `Basic`.
      */

--- a/sdk/nodejs/automation/dscConfiguration.ts
+++ b/sdk/nodejs/automation/dscConfiguration.ts
@@ -105,9 +105,6 @@ export class DscConfiguration extends pulumi.CustomResource {
             if (!args || args.contentEmbedded === undefined) {
                 throw new Error("Missing required property 'contentEmbedded'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -178,7 +175,7 @@ export interface DscConfigurationArgs {
     /**
      * Must be the same location as the Automation Account.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Verbose log option.
      */

--- a/sdk/nodejs/automation/runBook.ts
+++ b/sdk/nodejs/automation/runBook.ts
@@ -126,9 +126,6 @@ export class RunBook extends pulumi.CustomResource {
             if (!args || args.accountName === undefined) {
                 throw new Error("Missing required property 'accountName'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.logProgress === undefined) {
                 throw new Error("Missing required property 'logProgress'");
             }
@@ -229,7 +226,7 @@ export interface RunBookArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Progress log option.
      */

--- a/sdk/nodejs/autoscale/setting.ts
+++ b/sdk/nodejs/autoscale/setting.ts
@@ -309,9 +309,6 @@ export class Setting extends pulumi.CustomResource {
             inputs["targetResourceId"] = state ? state.targetResourceId : undefined;
         } else {
             const args = argsOrState as SettingArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.profiles === undefined) {
                 throw new Error("Missing required property 'profiles'");
             }
@@ -383,7 +380,7 @@ export interface SettingArgs {
     /**
      * Specifies the supported Azure location where the AutoScale Setting should exist. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name of the AutoScale Setting. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/batch/account.ts
+++ b/sdk/nodejs/batch/account.ts
@@ -109,9 +109,6 @@ export class Account extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as AccountArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -178,7 +175,7 @@ export interface AccountArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Batch account. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/cdn/endpoint.ts
+++ b/sdk/nodejs/cdn/endpoint.ts
@@ -152,9 +152,6 @@ export class Endpoint extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as EndpointArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.origins === undefined) {
                 throw new Error("Missing required property 'origins'");
             }
@@ -284,7 +281,7 @@ export interface EndpointArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the CDN Endpoint. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/cdn/profile.ts
+++ b/sdk/nodejs/cdn/profile.ts
@@ -84,9 +84,6 @@ export class Profile extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as ProfileArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -138,7 +135,7 @@ export interface ProfileArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the CDN Profile. Changing this forces a
      * new resource to be created.

--- a/sdk/nodejs/cognitive/account.ts
+++ b/sdk/nodejs/cognitive/account.ts
@@ -108,9 +108,6 @@ export class Account extends pulumi.CustomResource {
             if (!args || args.kind === undefined) {
                 throw new Error("Missing required property 'kind'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -184,7 +181,7 @@ export interface AccountArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Cognitive Service Account. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/compute/availabilitySet.ts
+++ b/sdk/nodejs/compute/availabilitySet.ts
@@ -90,9 +90,6 @@ export class AvailabilitySet extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as AvailabilitySetArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -149,7 +146,7 @@ export interface AvailabilitySetArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies whether the availability set is managed or not. Possible values are `true` (to specify aligned) or `false` (to specify classic). Default is `false`.
      */

--- a/sdk/nodejs/compute/extension.ts
+++ b/sdk/nodejs/compute/extension.ts
@@ -202,9 +202,6 @@ export class Extension extends pulumi.CustomResource {
             inputs["virtualMachineName"] = state ? state.virtualMachineName : undefined;
         } else {
             const args = argsOrState as ExtensionArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.publisher === undefined) {
                 throw new Error("Missing required property 'publisher'");
             }
@@ -310,7 +307,7 @@ export interface ExtensionArgs {
      * The location where the extension is created. Changing
      * this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name of the virtual machine extension peering. Changing
      * this forces a new resource to be created.

--- a/sdk/nodejs/compute/image.ts
+++ b/sdk/nodejs/compute/image.ts
@@ -119,9 +119,6 @@ export class Image extends pulumi.CustomResource {
             inputs["zoneResilient"] = state ? state.zoneResilient : undefined;
         } else {
             const args = argsOrState as ImageArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -191,7 +188,7 @@ export interface ImageArgs {
      * Specified the supported Azure location where the resource exists.
      * Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the image. Changing this forces a
      * new resource to be created.

--- a/sdk/nodejs/compute/managedDisk.ts
+++ b/sdk/nodejs/compute/managedDisk.ts
@@ -167,9 +167,6 @@ export class ManagedDisk extends pulumi.CustomResource {
             if (!args || args.createOption === undefined) {
                 throw new Error("Missing required property 'createOption'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -283,7 +280,7 @@ export interface ManagedDiskArgs {
      * Specified the supported Azure location where the resource exists.
      * Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the managed disk. Changing this forces a
      * new resource to be created.

--- a/sdk/nodejs/compute/scaleSet.ts
+++ b/sdk/nodejs/compute/scaleSet.ts
@@ -402,9 +402,6 @@ export class ScaleSet extends pulumi.CustomResource {
             inputs["zones"] = state ? state.zones : undefined;
         } else {
             const args = argsOrState as ScaleSetArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.networkProfiles === undefined) {
                 throw new Error("Missing required property 'networkProfiles'");
             }
@@ -598,7 +595,7 @@ export interface ScaleSetArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the image from the marketplace.
      */

--- a/sdk/nodejs/compute/sharedImage.ts
+++ b/sdk/nodejs/compute/sharedImage.ts
@@ -132,9 +132,6 @@ export class SharedImage extends pulumi.CustomResource {
             if (!args || args.identifier === undefined) {
                 throw new Error("Missing required property 'identifier'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.osType === undefined) {
                 throw new Error("Missing required property 'osType'");
             }
@@ -230,7 +227,7 @@ export interface SharedImageArgs {
     /**
      * Specifies the supported Azure location where the Shared Image Gallery exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Shared Image. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/compute/sharedImageGallery.ts
+++ b/sdk/nodejs/compute/sharedImageGallery.ts
@@ -89,9 +89,6 @@ export class SharedImageGallery extends pulumi.CustomResource {
             inputs["uniqueName"] = state ? state.uniqueName : undefined;
         } else {
             const args = argsOrState as SharedImageGalleryArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -147,7 +144,7 @@ export interface SharedImageGalleryArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Shared Image Gallery. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/compute/sharedImageVersion.ts
+++ b/sdk/nodejs/compute/sharedImageVersion.ts
@@ -117,9 +117,6 @@ export class SharedImageVersion extends pulumi.CustomResource {
             if (!args || args.imageName === undefined) {
                 throw new Error("Missing required property 'imageName'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.managedImageId === undefined) {
                 throw new Error("Missing required property 'managedImageId'");
             }
@@ -204,7 +201,7 @@ export interface SharedImageVersionArgs {
     /**
      * The Azure Region in which the Shared Image Gallery exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The ID of the Managed Image which should be used for this Shared Image Version. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/compute/snapshot.ts
+++ b/sdk/nodejs/compute/snapshot.ts
@@ -112,9 +112,6 @@ export class Snapshot extends pulumi.CustomResource {
             if (!args || args.createOption === undefined) {
                 throw new Error("Missing required property 'createOption'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -192,7 +189,7 @@ export interface SnapshotArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Snapshot resource. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/compute/virtualMachine.ts
+++ b/sdk/nodejs/compute/virtualMachine.ts
@@ -216,9 +216,6 @@ export class VirtualMachine extends pulumi.CustomResource {
             inputs["zones"] = state ? state.zones : undefined;
         } else {
             const args = argsOrState as VirtualMachineArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.networkInterfaceIds === undefined) {
                 throw new Error("Missing required property 'networkInterfaceIds'");
             }
@@ -383,7 +380,7 @@ export interface VirtualMachineArgs {
     /**
      * Specifies the Azure Region where the Virtual Machine exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Virtual Machine. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/config/vars.ts
+++ b/sdk/nodejs/config/vars.ts
@@ -18,3 +18,4 @@ export let skipProviderRegistration: boolean | undefined = __config.getObject<bo
 export let subscriptionId: string | undefined = __config.get("subscriptionId") || (utilities.getEnv("ARM_SUBSCRIPTION_ID") || "");
 export let tenantId: string | undefined = __config.get("tenantId") || (utilities.getEnv("ARM_TENANT_ID") || "");
 export let useMsi: boolean | undefined = __config.getObject<boolean>("useMsi") || (utilities.getEnvBoolean("ARM_USE_MSI") || false);
+export let location: string | undefined = __config.get("location") || utilities.getEnv("ARM_LOCATION");

--- a/sdk/nodejs/containerservice/group.ts
+++ b/sdk/nodejs/containerservice/group.ts
@@ -195,9 +195,6 @@ export class Group extends pulumi.CustomResource {
             if (!args || args.containers === undefined) {
                 throw new Error("Missing required property 'containers'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.osType === undefined) {
                 throw new Error("Missing required property 'osType'");
             }
@@ -307,7 +304,7 @@ export interface GroupArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Container Group. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/containerservice/kubernetesCluster.ts
+++ b/sdk/nodejs/containerservice/kubernetesCluster.ts
@@ -170,9 +170,6 @@ export class KubernetesCluster extends pulumi.CustomResource {
             if (!args || args.dnsPrefix === undefined) {
                 throw new Error("Missing required property 'dnsPrefix'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -307,7 +304,7 @@ export interface KubernetesClusterArgs {
     /**
      * The location where the Managed Kubernetes Cluster should be created. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name of the Managed Kubernetes Cluster to create. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/containerservice/registry.ts
+++ b/sdk/nodejs/containerservice/registry.ts
@@ -118,9 +118,6 @@ export class Registry extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as RegistryArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -207,7 +204,7 @@ export interface RegistryArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Container Registry. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/containerservice/service.ts
+++ b/sdk/nodejs/containerservice/service.ts
@@ -223,9 +223,6 @@ export class Service extends pulumi.CustomResource {
             if (!args || args.linuxProfile === undefined) {
                 throw new Error("Missing required property 'linuxProfile'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.masterProfile === undefined) {
                 throw new Error("Missing required property 'masterProfile'");
             }
@@ -315,7 +312,7 @@ export interface ServiceArgs {
     /**
      * The location where the Container Service instance should be created. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * A Master Profile block as documented below.
      */

--- a/sdk/nodejs/core/resourceGroup.ts
+++ b/sdk/nodejs/core/resourceGroup.ts
@@ -57,7 +57,7 @@ export class ResourceGroup extends pulumi.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args: ResourceGroupArgs, opts?: pulumi.CustomResourceOptions)
+    constructor(name: string, args?: ResourceGroupArgs, opts?: pulumi.CustomResourceOptions)
     constructor(name: string, argsOrState?: ResourceGroupArgs | ResourceGroupState, opts?: pulumi.CustomResourceOptions) {
         let inputs: pulumi.Inputs = {};
         if (opts && opts.id) {
@@ -67,9 +67,6 @@ export class ResourceGroup extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as ResourceGroupArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             inputs["location"] = args ? args.location : undefined;
             inputs["name"] = args ? args.name : undefined;
             inputs["tags"] = args ? args.tags : undefined;
@@ -106,7 +103,7 @@ export interface ResourceGroupArgs {
      * The location where the resource group should be created.
      * For a list of all Azure locations, please consult [this link](http://azure.microsoft.com/en-us/regions/) or run `az account list-locations --output table`.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name of the resource group. Must be unique on your
      * Azure subscription.

--- a/sdk/nodejs/cosmosdb/account.ts
+++ b/sdk/nodejs/cosmosdb/account.ts
@@ -191,9 +191,6 @@ export class Account extends pulumi.CustomResource {
             if (!args || args.consistencyPolicy === undefined) {
                 throw new Error("Missing required property 'consistencyPolicy'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.offerType === undefined) {
                 throw new Error("Missing required property 'offerType'");
             }
@@ -363,7 +360,7 @@ export interface AccountArgs {
     /**
      * The name of the Azure region to host replicated data.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The capability to enable - Possible values are `EnableTable`, `EnableCassandra`, and `EnableGremlin`.
      */

--- a/sdk/nodejs/databricks/workspace.ts
+++ b/sdk/nodejs/databricks/workspace.ts
@@ -91,9 +91,6 @@ export class Workspace extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as WorkspaceArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -153,7 +150,7 @@ export interface WorkspaceArgs {
     /**
      * Specifies the supported Azure location where the resource has to be created. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name of the resource group where Azure should place the managed Databricks resources. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/datafactory/factory.ts
+++ b/sdk/nodejs/datafactory/factory.ts
@@ -87,9 +87,6 @@ export class Factory extends pulumi.CustomResource {
             inputs["vstsConfiguration"] = state ? state.vstsConfiguration : undefined;
         } else {
             const args = argsOrState as FactoryArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -154,7 +151,7 @@ export interface FactoryArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Data Factory. Changing this forces a new resource to be created. Must be globally unique. See the [Microsoft documentation](https://docs.microsoft.com/en-us/azure/data-factory/naming-rules) for all restrictions.
      */

--- a/sdk/nodejs/datalake/analyticsAccount.ts
+++ b/sdk/nodejs/datalake/analyticsAccount.ts
@@ -91,9 +91,6 @@ export class AnalyticsAccount extends pulumi.CustomResource {
             if (!args || args.defaultStoreAccountName === undefined) {
                 throw new Error("Missing required property 'defaultStoreAccountName'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -149,7 +146,7 @@ export interface AnalyticsAccountArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Data Lake Analytics Account. Changing this forces a new resource to be created. Has to be between 3 to 24 characters.
      */

--- a/sdk/nodejs/datalake/store.ts
+++ b/sdk/nodejs/datalake/store.ts
@@ -104,9 +104,6 @@ export class Store extends pulumi.CustomResource {
             inputs["tier"] = state ? state.tier : undefined;
         } else {
             const args = argsOrState as StoreArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -194,7 +191,7 @@ export interface StoreArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Data Lake Store. Changing this forces a new resource to be created. Has to be between 3 to 24 characters.
      */

--- a/sdk/nodejs/ddosprotection/plan.ts
+++ b/sdk/nodejs/ddosprotection/plan.ts
@@ -81,9 +81,6 @@ export class Plan extends pulumi.CustomResource {
             inputs["virtualNetworkIds"] = state ? state.virtualNetworkIds : undefined;
         } else {
             const args = argsOrState as PlanArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -130,7 +127,7 @@ export interface PlanArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the DDoS Protection Plan. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/devspace/controller.ts
+++ b/sdk/nodejs/devspace/controller.ts
@@ -125,9 +125,6 @@ export class Controller extends pulumi.CustomResource {
             if (!args || args.hostSuffix === undefined) {
                 throw new Error("Missing required property 'hostSuffix'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -207,7 +204,7 @@ export interface ControllerArgs {
     /**
      * Specifies the supported location where the DevSpace Controller should exist. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the DevSpace Controller. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/devtest/lab.ts
+++ b/sdk/nodejs/devtest/lab.ts
@@ -110,9 +110,6 @@ export class Lab extends pulumi.CustomResource {
             inputs["uniqueIdentifier"] = state ? state.uniqueIdentifier : undefined;
         } else {
             const args = argsOrState as LabArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -189,7 +186,7 @@ export interface LabArgs {
     /**
      * Specifies the supported Azure location where the Dev Test Lab should exist. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Dev Test Lab. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/devtest/linuxVirtualMachine.ts
+++ b/sdk/nodejs/devtest/linuxVirtualMachine.ts
@@ -191,9 +191,6 @@ export class LinuxVirtualMachine extends pulumi.CustomResource {
             if (!args || args.labVirtualNetworkId === undefined) {
                 throw new Error("Missing required property 'labVirtualNetworkId'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -347,7 +344,7 @@ export interface LinuxVirtualMachineArgs {
     /**
      * Specifies the supported Azure location where the Dev Test Lab exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Dev Test Machine. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/devtest/windowsVirtualMachine.ts
+++ b/sdk/nodejs/devtest/windowsVirtualMachine.ts
@@ -185,9 +185,6 @@ export class WindowsVirtualMachine extends pulumi.CustomResource {
             if (!args || args.labVirtualNetworkId === undefined) {
                 throw new Error("Missing required property 'labVirtualNetworkId'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.password === undefined) {
                 throw new Error("Missing required property 'password'");
             }
@@ -339,7 +336,7 @@ export interface WindowsVirtualMachineArgs {
     /**
      * Specifies the supported Azure location where the Dev Test Lab exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Dev Test Machine. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/eventhub/eventGridDomain.ts
+++ b/sdk/nodejs/eventhub/eventGridDomain.ts
@@ -95,9 +95,6 @@ export class EventGridDomain extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as EventGridDomainArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -171,7 +168,7 @@ export interface EventGridDomainArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the EventGrid Domain resource. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/eventhub/eventGridTopic.ts
+++ b/sdk/nodejs/eventhub/eventGridTopic.ts
@@ -92,9 +92,6 @@ export class EventGridTopic extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as EventGridTopicArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -151,7 +148,7 @@ export interface EventGridTopicArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the EventGrid Topic resource. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/eventhub/eventHub.ts
+++ b/sdk/nodejs/eventhub/eventHub.ts
@@ -54,7 +54,7 @@ export class EventHub extends pulumi.CustomResource {
      * A `capture_description` block as defined below.
      */
     public readonly captureDescription: pulumi.Output<{ destination: { archiveNameFormat: string, blobContainerName: string, name: string, storageAccountId: string }, enabled: boolean, encoding: string, intervalInSeconds?: number, sizeLimitInBytes?: number, skipEmptyArchives?: boolean } | undefined>;
-    public readonly location: pulumi.Output<string | undefined>;
+    public readonly location: pulumi.Output<string>;
     /**
      * Specifies the number of days to retain the events for this Event Hub. Needs to be between 1 and 7 days; or 1 day when using a Basic SKU for the parent EventHub Namespace.
      */

--- a/sdk/nodejs/eventhub/eventHubAuthorizationRule.ts
+++ b/sdk/nodejs/eventhub/eventHubAuthorizationRule.ts
@@ -66,7 +66,7 @@ export class EventHubAuthorizationRule extends pulumi.CustomResource {
      * Does this Authorization Rule have permissions to Listen to the Event Hub? Defaults to `false`.
      */
     public readonly listen: pulumi.Output<boolean | undefined>;
-    public readonly location: pulumi.Output<string | undefined>;
+    public readonly location: pulumi.Output<string>;
     /**
      * Does this Authorization Rule have permissions to Manage to the Event Hub? When this property is `true` - both `listen` and `send` must be too. Defaults to `false`.
      */

--- a/sdk/nodejs/eventhub/eventHubConsumerGroup.ts
+++ b/sdk/nodejs/eventhub/eventHubConsumerGroup.ts
@@ -60,7 +60,7 @@ export class EventHubConsumerGroup extends pulumi.CustomResource {
      * Specifies the name of the EventHub. Changing this forces a new resource to be created.
      */
     public readonly eventhubName: pulumi.Output<string>;
-    public readonly location: pulumi.Output<string | undefined>;
+    public readonly location: pulumi.Output<string>;
     /**
      * Specifies the name of the EventHub Consumer Group resource. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/eventhub/eventHubNamespace.ts
+++ b/sdk/nodejs/eventhub/eventHubNamespace.ts
@@ -124,9 +124,6 @@ export class EventHubNamespace extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as EventHubNamespaceArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -230,7 +227,7 @@ export interface EventHubNamespaceArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the maximum number of throughput units when Auto Inflate is Enabled. Valid values range from 1 - 20.
      */

--- a/sdk/nodejs/eventhub/eventHubNamespaceAuthorizationRule.ts
+++ b/sdk/nodejs/eventhub/eventHubNamespaceAuthorizationRule.ts
@@ -54,7 +54,7 @@ export class EventHubNamespaceAuthorizationRule extends pulumi.CustomResource {
      * Grants listen access to this this Authorization Rule. Defaults to `false`.
      */
     public readonly listen: pulumi.Output<boolean | undefined>;
-    public readonly location: pulumi.Output<string | undefined>;
+    public readonly location: pulumi.Output<string>;
     /**
      * Grants manage access to this this Authorization Rule. When this property is `true` - both `listen` and `send` must be too. Defaults to `false`.
      */

--- a/sdk/nodejs/eventhub/namespace.ts
+++ b/sdk/nodejs/eventhub/namespace.ts
@@ -110,9 +110,6 @@ export class Namespace extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as NamespaceArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -195,7 +192,7 @@ export interface NamespaceArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the ServiceBus Namespace resource . Changing this forces a
      * new resource to be created.

--- a/sdk/nodejs/eventhub/queue.ts
+++ b/sdk/nodejs/eventhub/queue.ts
@@ -85,7 +85,7 @@ export class Queue extends pulumi.CustomResource {
      * Specifies the supported Azure location where the resource exists.
      * Changing this forces a new resource to be created.
      */
-    public readonly location: pulumi.Output<string | undefined>;
+    public readonly location: pulumi.Output<string>;
     /**
      * The ISO 8601 timespan duration of a peek-lock; that is, the amount of time that the message is locked for other receivers. Maximum value is 5 minutes. Defaults to 1 minute. (`PT1M`)
      */

--- a/sdk/nodejs/eventhub/subscription.ts
+++ b/sdk/nodejs/eventhub/subscription.ts
@@ -87,7 +87,7 @@ export class Subscription extends pulumi.CustomResource {
      * Specifies the supported Azure location where the resource exists.
      * Changing this forces a new resource to be created.
      */
-    public readonly location: pulumi.Output<string | undefined>;
+    public readonly location: pulumi.Output<string>;
     /**
      * The lock duration for the subscription, maximum
      * supported value is 5 minutes. Defaults to 1 minute.

--- a/sdk/nodejs/eventhub/topic.ts
+++ b/sdk/nodejs/eventhub/topic.ts
@@ -86,7 +86,7 @@ export class Topic extends pulumi.CustomResource {
      * Specifies the supported Azure location where the resource exists.
      * Changing this forces a new resource to be created.
      */
-    public readonly location: pulumi.Output<string | undefined>;
+    public readonly location: pulumi.Output<string>;
     /**
      * Integer value which controls the size of
      * memory allocated for the topic. For supported values see the "Queue/topic size"

--- a/sdk/nodejs/hdinsight/hBaseCluster.ts
+++ b/sdk/nodejs/hdinsight/hBaseCluster.ts
@@ -167,9 +167,6 @@ export class HBaseCluster extends pulumi.CustomResource {
             if (!args || args.gateway === undefined) {
                 throw new Error("Missing required property 'gateway'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -272,7 +269,7 @@ export interface HBaseClusterArgs {
     /**
      * Specifies the Azure Region which this HDInsight HBase Cluster should exist. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name for this HDInsight HBase Cluster. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/hdinsight/hadoopCluster.ts
+++ b/sdk/nodejs/hdinsight/hadoopCluster.ts
@@ -167,9 +167,6 @@ export class HadoopCluster extends pulumi.CustomResource {
             if (!args || args.gateway === undefined) {
                 throw new Error("Missing required property 'gateway'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -272,7 +269,7 @@ export interface HadoopClusterArgs {
     /**
      * Specifies the Azure Region which this HDInsight Hadoop Cluster should exist. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name for this HDInsight Hadoop Cluster. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/hdinsight/interactiveQueryCluster.ts
+++ b/sdk/nodejs/hdinsight/interactiveQueryCluster.ts
@@ -167,9 +167,6 @@ export class InteractiveQueryCluster extends pulumi.CustomResource {
             if (!args || args.gateway === undefined) {
                 throw new Error("Missing required property 'gateway'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -272,7 +269,7 @@ export interface InteractiveQueryClusterArgs {
     /**
      * Specifies the Azure Region which this HDInsight Interactive Query Cluster should exist. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name for this HDInsight Interactive Query Cluster. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/hdinsight/kafkaCluster.ts
+++ b/sdk/nodejs/hdinsight/kafkaCluster.ts
@@ -168,9 +168,6 @@ export class KafkaCluster extends pulumi.CustomResource {
             if (!args || args.gateway === undefined) {
                 throw new Error("Missing required property 'gateway'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -273,7 +270,7 @@ export interface KafkaClusterArgs {
     /**
      * Specifies the Azure Region which this HDInsight Kafka Cluster should exist. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name for this HDInsight Kafka Cluster. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/hdinsight/mLServicesCluster.ts
+++ b/sdk/nodejs/hdinsight/mLServicesCluster.ts
@@ -172,9 +172,6 @@ export class MLServicesCluster extends pulumi.CustomResource {
             if (!args || args.gateway === undefined) {
                 throw new Error("Missing required property 'gateway'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -281,7 +278,7 @@ export interface MLServicesClusterArgs {
     /**
      * Specifies the Azure Region which this HDInsight ML Services Cluster should exist. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name for this HDInsight ML Services Cluster. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/hdinsight/rServerCluster.ts
+++ b/sdk/nodejs/hdinsight/rServerCluster.ts
@@ -172,9 +172,6 @@ export class RServerCluster extends pulumi.CustomResource {
             if (!args || args.gateway === undefined) {
                 throw new Error("Missing required property 'gateway'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -281,7 +278,7 @@ export interface RServerClusterArgs {
     /**
      * Specifies the Azure Region which this HDInsight RServer Cluster should exist. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name for this HDInsight RServer Cluster. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/hdinsight/sparkCluster.ts
+++ b/sdk/nodejs/hdinsight/sparkCluster.ts
@@ -167,9 +167,6 @@ export class SparkCluster extends pulumi.CustomResource {
             if (!args || args.gateway === undefined) {
                 throw new Error("Missing required property 'gateway'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -272,7 +269,7 @@ export interface SparkClusterArgs {
     /**
      * Specifies the Azure Region which this HDInsight Spark Cluster should exist. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name for this HDInsight Spark Cluster. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/hdinsight/stormCluster.ts
+++ b/sdk/nodejs/hdinsight/stormCluster.ts
@@ -167,9 +167,6 @@ export class StormCluster extends pulumi.CustomResource {
             if (!args || args.gateway === undefined) {
                 throw new Error("Missing required property 'gateway'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -272,7 +269,7 @@ export interface StormClusterArgs {
     /**
      * Specifies the Azure Region which this HDInsight Storm Cluster should exist. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name for this HDInsight Storm Cluster. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/iot/ioTHub.ts
+++ b/sdk/nodejs/iot/ioTHub.ts
@@ -170,9 +170,6 @@ export class IoTHub extends pulumi.CustomResource {
             inputs["type"] = state ? state.type : undefined;
         } else {
             const args = argsOrState as IoTHubArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -286,7 +283,7 @@ export interface IoTHubArgs {
     /**
      * Specifies the supported Azure location where the resource has to be createc. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the IotHub resource. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/keyvault/keyVault.ts
+++ b/sdk/nodejs/keyvault/keyVault.ts
@@ -133,9 +133,6 @@ export class KeyVault extends pulumi.CustomResource {
             inputs["vaultUri"] = state ? state.vaultUri : undefined;
         } else {
             const args = argsOrState as KeyVaultArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -239,7 +236,7 @@ export interface KeyVaultArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Key Vault. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/lb/backendAddressPool.ts
+++ b/sdk/nodejs/lb/backendAddressPool.ts
@@ -66,7 +66,7 @@ export class BackendAddressPool extends pulumi.CustomResource {
      * The ID of the Load Balancer in which to create the Backend Address Pool.
      */
     public readonly loadbalancerId: pulumi.Output<string>;
-    public readonly location: pulumi.Output<string | undefined>;
+    public readonly location: pulumi.Output<string>;
     /**
      * Specifies the name of the Backend Address Pool.
      */

--- a/sdk/nodejs/lb/loadBalancer.ts
+++ b/sdk/nodejs/lb/loadBalancer.ts
@@ -102,9 +102,6 @@ export class LoadBalancer extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as LoadBalancerArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -170,7 +167,7 @@ export interface LoadBalancerArgs {
     /**
      * Specifies the supported Azure Region where the Load Balancer should be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the frontend ip configuration.
      */

--- a/sdk/nodejs/lb/natPool.ts
+++ b/sdk/nodejs/lb/natPool.ts
@@ -80,7 +80,7 @@ export class NatPool extends pulumi.CustomResource {
      * The ID of the Load Balancer in which to create the NAT pool.
      */
     public readonly loadbalancerId: pulumi.Output<string>;
-    public readonly location: pulumi.Output<string | undefined>;
+    public readonly location: pulumi.Output<string>;
     /**
      * Specifies the name of the NAT pool.
      */

--- a/sdk/nodejs/lb/natRule.ts
+++ b/sdk/nodejs/lb/natRule.ts
@@ -80,7 +80,7 @@ export class NatRule extends pulumi.CustomResource {
      * The ID of the Load Balancer in which to create the NAT Rule.
      */
     public readonly loadbalancerId: pulumi.Output<string>;
-    public readonly location: pulumi.Output<string | undefined>;
+    public readonly location: pulumi.Output<string>;
     /**
      * Specifies the name of the NAT Rule.
      */

--- a/sdk/nodejs/lb/probe.ts
+++ b/sdk/nodejs/lb/probe.ts
@@ -64,7 +64,7 @@ export class Probe extends pulumi.CustomResource {
      * The ID of the LoadBalancer in which to create the NAT Rule.
      */
     public readonly loadbalancerId: pulumi.Output<string>;
-    public readonly location: pulumi.Output<string | undefined>;
+    public readonly location: pulumi.Output<string>;
     /**
      * Specifies the name of the Probe.
      */

--- a/sdk/nodejs/lb/rule.ts
+++ b/sdk/nodejs/lb/rule.ts
@@ -91,7 +91,7 @@ export class Rule extends pulumi.CustomResource {
      * The ID of the Load Balancer in which to create the Rule.
      */
     public readonly loadbalancerId: pulumi.Output<string>;
-    public readonly location: pulumi.Output<string | undefined>;
+    public readonly location: pulumi.Output<string>;
     /**
      * Specifies the name of the LB Rule.
      */

--- a/sdk/nodejs/logicapps/workflow.ts
+++ b/sdk/nodejs/logicapps/workflow.ts
@@ -92,9 +92,6 @@ export class Workflow extends pulumi.CustomResource {
             inputs["workflowVersion"] = state ? state.workflowVersion : undefined;
         } else {
             const args = argsOrState as WorkflowArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -156,7 +153,7 @@ export interface WorkflowArgs {
     /**
      * Specifies the supported Azure location where the Logic App Workflow exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Logic App Workflow. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/mariadb/server.ts
+++ b/sdk/nodejs/mariadb/server.ts
@@ -130,9 +130,6 @@ export class Server extends pulumi.CustomResource {
             if (!args || args.administratorLoginPassword === undefined) {
                 throw new Error("Missing required property 'administratorLoginPassword'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -229,7 +226,7 @@ export interface ServerArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the MariaDB Server. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/mediaservices/account.ts
+++ b/sdk/nodejs/mediaservices/account.ts
@@ -83,9 +83,6 @@ export class Account extends pulumi.CustomResource {
             inputs["storageAccounts"] = state ? state.storageAccounts : undefined;
         } else {
             const args = argsOrState as AccountArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -130,7 +127,7 @@ export interface AccountArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Media Services Account. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/monitoring/alertRule.ts
+++ b/sdk/nodejs/monitoring/alertRule.ts
@@ -174,9 +174,6 @@ export class AlertRule extends pulumi.CustomResource {
             if (!args || args.aggregation === undefined) {
                 throw new Error("Missing required property 'aggregation'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.metricName === undefined) {
                 throw new Error("Missing required property 'metricName'");
             }
@@ -299,7 +296,7 @@ export interface AlertRuleArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The metric that defines what the rule monitors.
      */

--- a/sdk/nodejs/monitoring/autoscaleSetting.ts
+++ b/sdk/nodejs/monitoring/autoscaleSetting.ts
@@ -307,9 +307,6 @@ export class AutoscaleSetting extends pulumi.CustomResource {
             inputs["targetResourceId"] = state ? state.targetResourceId : undefined;
         } else {
             const args = argsOrState as AutoscaleSettingArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.profiles === undefined) {
                 throw new Error("Missing required property 'profiles'");
             }
@@ -381,7 +378,7 @@ export interface AutoscaleSettingArgs {
     /**
      * Specifies the supported Azure location where the AutoScale Setting should exist. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name of the AutoScale Setting. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/monitoring/metricAlertRule.ts
+++ b/sdk/nodejs/monitoring/metricAlertRule.ts
@@ -172,9 +172,6 @@ export class MetricAlertRule extends pulumi.CustomResource {
             if (!args || args.aggregation === undefined) {
                 throw new Error("Missing required property 'aggregation'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.metricName === undefined) {
                 throw new Error("Missing required property 'metricName'");
             }
@@ -297,7 +294,7 @@ export interface MetricAlertRuleArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The metric that defines what the rule monitors.
      */

--- a/sdk/nodejs/msi/userAssignedIdentity.ts
+++ b/sdk/nodejs/msi/userAssignedIdentity.ts
@@ -85,9 +85,6 @@ export class UserAssignedIdentity extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as UserAssignedIdentityArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -143,7 +140,7 @@ export interface UserAssignedIdentityArgs {
      * The location/region where the user assigned identity is
      * created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name of the user assigned identity. Changing this forces a
      * new identity to be created.

--- a/sdk/nodejs/mssql/elasticPool.ts
+++ b/sdk/nodejs/mssql/elasticPool.ts
@@ -124,9 +124,6 @@ export class ElasticPool extends pulumi.CustomResource {
             inputs["zoneRedundant"] = state ? state.zoneRedundant : undefined;
         } else {
             const args = argsOrState as ElasticPoolArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.perDatabaseSettings === undefined) {
                 throw new Error("Missing required property 'perDatabaseSettings'");
             }
@@ -209,7 +206,7 @@ export interface ElasticPoolArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The max data size of the elastic pool in bytes. Conflicts with `max_size_gb`.
      */

--- a/sdk/nodejs/mysql/server.ts
+++ b/sdk/nodejs/mysql/server.ts
@@ -128,9 +128,6 @@ export class Server extends pulumi.CustomResource {
             if (!args || args.administratorLoginPassword === undefined) {
                 throw new Error("Missing required property 'administratorLoginPassword'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -227,7 +224,7 @@ export interface ServerArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the SKU Name for this MySQL Server. The name of the SKU, follows the `tier` + `family` + `cores` pattern (e.g. B_Gen4_1, GP_Gen5_8). For more information see the [product documentation](https://docs.microsoft.com/en-us/rest/api/mysql/servers/create#sku).
      */

--- a/sdk/nodejs/network/applicationGateway.ts
+++ b/sdk/nodejs/network/applicationGateway.ts
@@ -252,9 +252,6 @@ export class ApplicationGateway extends pulumi.CustomResource {
             if (!args || args.httpListeners === undefined) {
                 throw new Error("Missing required property 'httpListeners'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.requestRoutingRules === undefined) {
                 throw new Error("Missing required property 'requestRoutingRules'");
             }
@@ -432,7 +429,7 @@ export interface ApplicationGatewayArgs {
     /**
      * The Azure region where the Application Gateway should exist. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name of the Application Gateway. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/network/applicationSecurityGroup.ts
+++ b/sdk/nodejs/network/applicationSecurityGroup.ts
@@ -75,9 +75,6 @@ export class ApplicationSecurityGroup extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as ApplicationSecurityGroupArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -119,7 +116,7 @@ export interface ApplicationSecurityGroupArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Application Security Group. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/network/connectionMonitor.ts
+++ b/sdk/nodejs/network/connectionMonitor.ts
@@ -176,9 +176,6 @@ export class ConnectionMonitor extends pulumi.CustomResource {
             if (!args || args.destination === undefined) {
                 throw new Error("Missing required property 'destination'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.networkWatcherName === undefined) {
                 throw new Error("Missing required property 'networkWatcherName'");
             }
@@ -263,7 +260,7 @@ export interface ConnectionMonitorArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name of the Connection Monitor. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/network/expressRouteCircuit.ts
+++ b/sdk/nodejs/network/expressRouteCircuit.ts
@@ -120,9 +120,6 @@ export class ExpressRouteCircuit extends pulumi.CustomResource {
             if (!args || args.bandwidthInMbps === undefined) {
                 throw new Error("Missing required property 'bandwidthInMbps'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.peeringLocation === undefined) {
                 throw new Error("Missing required property 'peeringLocation'");
             }
@@ -216,7 +213,7 @@ export interface ExpressRouteCircuitArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name of the ExpressRoute circuit. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/network/firewall.ts
+++ b/sdk/nodejs/network/firewall.ts
@@ -104,9 +104,6 @@ export class Firewall extends pulumi.CustomResource {
             if (!args || args.ipConfiguration === undefined) {
                 throw new Error("Missing required property 'ipConfiguration'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -157,7 +154,7 @@ export interface FirewallArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Firewall. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/network/localNetworkGateway.ts
+++ b/sdk/nodejs/network/localNetworkGateway.ts
@@ -101,9 +101,6 @@ export class LocalNetworkGateway extends pulumi.CustomResource {
             if (!args || args.gatewayAddress === undefined) {
                 throw new Error("Missing required property 'gatewayAddress'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -182,7 +179,7 @@ export interface LocalNetworkGatewayArgs {
      * The location/region where the local network gateway is
      * created. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name of the local network gateway. Changing this
      * forces a new resource to be created.

--- a/sdk/nodejs/network/networkInterface.ts
+++ b/sdk/nodejs/network/networkInterface.ts
@@ -152,9 +152,6 @@ export class NetworkInterface extends pulumi.CustomResource {
             if (!args || args.ipConfigurations === undefined) {
                 throw new Error("Missing required property 'ipConfigurations'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -278,7 +275,7 @@ export interface NetworkInterfaceArgs {
     /**
      * The location/region where the network interface is created. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The media access control (MAC) address of the network interface.
      */

--- a/sdk/nodejs/network/networkSecurityGroup.ts
+++ b/sdk/nodejs/network/networkSecurityGroup.ts
@@ -95,9 +95,6 @@ export class NetworkSecurityGroup extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as NetworkSecurityGroupArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -144,7 +141,7 @@ export interface NetworkSecurityGroupArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the network security group. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/network/networkWatcher.ts
+++ b/sdk/nodejs/network/networkWatcher.ts
@@ -72,9 +72,6 @@ export class NetworkWatcher extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as NetworkWatcherArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -116,7 +113,7 @@ export interface NetworkWatcherArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name of the Network Watcher. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/network/publicIp.ts
+++ b/sdk/nodejs/network/publicIp.ts
@@ -130,9 +130,6 @@ export class PublicIp extends pulumi.CustomResource {
             inputs["zones"] = state ? state.zones : undefined;
         } else {
             const args = argsOrState as PublicIpArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -244,7 +241,7 @@ export interface PublicIpArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Public IP resource . Changing this forces a
      * new resource to be created.

--- a/sdk/nodejs/network/publicIpPrefix.ts
+++ b/sdk/nodejs/network/publicIpPrefix.ts
@@ -98,9 +98,6 @@ export class PublicIpPrefix extends pulumi.CustomResource {
             inputs["zones"] = state ? state.zones : undefined;
         } else {
             const args = argsOrState as PublicIpPrefixArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -162,7 +159,7 @@ export interface PublicIpPrefixArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Public IP resource . Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/network/routeTable.ts
+++ b/sdk/nodejs/network/routeTable.ts
@@ -96,9 +96,6 @@ export class RouteTable extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as RouteTableArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -159,7 +156,7 @@ export interface RouteTableArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name of the route table. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/network/virtualNetwork.ts
+++ b/sdk/nodejs/network/virtualNetwork.ts
@@ -143,9 +143,6 @@ export class VirtualNetwork extends pulumi.CustomResource {
             if (!args || args.addressSpaces === undefined) {
                 throw new Error("Missing required property 'addressSpaces'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -228,7 +225,7 @@ export interface VirtualNetworkArgs {
      * The location/region where the virtual network is
      * created. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name of the virtual network. Changing this forces a
      * new resource to be created.

--- a/sdk/nodejs/network/virtualNetworkGateway.ts
+++ b/sdk/nodejs/network/virtualNetworkGateway.ts
@@ -202,9 +202,6 @@ export class VirtualNetworkGateway extends pulumi.CustomResource {
             if (!args || args.ipConfigurations === undefined) {
                 throw new Error("Missing required property 'ipConfigurations'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -345,7 +342,7 @@ export interface VirtualNetworkGatewayArgs {
      * The location/region where the Virtual Network Gateway is
      * located. Changing the location/region forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name of the Virtual Network Gateway. Changing the name
      * forces a new resource to be created.

--- a/sdk/nodejs/network/virtualNetworkGatewayConnection.ts
+++ b/sdk/nodejs/network/virtualNetworkGatewayConnection.ts
@@ -304,9 +304,6 @@ export class VirtualNetworkGatewayConnection extends pulumi.CustomResource {
             inputs["virtualNetworkGatewayId"] = state ? state.virtualNetworkGatewayId : undefined;
         } else {
             const args = argsOrState as VirtualNetworkGatewayConnectionArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -471,7 +468,7 @@ export interface VirtualNetworkGatewayConnectionArgs {
      * The location/region where the connection is
      * located. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name of the connection. Changing the name forces a
      * new resource to be created.

--- a/sdk/nodejs/notificationhub/hub.ts
+++ b/sdk/nodejs/notificationhub/hub.ts
@@ -92,9 +92,6 @@ export class Hub extends pulumi.CustomResource {
             inputs["resourceGroupName"] = state ? state.resourceGroupName : undefined;
         } else {
             const args = argsOrState as HubArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.namespaceName === undefined) {
                 throw new Error("Missing required property 'namespaceName'");
             }
@@ -157,7 +154,7 @@ export interface HubArgs {
     /**
      * The Azure Region in which this Notification Hub Namespace exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name to use for this Notification Hub. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/notificationhub/namespace.ts
+++ b/sdk/nodejs/notificationhub/namespace.ts
@@ -91,9 +91,6 @@ export class Namespace extends pulumi.CustomResource {
             inputs["sku"] = state ? state.sku : undefined;
         } else {
             const args = argsOrState as NamespaceArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.namespaceType === undefined) {
                 throw new Error("Missing required property 'namespaceType'");
             }
@@ -160,7 +157,7 @@ export interface NamespaceArgs {
     /**
      * The Azure Region in which this Notification Hub Namespace should be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name to use for this Notification Hub Namespace. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/operationalinsights/analyticsSolution.ts
+++ b/sdk/nodejs/operationalinsights/analyticsSolution.ts
@@ -102,9 +102,6 @@ export class AnalyticsSolution extends pulumi.CustomResource {
             inputs["workspaceResourceId"] = state ? state.workspaceResourceId : undefined;
         } else {
             const args = argsOrState as AnalyticsSolutionArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.plan === undefined) {
                 throw new Error("Missing required property 'plan'");
             }
@@ -168,7 +165,7 @@ export interface AnalyticsSolutionArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * A `plan` block as documented below.
      */

--- a/sdk/nodejs/operationalinsights/analyticsWorkspace.ts
+++ b/sdk/nodejs/operationalinsights/analyticsWorkspace.ts
@@ -104,9 +104,6 @@ export class AnalyticsWorkspace extends pulumi.CustomResource {
             inputs["workspaceId"] = state ? state.workspaceId : undefined;
         } else {
             const args = argsOrState as AnalyticsWorkspaceArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -181,7 +178,7 @@ export interface AnalyticsWorkspaceArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Log Analytics Workspace. Workspace name should include 4-63 letters, digits or '-'. The '-' shouldn't be the first or the last symbol. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/policy/assignment.ts
+++ b/sdk/nodejs/policy/assignment.ts
@@ -89,7 +89,7 @@ export class Assignment extends pulumi.CustomResource {
     /**
      * The Azure location where this policy assignment should exist. This is required when an Identity is assigned. Changing this forces a new resource to be created.
      */
-    public readonly location: pulumi.Output<string | undefined>;
+    public readonly location: pulumi.Output<string>;
     /**
      * The name of the Policy Assignment. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/postgresql/server.ts
+++ b/sdk/nodejs/postgresql/server.ts
@@ -128,9 +128,6 @@ export class Server extends pulumi.CustomResource {
             if (!args || args.administratorLoginPassword === undefined) {
                 throw new Error("Missing required property 'administratorLoginPassword'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -227,7 +224,7 @@ export interface ServerArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the SKU Name for this PostgreSQL Server. The name of the SKU, follows the `tier` + `family` + `cores` pattern (e.g. B_Gen4_1, GP_Gen5_8). For more information see the [product documentation](https://docs.microsoft.com/en-us/rest/api/postgresql/servers/create#sku).
      */

--- a/sdk/nodejs/recoveryservices/vault.ts
+++ b/sdk/nodejs/recoveryservices/vault.ts
@@ -78,9 +78,6 @@ export class Vault extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as VaultArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -130,7 +127,7 @@ export interface VaultArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Recovery Services Vault. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/redis/cache.ts
+++ b/sdk/nodejs/redis/cache.ts
@@ -274,9 +274,6 @@ export class Cache extends pulumi.CustomResource {
             if (!args || args.family === undefined) {
                 throw new Error("Missing required property 'family'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.redisConfiguration === undefined) {
                 throw new Error("Missing required property 'redisConfiguration'");
             }
@@ -418,7 +415,7 @@ export interface CacheArgs {
     /**
      * The location of the resource group.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The minimum TLS version.  Defaults to `1.0`.
      */

--- a/sdk/nodejs/relay/namespace.ts
+++ b/sdk/nodejs/relay/namespace.ts
@@ -108,9 +108,6 @@ export class Namespace extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as NamespaceArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -185,7 +182,7 @@ export interface NamespaceArgs {
     /**
      * Specifies the supported Azure location where the Azure Relay Namespace exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Azure Relay Namespace. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/scheduler/jobCollection.ts
+++ b/sdk/nodejs/scheduler/jobCollection.ts
@@ -96,9 +96,6 @@ export class JobCollection extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as JobCollectionArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -158,7 +155,7 @@ export interface JobCollectionArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the name of the Scheduler Job Collection. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/search/service.ts
+++ b/sdk/nodejs/search/service.ts
@@ -102,9 +102,6 @@ export class Service extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as ServiceArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -174,7 +171,7 @@ export interface ServiceArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name of the Search Service. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/servicefabric/cluster.ts
+++ b/sdk/nodejs/servicefabric/cluster.ts
@@ -154,9 +154,6 @@ export class Cluster extends pulumi.CustomResource {
             inputs["vmImage"] = state ? state.vmImage : undefined;
         } else {
             const args = argsOrState as ClusterArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.managementEndpoint === undefined) {
                 throw new Error("Missing required property 'managementEndpoint'");
             }
@@ -311,7 +308,7 @@ export interface ClusterArgs {
     /**
      * Specifies the Azure Region where the Service Fabric Cluster should exist. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * Specifies the Management Endpoint of the cluster such as `http://example.com`. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/signalr/service.ts
+++ b/sdk/nodejs/signalr/service.ts
@@ -121,9 +121,6 @@ export class Service extends pulumi.CustomResource {
             inputs["tags"] = state ? state.tags : undefined;
         } else {
             const args = argsOrState as ServiceArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -213,7 +210,7 @@ export interface ServiceArgs {
     /**
      * Specifies the supported Azure location where the SignalR service exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name of the SignalR service. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/sql/database.ts
+++ b/sdk/nodejs/sql/database.ts
@@ -162,9 +162,6 @@ export class Database extends pulumi.CustomResource {
             inputs["threatDetectionPolicy"] = state ? state.threatDetectionPolicy : undefined;
         } else {
             const args = argsOrState as DatabaseArgs | undefined;
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -307,7 +304,7 @@ export interface DatabaseArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The maximum size that the database can grow to. Applies only if `create_mode` is `Default`.  Please see [Azure SQL Database Service Tiers](https://azure.microsoft.com/en-gb/documentation/articles/sql-database-service-tiers/).
      */

--- a/sdk/nodejs/sql/elasticPool.ts
+++ b/sdk/nodejs/sql/elasticPool.ts
@@ -131,9 +131,6 @@ export class ElasticPool extends pulumi.CustomResource {
             if (!args || args.edition === undefined) {
                 throw new Error("Missing required property 'edition'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -229,7 +226,7 @@ export interface ElasticPoolArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name of the elastic pool. This needs to be globally unique. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/sql/sqlServer.ts
+++ b/sdk/nodejs/sql/sqlServer.ts
@@ -107,9 +107,6 @@ export class SqlServer extends pulumi.CustomResource {
             if (!args || args.administratorLoginPassword === undefined) {
                 throw new Error("Missing required property 'administratorLoginPassword'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -182,7 +179,7 @@ export interface SqlServerArgs {
     /**
      * Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name of the SQL Server. This needs to be globally unique within Azure.
      */

--- a/sdk/nodejs/storage/account.ts
+++ b/sdk/nodejs/storage/account.ts
@@ -352,9 +352,6 @@ export class Account extends pulumi.CustomResource {
             if (!args || args.accountTier === undefined) {
                 throw new Error("Missing required property 'accountTier'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -672,7 +669,7 @@ export interface AccountArgs {
      * Specifies the supported Azure location where the
      * resource exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The Custom Domain Name to use for the Storage Account, which will be validated by Azure.
      */

--- a/sdk/nodejs/streamanalytics/job.ts
+++ b/sdk/nodejs/streamanalytics/job.ts
@@ -138,9 +138,6 @@ export class Job extends pulumi.CustomResource {
             if (!args || args.eventsOutOfOrderPolicy === undefined) {
                 throw new Error("Missing required property 'eventsOutOfOrderPolicy'");
             }
-            if (!args || args.location === undefined) {
-                throw new Error("Missing required property 'location'");
-            }
             if (!args || args.outputErrorPolicy === undefined) {
                 throw new Error("Missing required property 'outputErrorPolicy'");
             }
@@ -251,7 +248,7 @@ export interface JobArgs {
     /**
      * The Azure Region in which the Resource Group exists. Changing this forces a new resource to be created.
      */
-    readonly location: pulumi.Input<string>;
+    readonly location?: pulumi.Input<string>;
     /**
      * The name of the Stream Analytics Job. Changing this forces a new resource to be created.
      */

--- a/sdk/python/pulumi_azure/apimanagement/service.py
+++ b/sdk/python/pulumi_azure/apimanagement/service.py
@@ -143,8 +143,6 @@ class Service(pulumi.CustomResource):
 
         __props__['identity'] = identity
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/appinsights/insights.py
+++ b/sdk/python/pulumi_azure/appinsights/insights.py
@@ -72,8 +72,6 @@ class Insights(pulumi.CustomResource):
             raise TypeError("Missing required property 'application_type'")
         __props__['application_type'] = application_type
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/appservice/app_service.py
+++ b/sdk/python/pulumi_azure/appservice/app_service.py
@@ -136,8 +136,6 @@ class AppService(pulumi.CustomResource):
 
         __props__['identity'] = identity
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/appservice/function_app.py
+++ b/sdk/python/pulumi_azure/appservice/function_app.py
@@ -144,8 +144,6 @@ class FunctionApp(pulumi.CustomResource):
 
         __props__['identity'] = identity
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/appservice/plan.py
+++ b/sdk/python/pulumi_azure/appservice/plan.py
@@ -85,8 +85,6 @@ class Plan(pulumi.CustomResource):
 
         __props__['kind'] = kind
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/appservice/slot.py
+++ b/sdk/python/pulumi_azure/appservice/slot.py
@@ -122,8 +122,6 @@ class Slot(pulumi.CustomResource):
 
         __props__['identity'] = identity
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/automation/account.py
+++ b/sdk/python/pulumi_azure/automation/account.py
@@ -68,8 +68,6 @@ class Account(pulumi.CustomResource):
 
         __props__ = dict()
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/automation/dsc_configuration.py
+++ b/sdk/python/pulumi_azure/automation/dsc_configuration.py
@@ -77,8 +77,6 @@ class DscConfiguration(pulumi.CustomResource):
 
         __props__['description'] = description
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['log_verbose'] = log_verbose

--- a/sdk/python/pulumi_azure/automation/run_book.py
+++ b/sdk/python/pulumi_azure/automation/run_book.py
@@ -94,8 +94,6 @@ class RunBook(pulumi.CustomResource):
 
         __props__['description'] = description
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         if log_progress is None:

--- a/sdk/python/pulumi_azure/autoscale/setting.py
+++ b/sdk/python/pulumi_azure/autoscale/setting.py
@@ -75,8 +75,6 @@ class Setting(pulumi.CustomResource):
 
         __props__['enabled'] = enabled
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/batch/account.py
+++ b/sdk/python/pulumi_azure/batch/account.py
@@ -73,8 +73,6 @@ class Account(pulumi.CustomResource):
 
         __props__ = dict()
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/cdn/endpoint.py
+++ b/sdk/python/pulumi_azure/cdn/endpoint.py
@@ -122,8 +122,6 @@ class Endpoint(pulumi.CustomResource):
 
         __props__['is_https_allowed'] = is_https_allowed
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/cdn/profile.py
+++ b/sdk/python/pulumi_azure/cdn/profile.py
@@ -60,8 +60,6 @@ class Profile(pulumi.CustomResource):
 
         __props__ = dict()
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/cognitive/account.py
+++ b/sdk/python/pulumi_azure/cognitive/account.py
@@ -77,8 +77,6 @@ class Account(pulumi.CustomResource):
             raise TypeError("Missing required property 'kind'")
         __props__['kind'] = kind
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/compute/availability_set.py
+++ b/sdk/python/pulumi_azure/compute/availability_set.py
@@ -66,8 +66,6 @@ class AvailabilitySet(pulumi.CustomResource):
 
         __props__ = dict()
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['managed'] = managed

--- a/sdk/python/pulumi_azure/compute/extension.py
+++ b/sdk/python/pulumi_azure/compute/extension.py
@@ -115,8 +115,6 @@ class Extension(pulumi.CustomResource):
 
         __props__['auto_upgrade_minor_version'] = auto_upgrade_minor_version
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/compute/image.py
+++ b/sdk/python/pulumi_azure/compute/image.py
@@ -79,8 +79,6 @@ class Image(pulumi.CustomResource):
 
         __props__['data_disks'] = data_disks
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/compute/managed_disk.py
+++ b/sdk/python/pulumi_azure/compute/managed_disk.py
@@ -118,8 +118,6 @@ class ManagedDisk(pulumi.CustomResource):
 
         __props__['image_reference_id'] = image_reference_id
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/compute/scale_set.py
+++ b/sdk/python/pulumi_azure/compute/scale_set.py
@@ -179,8 +179,6 @@ class ScaleSet(pulumi.CustomResource):
 
         __props__['license_type'] = license_type
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/compute/shared_image.py
+++ b/sdk/python/pulumi_azure/compute/shared_image.py
@@ -100,8 +100,6 @@ class SharedImage(pulumi.CustomResource):
             raise TypeError("Missing required property 'identifier'")
         __props__['identifier'] = identifier
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/compute/shared_image_gallery.py
+++ b/sdk/python/pulumi_azure/compute/shared_image_gallery.py
@@ -64,8 +64,6 @@ class SharedImageGallery(pulumi.CustomResource):
 
         __props__['description'] = description
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/compute/shared_image_version.py
+++ b/sdk/python/pulumi_azure/compute/shared_image_version.py
@@ -88,8 +88,6 @@ class SharedImageVersion(pulumi.CustomResource):
             raise TypeError("Missing required property 'image_name'")
         __props__['image_name'] = image_name
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         if managed_image_id is None:

--- a/sdk/python/pulumi_azure/compute/snapshot.py
+++ b/sdk/python/pulumi_azure/compute/snapshot.py
@@ -85,8 +85,6 @@ class Snapshot(pulumi.CustomResource):
 
         __props__['encryption_settings'] = encryption_settings
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/compute/virtual_machine.py
+++ b/sdk/python/pulumi_azure/compute/virtual_machine.py
@@ -155,8 +155,6 @@ class VirtualMachine(pulumi.CustomResource):
 
         __props__['license_type'] = license_type
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/config/vars.py
+++ b/sdk/python/pulumi_azure/config/vars.py
@@ -34,3 +34,5 @@ tenant_id = __config__.get('tenantId') or (utilities.get_env('ARM_TENANT_ID') or
 
 use_msi = __config__.get('useMsi') or (utilities.get_env_bool('ARM_USE_MSI') or False)
 
+location = __config__.get('location') or utilities.get_env('ARM_LOCATION')
+

--- a/sdk/python/pulumi_azure/containerservice/group.py
+++ b/sdk/python/pulumi_azure/containerservice/group.py
@@ -106,8 +106,6 @@ class Group(pulumi.CustomResource):
 
         __props__['ip_address_type'] = ip_address_type
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/containerservice/kubernetes_cluster.py
+++ b/sdk/python/pulumi_azure/containerservice/kubernetes_cluster.py
@@ -131,8 +131,6 @@ class KubernetesCluster(pulumi.CustomResource):
 
         __props__['linux_profile'] = linux_profile
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/containerservice/registry.py
+++ b/sdk/python/pulumi_azure/containerservice/registry.py
@@ -91,8 +91,6 @@ class Registry(pulumi.CustomResource):
 
         __props__['georeplication_locations'] = georeplication_locations
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/containerservice/service.py
+++ b/sdk/python/pulumi_azure/containerservice/service.py
@@ -100,8 +100,6 @@ class Service(pulumi.CustomResource):
             raise TypeError("Missing required property 'linux_profile'")
         __props__['linux_profile'] = linux_profile
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         if master_profile is None:

--- a/sdk/python/pulumi_azure/core/resource_group.py
+++ b/sdk/python/pulumi_azure/core/resource_group.py
@@ -50,8 +50,6 @@ class ResourceGroup(pulumi.CustomResource):
 
         __props__ = dict()
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/cosmosdb/account.py
+++ b/sdk/python/pulumi_azure/cosmosdb/account.py
@@ -154,8 +154,6 @@ class Account(pulumi.CustomResource):
 
         __props__['kind'] = kind
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/databricks/workspace.py
+++ b/sdk/python/pulumi_azure/databricks/workspace.py
@@ -65,8 +65,6 @@ class Workspace(pulumi.CustomResource):
 
         __props__ = dict()
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['managed_resource_group_name'] = managed_resource_group_name

--- a/sdk/python/pulumi_azure/datafactory/factory.py
+++ b/sdk/python/pulumi_azure/datafactory/factory.py
@@ -70,8 +70,6 @@ class Factory(pulumi.CustomResource):
 
         __props__['identity'] = identity
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/datalake/analytics_account.py
+++ b/sdk/python/pulumi_azure/datalake/analytics_account.py
@@ -65,8 +65,6 @@ class AnalyticsAccount(pulumi.CustomResource):
             raise TypeError("Missing required property 'default_store_account_name'")
         __props__['default_store_account_name'] = default_store_account_name
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/datalake/store.py
+++ b/sdk/python/pulumi_azure/datalake/store.py
@@ -88,8 +88,6 @@ class Store(pulumi.CustomResource):
 
         __props__['firewall_state'] = firewall_state
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/ddosprotection/plan.py
+++ b/sdk/python/pulumi_azure/ddosprotection/plan.py
@@ -59,8 +59,6 @@ class Plan(pulumi.CustomResource):
 
         __props__ = dict()
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/devspace/controller.py
+++ b/sdk/python/pulumi_azure/devspace/controller.py
@@ -79,8 +79,6 @@ class Controller(pulumi.CustomResource):
             raise TypeError("Missing required property 'host_suffix'")
         __props__['host_suffix'] = host_suffix
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/devtest/lab.py
+++ b/sdk/python/pulumi_azure/devtest/lab.py
@@ -80,8 +80,6 @@ class Lab(pulumi.CustomResource):
 
         __props__ = dict()
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/devtest/linux_virtual_machine.py
+++ b/sdk/python/pulumi_azure/devtest/linux_virtual_machine.py
@@ -146,8 +146,6 @@ class LinuxVirtualMachine(pulumi.CustomResource):
             raise TypeError("Missing required property 'lab_virtual_network_id'")
         __props__['lab_virtual_network_id'] = lab_virtual_network_id
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/devtest/windows_virtual_machine.py
+++ b/sdk/python/pulumi_azure/devtest/windows_virtual_machine.py
@@ -141,8 +141,6 @@ class WindowsVirtualMachine(pulumi.CustomResource):
             raise TypeError("Missing required property 'lab_virtual_network_id'")
         __props__['lab_virtual_network_id'] = lab_virtual_network_id
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/eventhub/event_grid_domain.py
+++ b/sdk/python/pulumi_azure/eventhub/event_grid_domain.py
@@ -76,8 +76,6 @@ class EventGridDomain(pulumi.CustomResource):
 
         __props__['input_schema'] = input_schema
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/eventhub/event_grid_topic.py
+++ b/sdk/python/pulumi_azure/eventhub/event_grid_topic.py
@@ -65,8 +65,6 @@ class EventGridTopic(pulumi.CustomResource):
 
         __props__ = dict()
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/eventhub/event_hub_namespace.py
+++ b/sdk/python/pulumi_azure/eventhub/event_hub_namespace.py
@@ -100,8 +100,6 @@ class EventHubNamespace(pulumi.CustomResource):
 
         __props__['kafka_enabled'] = kafka_enabled
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['maximum_throughput_units'] = maximum_throughput_units

--- a/sdk/python/pulumi_azure/eventhub/namespace.py
+++ b/sdk/python/pulumi_azure/eventhub/namespace.py
@@ -85,8 +85,6 @@ class Namespace(pulumi.CustomResource):
 
         __props__['capacity'] = capacity
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/hdinsight/h_base_cluster.py
+++ b/sdk/python/pulumi_azure/hdinsight/h_base_cluster.py
@@ -101,8 +101,6 @@ class HBaseCluster(pulumi.CustomResource):
             raise TypeError("Missing required property 'gateway'")
         __props__['gateway'] = gateway
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/hdinsight/hadoop_cluster.py
+++ b/sdk/python/pulumi_azure/hdinsight/hadoop_cluster.py
@@ -101,8 +101,6 @@ class HadoopCluster(pulumi.CustomResource):
             raise TypeError("Missing required property 'gateway'")
         __props__['gateway'] = gateway
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/hdinsight/interactive_query_cluster.py
+++ b/sdk/python/pulumi_azure/hdinsight/interactive_query_cluster.py
@@ -101,8 +101,6 @@ class InteractiveQueryCluster(pulumi.CustomResource):
             raise TypeError("Missing required property 'gateway'")
         __props__['gateway'] = gateway
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/hdinsight/kafka_cluster.py
+++ b/sdk/python/pulumi_azure/hdinsight/kafka_cluster.py
@@ -101,8 +101,6 @@ class KafkaCluster(pulumi.CustomResource):
             raise TypeError("Missing required property 'gateway'")
         __props__['gateway'] = gateway
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/hdinsight/ml_services_cluster.py
+++ b/sdk/python/pulumi_azure/hdinsight/ml_services_cluster.py
@@ -101,8 +101,6 @@ class MLServicesCluster(pulumi.CustomResource):
             raise TypeError("Missing required property 'gateway'")
         __props__['gateway'] = gateway
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/hdinsight/r_server_cluster.py
+++ b/sdk/python/pulumi_azure/hdinsight/r_server_cluster.py
@@ -101,8 +101,6 @@ class RServerCluster(pulumi.CustomResource):
             raise TypeError("Missing required property 'gateway'")
         __props__['gateway'] = gateway
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/hdinsight/spark_cluster.py
+++ b/sdk/python/pulumi_azure/hdinsight/spark_cluster.py
@@ -101,8 +101,6 @@ class SparkCluster(pulumi.CustomResource):
             raise TypeError("Missing required property 'gateway'")
         __props__['gateway'] = gateway
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/hdinsight/storm_cluster.py
+++ b/sdk/python/pulumi_azure/hdinsight/storm_cluster.py
@@ -101,8 +101,6 @@ class StormCluster(pulumi.CustomResource):
             raise TypeError("Missing required property 'gateway'")
         __props__['gateway'] = gateway
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/iot/io_t_hub.py
+++ b/sdk/python/pulumi_azure/iot/io_t_hub.py
@@ -107,8 +107,6 @@ class IoTHub(pulumi.CustomResource):
 
         __props__['ip_filter_rules'] = ip_filter_rules
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/keyvault/key_vault.py
+++ b/sdk/python/pulumi_azure/keyvault/key_vault.py
@@ -100,8 +100,6 @@ class KeyVault(pulumi.CustomResource):
 
         __props__['enabled_for_template_deployment'] = enabled_for_template_deployment
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/lb/load_balancer.py
+++ b/sdk/python/pulumi_azure/lb/load_balancer.py
@@ -71,8 +71,6 @@ class LoadBalancer(pulumi.CustomResource):
 
         __props__['frontend_ip_configurations'] = frontend_ip_configurations
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/logicapps/workflow.py
+++ b/sdk/python/pulumi_azure/logicapps/workflow.py
@@ -70,8 +70,6 @@ class Workflow(pulumi.CustomResource):
 
         __props__ = dict()
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/mariadb/server.py
+++ b/sdk/python/pulumi_azure/mariadb/server.py
@@ -95,8 +95,6 @@ class Server(pulumi.CustomResource):
             raise TypeError("Missing required property 'administrator_login_password'")
         __props__['administrator_login_password'] = administrator_login_password
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/mediaservices/account.py
+++ b/sdk/python/pulumi_azure/mediaservices/account.py
@@ -51,8 +51,6 @@ class Account(pulumi.CustomResource):
 
         __props__ = dict()
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/monitoring/alert_rule.py
+++ b/sdk/python/pulumi_azure/monitoring/alert_rule.py
@@ -113,8 +113,6 @@ class AlertRule(pulumi.CustomResource):
 
         __props__['enabled'] = enabled
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         if metric_name is None:

--- a/sdk/python/pulumi_azure/monitoring/autoscale_setting.py
+++ b/sdk/python/pulumi_azure/monitoring/autoscale_setting.py
@@ -73,8 +73,6 @@ class AutoscaleSetting(pulumi.CustomResource):
 
         __props__['enabled'] = enabled
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/monitoring/metric_alert_rule.py
+++ b/sdk/python/pulumi_azure/monitoring/metric_alert_rule.py
@@ -111,8 +111,6 @@ class MetricAlertRule(pulumi.CustomResource):
 
         __props__['enabled'] = enabled
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         if metric_name is None:

--- a/sdk/python/pulumi_azure/msi/user_assigned_identity.py
+++ b/sdk/python/pulumi_azure/msi/user_assigned_identity.py
@@ -65,8 +65,6 @@ class UserAssignedIdentity(pulumi.CustomResource):
 
         __props__ = dict()
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/mssql/elastic_pool.py
+++ b/sdk/python/pulumi_azure/mssql/elastic_pool.py
@@ -82,8 +82,6 @@ class ElasticPool(pulumi.CustomResource):
 
         __props__ = dict()
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['max_size_bytes'] = max_size_bytes

--- a/sdk/python/pulumi_azure/mysql/server.py
+++ b/sdk/python/pulumi_azure/mysql/server.py
@@ -93,8 +93,6 @@ class Server(pulumi.CustomResource):
             raise TypeError("Missing required property 'administrator_login_password'")
         __props__['administrator_login_password'] = administrator_login_password
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/network/application_gateway.py
+++ b/sdk/python/pulumi_azure/network/application_gateway.py
@@ -173,8 +173,6 @@ class ApplicationGateway(pulumi.CustomResource):
             raise TypeError("Missing required property 'http_listeners'")
         __props__['http_listeners'] = http_listeners
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/network/application_security_group.py
+++ b/sdk/python/pulumi_azure/network/application_security_group.py
@@ -51,8 +51,6 @@ class ApplicationSecurityGroup(pulumi.CustomResource):
 
         __props__ = dict()
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/network/connection_monitor.py
+++ b/sdk/python/pulumi_azure/network/connection_monitor.py
@@ -86,8 +86,6 @@ class ConnectionMonitor(pulumi.CustomResource):
 
         __props__['interval_in_seconds'] = interval_in_seconds
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/network/express_route_circuit.py
+++ b/sdk/python/pulumi_azure/network/express_route_circuit.py
@@ -90,8 +90,6 @@ class ExpressRouteCircuit(pulumi.CustomResource):
             raise TypeError("Missing required property 'bandwidth_in_mbps'")
         __props__['bandwidth_in_mbps'] = bandwidth_in_mbps
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/network/firewall.py
+++ b/sdk/python/pulumi_azure/network/firewall.py
@@ -60,8 +60,6 @@ class Firewall(pulumi.CustomResource):
             raise TypeError("Missing required property 'ip_configuration'")
         __props__['ip_configuration'] = ip_configuration
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/network/local_network_gateway.py
+++ b/sdk/python/pulumi_azure/network/local_network_gateway.py
@@ -88,8 +88,6 @@ class LocalNetworkGateway(pulumi.CustomResource):
             raise TypeError("Missing required property 'gateway_address'")
         __props__['gateway_address'] = gateway_address
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/network/network_interface.py
+++ b/sdk/python/pulumi_azure/network/network_interface.py
@@ -121,8 +121,6 @@ class NetworkInterface(pulumi.CustomResource):
             raise TypeError("Missing required property 'ip_configurations'")
         __props__['ip_configurations'] = ip_configurations
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['mac_address'] = mac_address

--- a/sdk/python/pulumi_azure/network/network_security_group.py
+++ b/sdk/python/pulumi_azure/network/network_security_group.py
@@ -60,8 +60,6 @@ class NetworkSecurityGroup(pulumi.CustomResource):
 
         __props__ = dict()
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/network/network_watcher.py
+++ b/sdk/python/pulumi_azure/network/network_watcher.py
@@ -51,8 +51,6 @@ class NetworkWatcher(pulumi.CustomResource):
 
         __props__ = dict()
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/network/public_ip.py
+++ b/sdk/python/pulumi_azure/network/public_ip.py
@@ -112,8 +112,6 @@ class PublicIp(pulumi.CustomResource):
 
         __props__['ip_version'] = ip_version
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/network/public_ip_prefix.py
+++ b/sdk/python/pulumi_azure/network/public_ip_prefix.py
@@ -72,8 +72,6 @@ class PublicIpPrefix(pulumi.CustomResource):
 
         __props__ = dict()
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/network/route_table.py
+++ b/sdk/python/pulumi_azure/network/route_table.py
@@ -67,8 +67,6 @@ class RouteTable(pulumi.CustomResource):
 
         __props__['disable_bgp_route_propagation'] = disable_bgp_route_propagation
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/network/virtual_network.py
+++ b/sdk/python/pulumi_azure/network/virtual_network.py
@@ -96,8 +96,6 @@ class VirtualNetwork(pulumi.CustomResource):
 
         __props__['dns_servers'] = dns_servers
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/network/virtual_network_gateway.py
+++ b/sdk/python/pulumi_azure/network/virtual_network_gateway.py
@@ -152,8 +152,6 @@ class VirtualNetworkGateway(pulumi.CustomResource):
             raise TypeError("Missing required property 'ip_configurations'")
         __props__['ip_configurations'] = ip_configurations
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/network/virtual_network_gateway_connection.py
+++ b/sdk/python/pulumi_azure/network/virtual_network_gateway_connection.py
@@ -171,8 +171,6 @@ class VirtualNetworkGatewayConnection(pulumi.CustomResource):
 
         __props__['local_network_gateway_id'] = local_network_gateway_id
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/notificationhub/hub.py
+++ b/sdk/python/pulumi_azure/notificationhub/hub.py
@@ -65,8 +65,6 @@ class Hub(pulumi.CustomResource):
 
         __props__['gcm_credential'] = gcm_credential
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/notificationhub/namespace.py
+++ b/sdk/python/pulumi_azure/notificationhub/namespace.py
@@ -67,8 +67,6 @@ class Namespace(pulumi.CustomResource):
 
         __props__['enabled'] = enabled
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/operationalinsights/analytics_solution.py
+++ b/sdk/python/pulumi_azure/operationalinsights/analytics_solution.py
@@ -61,8 +61,6 @@ class AnalyticsSolution(pulumi.CustomResource):
 
         __props__ = dict()
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         if plan is None:

--- a/sdk/python/pulumi_azure/operationalinsights/analytics_workspace.py
+++ b/sdk/python/pulumi_azure/operationalinsights/analytics_workspace.py
@@ -77,8 +77,6 @@ class AnalyticsWorkspace(pulumi.CustomResource):
 
         __props__ = dict()
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/postgresql/server.py
+++ b/sdk/python/pulumi_azure/postgresql/server.py
@@ -93,8 +93,6 @@ class Server(pulumi.CustomResource):
             raise TypeError("Missing required property 'administrator_login_password'")
         __props__['administrator_login_password'] = administrator_login_password
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/recoveryservices/vault.py
+++ b/sdk/python/pulumi_azure/recoveryservices/vault.py
@@ -56,8 +56,6 @@ class Vault(pulumi.CustomResource):
 
         __props__ = dict()
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/redis/cache.py
+++ b/sdk/python/pulumi_azure/redis/cache.py
@@ -163,8 +163,6 @@ class Cache(pulumi.CustomResource):
             raise TypeError("Missing required property 'family'")
         __props__['family'] = family
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['minimum_tls_version'] = minimum_tls_version

--- a/sdk/python/pulumi_azure/relay/namespace.py
+++ b/sdk/python/pulumi_azure/relay/namespace.py
@@ -76,8 +76,6 @@ class Namespace(pulumi.CustomResource):
 
         __props__ = dict()
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/scheduler/job_collection.py
+++ b/sdk/python/pulumi_azure/scheduler/job_collection.py
@@ -68,8 +68,6 @@ class JobCollection(pulumi.CustomResource):
 
         __props__ = dict()
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/search/service.py
+++ b/sdk/python/pulumi_azure/search/service.py
@@ -74,8 +74,6 @@ class Service(pulumi.CustomResource):
 
         __props__ = dict()
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/servicefabric/cluster.py
+++ b/sdk/python/pulumi_azure/servicefabric/cluster.py
@@ -134,8 +134,6 @@ class Cluster(pulumi.CustomResource):
 
         __props__['fabric_settings'] = fabric_settings
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         if management_endpoint is None:

--- a/sdk/python/pulumi_azure/signalr/service.py
+++ b/sdk/python/pulumi_azure/signalr/service.py
@@ -88,8 +88,6 @@ class Service(pulumi.CustomResource):
 
         __props__ = dict()
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/sql/database.py
+++ b/sdk/python/pulumi_azure/sql/database.py
@@ -137,8 +137,6 @@ class Database(pulumi.CustomResource):
 
         __props__['import_'] = import_
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['max_size_bytes'] = max_size_bytes

--- a/sdk/python/pulumi_azure/sql/elastic_pool.py
+++ b/sdk/python/pulumi_azure/sql/elastic_pool.py
@@ -99,8 +99,6 @@ class ElasticPool(pulumi.CustomResource):
             raise TypeError("Missing required property 'edition'")
         __props__['edition'] = edition
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/sql/sql_server.py
+++ b/sdk/python/pulumi_azure/sql/sql_server.py
@@ -81,8 +81,6 @@ class SqlServer(pulumi.CustomResource):
             raise TypeError("Missing required property 'administrator_login_password'")
         __props__['administrator_login_password'] = administrator_login_password
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/storage/account.py
+++ b/sdk/python/pulumi_azure/storage/account.py
@@ -278,8 +278,6 @@ class Account(pulumi.CustomResource):
 
         __props__['is_hns_enabled'] = is_hns_enabled
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name

--- a/sdk/python/pulumi_azure/streamanalytics/job.py
+++ b/sdk/python/pulumi_azure/streamanalytics/job.py
@@ -110,8 +110,6 @@ class Job(pulumi.CustomResource):
             raise TypeError("Missing required property 'events_out_of_order_policy'")
         __props__['events_out_of_order_policy'] = events_out_of_order_policy
 
-        if location is None:
-            raise TypeError("Missing required property 'location'")
         __props__['location'] = location
 
         __props__['name'] = name


### PR DESCRIPTION
By leveraging some new TF bridge capabilities, we can improve the
usability of Azure resources generally. Namely, we can go from this

    const rg = new azure.core.ResourceGroup("rg", { location" EastUS" });
    const sa = new azure.storage.Account("storage", {
        resourceGroupName: rg.name,
        location: "EastUS",
    });

to

    const rg = new azure.core.ResourceGroup("rg");
    const sa = new azure.storage.Account("storage", {
        resourceGroupName: rg.name,
    });

and an incantation

    $ pulumi config set azure:location EastUS

with the same end result. Effectively this is two features combined

    1) ResourceGroups will consult configuration for a default location,
       if one was not supplied explicitly.

    2) All other resources with resourceGroupName properties will
       default to that resource group's location, if not supplied
       explicitly.

This resolves pulumi/pulumi-azure#176.