### PR TITLE
Adjust max name lengths of several resource types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Fixed bug #2511, which resulted in crashes when updating many properties of an
   `azure.containerservice.KubernetesCluster`.
 - Fix a bug where omitting a location would result in the initial failure of `pulumi preview` (#239).
-- Updated the provider to be based on version 1.28.0 of the AzureRM Terraform proivder.
+- Updated the provider to be based on version 1.28.0 of the AzureRM Terraform provider.
+- Relax the max length of names of several resource types (#159).
 
 ## 0.18.2 (Released May 6th, 2019)
 

--- a/resources.go
+++ b/resources.go
@@ -234,7 +234,14 @@ func Provider() tfbridge.ProviderInfo {
 			"azurerm_azuread_service_principal_password": {Tok: azureResource(azureAD, "ServicePrincipalPassword")},
 
 			// API Mannagement
-			"azurerm_api_management":                         {Tok: azureResource(azureAPIManagement, "Service")},
+			"azurerm_api_management": {
+				Tok: azureResource(azureAPIManagement, "Service"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					// Max length of an API Management name is 50.
+					// Source: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions#general
+					azureName: AutoNameWithMaxLength(azureName, 50),
+				},
+			},
 			"azurerm_api_management_api":                     {Tok: azureResource(azureAPIManagement, "Api")},
 			"azurerm_api_management_api_operation":           {Tok: azureResource(azureAPIManagement, "ApiOperation")},
 			"azurerm_api_management_api_operation_policy":    {Tok: azureResource(azureAPIManagement, "ApiOperationPolicy")},
@@ -263,6 +270,9 @@ func Provider() tfbridge.ProviderInfo {
 			"azurerm_app_service": {
 				Tok: azureResource(azureAppService, "AppService"),
 				Fields: map[string]*tfbridge.SchemaInfo{
+					// Max length of an app service name is 60. 
+					// Source: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions#general
+					azureName: AutoNameWithMaxLength(azureName, 60),
 					"site_config": {
 						Elem: &tfbridge.SchemaInfo{
 							Fields: map[string]*tfbridge.SchemaInfo{
@@ -288,7 +298,7 @@ func Provider() tfbridge.ProviderInfo {
 				Tok: azureResource(azureAppService, "FunctionApp"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					// Max length of a functionapp name is 60.
-					// This was discovered directly through the portal.
+					// Source: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions#compute
 					azureName: AutoNameWithMaxLength(azureName, 60),
 					"site_config": {
 						Elem: &tfbridge.SchemaInfo{
@@ -385,9 +395,23 @@ func Provider() tfbridge.ProviderInfo {
 			"azurerm_cognitive_account": {Tok: azureResource(azureCognitive, "Account")},
 
 			// Compute
-			"azurerm_availability_set":                     {Tok: azureResource(azureCompute, "AvailabilitySet")},
+			"azurerm_availability_set": {
+				Tok: azureResource(azureCompute, "AvailabilitySet"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					// Max length of an availability set name is 80. 
+					// Source: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions#general
+					azureName: AutoNameWithMaxLength(azureName, 80),
+				},
+			},
 			"azurerm_virtual_machine_extension":            {Tok: azureResource(azureCompute, "Extension")},
-			"azurerm_virtual_machine":                      {Tok: azureResource(azureCompute, "VirtualMachine")},
+			"azurerm_virtual_machine": {
+				Tok: azureResource(azureCompute, "VirtualMachine"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					// Max length of a virtual machine name is 64. Note that the Windows host name is max 15 characters but it can be set separately.
+					// Source: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions#compute
+					azureName: AutoNameWithMaxLength(azureName, 64),
+				},
+			},
 			"azurerm_virtual_machine_data_disk_attachment": {Tok: azureResource(azureCompute, "DataDiskAttachment")},
 			"azurerm_virtual_machine_scale_set":            {Tok: azureResource(azureCompute, "ScaleSet")},
 
@@ -527,6 +551,11 @@ func Provider() tfbridge.ProviderInfo {
 				Docs: &tfbridge.DocInfo{
 					Source: "loadbalancer.html.markdown",
 				},
+				Fields: map[string]*tfbridge.SchemaInfo{
+					// Max length of a Load Balancer is 80.
+					// Source: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions#networking
+					azureName: AutoNameWithMaxLength(azureName, 80),
+				},
 			},
 			"azurerm_lb_backend_address_pool": {Tok: azureResource(azureLB, "BackendAddressPool"),
 				Docs: &tfbridge.DocInfo{
@@ -653,12 +682,26 @@ func Provider() tfbridge.ProviderInfo {
 			"azurerm_sql_active_directory_administrator": {Tok: azureResource(azureSQL, "ActiveDirectoryAdministrator")},
 
 			// Network
-			"azurerm_virtual_network":                                                        {Tok: azureResource(azureNetwork, "VirtualNetwork")},
+			"azurerm_virtual_network": {
+				Tok: azureResource(azureNetwork, "VirtualNetwork"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					// Max length of a Virtual Network is 64.
+					// Source: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions#networking
+					azureName: AutoNameWithMaxLength(azureName, 64),
+				},
+			},
 			"azurerm_virtual_network_peering":                                                {Tok: azureResource(azureNetwork, "VirtualNetworkPeering")},
 			"azurerm_virtual_network_gateway":                                                {Tok: azureResource(azureNetwork, "VirtualNetworkGateway")},
 			"azurerm_virtual_network_gateway_connection":                                     {Tok: azureResource(azureNetwork, "VirtualNetworkGatewayConnection")},
 			"azurerm_local_network_gateway":                                                  {Tok: azureResource(azureNetwork, "LocalNetworkGateway")},
-			"azurerm_application_gateway":                                                    {Tok: azureResource(azureNetwork, "ApplicationGateway")},
+			"azurerm_application_gateway":{
+				Tok: azureResource(azureNetwork, "ApplicationGateway"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					// Max length of an Application Gateway is 80.
+					// Source: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions#networking
+					azureName: AutoNameWithMaxLength(azureName, 80),
+				},
+			},
 			"azurerm_application_security_group":                                             {Tok: azureResource(azureNetwork, "ApplicationSecurityGroup")},
 			"azurerm_connection_monitor":                                                     {Tok: azureResource(azureNetwork, "ConnectionMonitor")},
 			"azurerm_firewall":                                                               {Tok: azureResource(azureNetwork, "Firewall")},
@@ -667,18 +710,46 @@ func Provider() tfbridge.ProviderInfo {
 			"azurerm_firewall_network_rule_collection":                                       {Tok: azureResource(azureNetwork, "FirewallNetworkRuleCollection")},
 			"azurerm_network_connection_monitor":                                             {Tok: azureResource(azureNetwork, "NetworkConnectionMonitor")},
 			"azurerm_network_ddos_protection_plan":                                           {Tok: azureResource(azureNetwork, "DdosProtectionPlan")},
-			"azurerm_network_interface":                                                      {Tok: azureResource(azureNetwork, "NetworkInterface")},
+			"azurerm_network_interface":{
+				Tok: azureResource(azureNetwork, "NetworkInterface"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					// Max length of a Network Interface is 80.
+					// Source: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions#networking
+					azureName: AutoNameWithMaxLength(azureName, 80),
+				},
+			},
 			"azurerm_network_interface_application_gateway_backend_address_pool_association": {Tok: azureResource(azureNetwork, "NetworkInterfaceApplicationGatewayBackendAddressPoolAssociation")},
 			"azurerm_network_interface_application_security_group_association":               {Tok: azureResource(azureNetwork, "NetworkInterfaceApplicationSecurityGroupAssociation")},
 			"azurerm_network_interface_backend_address_pool_association":                     {Tok: azureResource(azureNetwork, "NetworkInterfaceBackendAddressPoolAssociation")},
 			"azurerm_network_interface_nat_rule_association":                                 {Tok: azureResource(azureNetwork, "NetworkInterfaceNatRuleAssociation")},
 			"azurerm_network_packet_capture":                                                 {Tok: azureResource(azureNetwork, "NetworkPacketCapture")},
 			"azurerm_network_profile":                                                        {Tok: azureResource(azureNetwork, "Profile")},
-			"azurerm_network_security_group":                                                 {Tok: azureResource(azureNetwork, "NetworkSecurityGroup")},
-			"azurerm_network_security_rule":                                                  {Tok: azureResource(azureNetwork, "NetworkSecurityRule")},
+			"azurerm_network_security_group":{
+				Tok: azureResource(azureNetwork, "NetworkSecurityGroup"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					// Max length of a Network Security Group is 80.
+					// Source: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions#networking
+					azureName: AutoNameWithMaxLength(azureName, 80),
+				},
+			},
+			"azurerm_network_security_rule":{
+				Tok: azureResource(azureNetwork, "NetworkSecurityRule"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					// Max length of a Network Security Rule is 80.
+					// Source: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions#networking
+					azureName: AutoNameWithMaxLength(azureName, 80),
+				},
+			},
 			"azurerm_network_watcher":                                                        {Tok: azureResource(azureNetwork, "NetworkWatcher")},
 			"azurerm_packet_capture":                                                         {Tok: azureResource(azureNetwork, "PacketCapture")},
-			"azurerm_public_ip":                                                              {Tok: azureResource(azureNetwork, "PublicIp")},
+			"azurerm_public_ip":{
+				Tok: azureResource(azureNetwork, "PublicIp"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					// Max length of a Public IP Address is 80.
+					// Source: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions#networking
+					azureName: AutoNameWithMaxLength(azureName, 80),
+				},
+			},
 			"azurerm_public_ip_prefix": {
 				Tok: azureResource(azureNetwork, "PublicIpPrefix"),
 				Fields: map[string]*tfbridge.SchemaInfo{
@@ -688,7 +759,14 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			"azurerm_route":       {Tok: azureResource(azureNetwork, "Route")},
 			"azurerm_route_table": {Tok: azureResource(azureNetwork, "RouteTable")},
-			"azurerm_subnet":      {Tok: azureResource(azureNetwork, "Subnet")},
+			"azurerm_subnet":{
+				Tok: azureResource(azureNetwork, "Subnet"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					// Max length of a Subnet is 80.
+					// Source: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions#networking
+					azureName: AutoNameWithMaxLength(azureName, 80),
+				},
+			},
 			"azurerm_subnet_network_security_group_association": {Tok: azureResource(azureNetwork, "SubnetNetworkSecurityGroupAssociation")},
 			"azurerm_subnet_route_table_association":            {Tok: azureResource(azureNetwork, "SubnetRouteTableAssociation")},
 			"azurerm_express_route_circuit":                     {Tok: azureResource(azureNetwork, "ExpressRouteCircuit")},
@@ -705,7 +783,14 @@ func Provider() tfbridge.ProviderInfo {
 
 			// Traffic Manager
 			"azurerm_traffic_manager_endpoint": {Tok: azureResource(azureTrafficManager, "Endpoint")},
-			"azurerm_traffic_manager_profile":  {Tok: azureResource(azureTrafficManager, "Profile")},
+			"azurerm_traffic_manager_profile":{
+				Tok: azureResource(azureTrafficManager, "Profile"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					// Max length of a Traffic Manager Profile is 80.
+					// Source: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions#networking
+					azureName: AutoNameWithMaxLength(azureName, 80),
+				},
+			},
 
 			// Recovery Services
 			"azurerm_recovery_services_protected_vm":         {Tok: azureResource(azureRecoveryServices, "ProtectedVM")},
@@ -754,7 +839,13 @@ func Provider() tfbridge.ProviderInfo {
 					azureName: AutoNameWithMaxLength(azureName, 63),
 				}},
 			"azurerm_storage_share": {Tok: azureResource(azureStorage, "Share")},
-			"azurerm_storage_queue": {Tok: azureResource(azureStorage, "Queue")},
+			"azurerm_storage_queue": {
+				Tok: azureResource(azureStorage, "Queue"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					// https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions#storage
+					// Max length of a queue name is 63.
+					azureName: AutoNameWithMaxLength(azureName, 63),
+				}},
 			"azurerm_storage_table": {
 				Tok: azureResource(azureStorage, "Table"),
 				Fields: map[string]*tfbridge.SchemaInfo{

--- a/resources.go
+++ b/resources.go
@@ -270,7 +270,7 @@ func Provider() tfbridge.ProviderInfo {
 			"azurerm_app_service": {
 				Tok: azureResource(azureAppService, "AppService"),
 				Fields: map[string]*tfbridge.SchemaInfo{
-					// Max length of an app service name is 60. 
+					// Max length of an app service name is 60.
 					// Source: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions#general
 					azureName: AutoNameWithMaxLength(azureName, 60),
 					"site_config": {
@@ -398,12 +398,12 @@ func Provider() tfbridge.ProviderInfo {
 			"azurerm_availability_set": {
 				Tok: azureResource(azureCompute, "AvailabilitySet"),
 				Fields: map[string]*tfbridge.SchemaInfo{
-					// Max length of an availability set name is 80. 
+					// Max length of an availability set name is 80.
 					// Source: https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions#general
 					azureName: AutoNameWithMaxLength(azureName, 80),
 				},
 			},
-			"azurerm_virtual_machine_extension":            {Tok: azureResource(azureCompute, "Extension")},
+			"azurerm_virtual_machine_extension": {Tok: azureResource(azureCompute, "Extension")},
 			"azurerm_virtual_machine": {
 				Tok: azureResource(azureCompute, "VirtualMachine"),
 				Fields: map[string]*tfbridge.SchemaInfo{
@@ -690,11 +690,11 @@ func Provider() tfbridge.ProviderInfo {
 					azureName: AutoNameWithMaxLength(azureName, 64),
 				},
 			},
-			"azurerm_virtual_network_peering":                                                {Tok: azureResource(azureNetwork, "VirtualNetworkPeering")},
-			"azurerm_virtual_network_gateway":                                                {Tok: azureResource(azureNetwork, "VirtualNetworkGateway")},
-			"azurerm_virtual_network_gateway_connection":                                     {Tok: azureResource(azureNetwork, "VirtualNetworkGatewayConnection")},
-			"azurerm_local_network_gateway":                                                  {Tok: azureResource(azureNetwork, "LocalNetworkGateway")},
-			"azurerm_application_gateway":{
+			"azurerm_virtual_network_peering":            {Tok: azureResource(azureNetwork, "VirtualNetworkPeering")},
+			"azurerm_virtual_network_gateway":            {Tok: azureResource(azureNetwork, "VirtualNetworkGateway")},
+			"azurerm_virtual_network_gateway_connection": {Tok: azureResource(azureNetwork, "VirtualNetworkGatewayConnection")},
+			"azurerm_local_network_gateway":              {Tok: azureResource(azureNetwork, "LocalNetworkGateway")},
+			"azurerm_application_gateway": {
 				Tok: azureResource(azureNetwork, "ApplicationGateway"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					// Max length of an Application Gateway is 80.
@@ -702,15 +702,15 @@ func Provider() tfbridge.ProviderInfo {
 					azureName: AutoNameWithMaxLength(azureName, 80),
 				},
 			},
-			"azurerm_application_security_group":                                             {Tok: azureResource(azureNetwork, "ApplicationSecurityGroup")},
-			"azurerm_connection_monitor":                                                     {Tok: azureResource(azureNetwork, "ConnectionMonitor")},
-			"azurerm_firewall":                                                               {Tok: azureResource(azureNetwork, "Firewall")},
-			"azurerm_firewall_application_rule_collection":                                   {Tok: azureResource(azureNetwork, "FirewallApplicationRuleCollection")},
-			"azurerm_firewall_nat_rule_collection":                                           {Tok: azureResource(azureNetwork, "FirewallNatRuleCollection")},
-			"azurerm_firewall_network_rule_collection":                                       {Tok: azureResource(azureNetwork, "FirewallNetworkRuleCollection")},
-			"azurerm_network_connection_monitor":                                             {Tok: azureResource(azureNetwork, "NetworkConnectionMonitor")},
-			"azurerm_network_ddos_protection_plan":                                           {Tok: azureResource(azureNetwork, "DdosProtectionPlan")},
-			"azurerm_network_interface":{
+			"azurerm_application_security_group":           {Tok: azureResource(azureNetwork, "ApplicationSecurityGroup")},
+			"azurerm_connection_monitor":                   {Tok: azureResource(azureNetwork, "ConnectionMonitor")},
+			"azurerm_firewall":                             {Tok: azureResource(azureNetwork, "Firewall")},
+			"azurerm_firewall_application_rule_collection": {Tok: azureResource(azureNetwork, "FirewallApplicationRuleCollection")},
+			"azurerm_firewall_nat_rule_collection":         {Tok: azureResource(azureNetwork, "FirewallNatRuleCollection")},
+			"azurerm_firewall_network_rule_collection":     {Tok: azureResource(azureNetwork, "FirewallNetworkRuleCollection")},
+			"azurerm_network_connection_monitor":           {Tok: azureResource(azureNetwork, "NetworkConnectionMonitor")},
+			"azurerm_network_ddos_protection_plan":         {Tok: azureResource(azureNetwork, "DdosProtectionPlan")},
+			"azurerm_network_interface": {
 				Tok: azureResource(azureNetwork, "NetworkInterface"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					// Max length of a Network Interface is 80.
@@ -724,7 +724,7 @@ func Provider() tfbridge.ProviderInfo {
 			"azurerm_network_interface_nat_rule_association":                                 {Tok: azureResource(azureNetwork, "NetworkInterfaceNatRuleAssociation")},
 			"azurerm_network_packet_capture":                                                 {Tok: azureResource(azureNetwork, "NetworkPacketCapture")},
 			"azurerm_network_profile":                                                        {Tok: azureResource(azureNetwork, "Profile")},
-			"azurerm_network_security_group":{
+			"azurerm_network_security_group": {
 				Tok: azureResource(azureNetwork, "NetworkSecurityGroup"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					// Max length of a Network Security Group is 80.
@@ -732,7 +732,7 @@ func Provider() tfbridge.ProviderInfo {
 					azureName: AutoNameWithMaxLength(azureName, 80),
 				},
 			},
-			"azurerm_network_security_rule":{
+			"azurerm_network_security_rule": {
 				Tok: azureResource(azureNetwork, "NetworkSecurityRule"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					// Max length of a Network Security Rule is 80.
@@ -740,9 +740,9 @@ func Provider() tfbridge.ProviderInfo {
 					azureName: AutoNameWithMaxLength(azureName, 80),
 				},
 			},
-			"azurerm_network_watcher":                                                        {Tok: azureResource(azureNetwork, "NetworkWatcher")},
-			"azurerm_packet_capture":                                                         {Tok: azureResource(azureNetwork, "PacketCapture")},
-			"azurerm_public_ip":{
+			"azurerm_network_watcher": {Tok: azureResource(azureNetwork, "NetworkWatcher")},
+			"azurerm_packet_capture":  {Tok: azureResource(azureNetwork, "PacketCapture")},
+			"azurerm_public_ip": {
 				Tok: azureResource(azureNetwork, "PublicIp"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					// Max length of a Public IP Address is 80.
@@ -759,7 +759,7 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			"azurerm_route":       {Tok: azureResource(azureNetwork, "Route")},
 			"azurerm_route_table": {Tok: azureResource(azureNetwork, "RouteTable")},
-			"azurerm_subnet":{
+			"azurerm_subnet": {
 				Tok: azureResource(azureNetwork, "Subnet"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					// Max length of a Subnet is 80.
@@ -783,7 +783,7 @@ func Provider() tfbridge.ProviderInfo {
 
 			// Traffic Manager
 			"azurerm_traffic_manager_endpoint": {Tok: azureResource(azureTrafficManager, "Endpoint")},
-			"azurerm_traffic_manager_profile":{
+			"azurerm_traffic_manager_profile": {
 				Tok: azureResource(azureTrafficManager, "Profile"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					// Max length of a Traffic Manager Profile is 80.


### PR DESCRIPTION
Adjust max name lengths of several resource types as per the official guidance in https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions

Fixes #159 