### PR TITLE
Switch upstream to terraform-providers/terraform-provider-azurerm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ install_plugins::
 
 lint::
 	golangci-lint run
+	nm "$(shell which pulumi-resource-azure)" | grep github.com/pulumi/pulumi-azure/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm.requireResourcesToBeImported
 
 install::
 	GOBIN=$(PULUMI_BIN) go install -ldflags "-X github.com/pulumi/pulumi-azure/pkg/version.Version=${VERSION}" ${PROJECT}/cmd/${PROVIDER}

--- a/cmd/pulumi-resource-azure/main.go
+++ b/cmd/pulumi-resource-azure/main.go
@@ -15,11 +15,56 @@
 package main
 
 import (
+	_ "unsafe" // Import go:linkname
+
+	"github.com/pulumi/pulumi-terraform/pkg/tfbridge"
+
 	azure "github.com/pulumi/pulumi-azure"
 	"github.com/pulumi/pulumi-azure/pkg/version"
-	"github.com/pulumi/pulumi-terraform/pkg/tfbridge"
 )
 
+// The AzureRM Terraform Provider has a setting named ARM_PROVIDER_STRICT, the bulk
+// of which was introduced into terraform-providers/terraform-provider-azurerm in commit
+// 447abecad. The setting prevents accidental adoption of existing resources, and is
+// something we want to opt into - not delegate to user control via the environment.
+//
+// When we maintained our own fork of terraform-providers-azurerm, we just enabled the
+// setting by modifying the feature flag value directly. Sadly it is unexported, and now
+// we do _not_ depend on a fork but on upstream directly, we need a way to set that.
+//
+// One option would be to use os.Setenv to set the environment variable for the child
+// processes - but this would put Azure specific bits into the plugin loader which is
+// not desirable. Instead, we use `go:linkname` to make the private package-level variable
+// which controls this behaviour accessible to us.
+//
+// go:linkname is not widely used outside the standard library, but allows us to
+// effectively alias a particular symbol via an accessible name. Per Ian Lance Taylor's
+// post on golang-dev [1], "it means: every time you are about to write out X in the object
+// file, write out Y instead."
+//
+// So, by aliasing a local variable `strictMode` to the particular symbol in question in
+// the azure provider (identified via `nm`), we can set the private value here by assigning
+// our own `strictMode` variable. Note that since we build with the vendor/ directory, we
+// must use the qualified vendor path to the symbol.
+//
+// Unfortunately, `go:linkname` does not give an error if the symbol being aliased does
+// not exist. Since we are aliasing into someone elses package, there is a real risk that
+// an upstream refactor will move or break this variable. To that end, as part of the lint
+// step in Makefile, we verify that the built binary actually has the symbol listed here
+// present. This does not protect against behavioural change, but we can likely write a
+// test for the undesirable behaviour to validate against that.
+//
+// Changes to this area of code are noted for upstream v1.30.0 (we are adopting this at
+// v1.29.0) but do not affect the way we need to handle this.
+//
+// [1]: https://groups.google.com/forum/#!topic/golang-dev/j2r7Vq6CBZk
+
+//nolint:lll
+//go:linkname strictMode github.com/pulumi/pulumi-azure/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm.requireResourcesToBeImported
+
+var strictMode bool
+
 func main() {
+	strictMode = true
 	tfbridge.Main("azure", version.Version, azure.Provider())
 }

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/reconquest/loreley v0.0.0-20190408221007-9e95b93c818f // indirect
 	github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304 // indirect
 	github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709
-	github.com/terraform-providers/terraform-provider-azurerm v1.24.0
+	github.com/terraform-providers/terraform-provider-azurerm v1.29.0
 	github.com/uber/jaeger-client-go v2.16.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.0.0+incompatible // indirect
 	gopkg.in/AlecAivazis/survey.v1 v1.8.2 // indirect
@@ -39,5 +39,4 @@ replace (
 	github.com/Nvveen/Gotty => github.com/ijc25/Gotty v0.0.0-20170406111628-a8b993ba6abd
 	github.com/Sirupsen/logrus => github.com/sirupsen/logrus v1.4.2-0.20190403091019-9b3cdde74fbe
 	github.com/golang/glog => github.com/pulumi/glog v0.0.0-20180820174630-7eaa6ffb71e4
-	github.com/terraform-providers/terraform-provider-azurerm => github.com/pulumi/terraform-provider-azurerm v0.0.0-20190526025255-339e6934dd35
 )

--- a/go.sum
+++ b/go.sum
@@ -634,6 +634,8 @@ github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d/go.mod h1:BST
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/terraform-providers/terraform-provider-azurerm v1.24.0 h1:22zj4kWKh7M/D08vxV6NDDiQrqia6y+EotgM7XMR4/M=
 github.com/terraform-providers/terraform-provider-azurerm v1.24.0/go.mod h1:SfLvk7M3ulg33lqkqquv0E5x5Tor/WyRb83pxKlaEfw=
+github.com/terraform-providers/terraform-provider-azurerm v1.29.0 h1:nJ2fO2hNuMdqQ4IcBPA57OmumGwgMG2n5szXSY7qS4I=
+github.com/terraform-providers/terraform-provider-azurerm v1.29.0/go.mod h1:ZWIvltGJ+Q1tvxQjvn/h4q1ONwvaBlAyxO1py8CYQCE=
 github.com/terraform-providers/terraform-provider-openstack v1.15.0/go.mod h1:2aQ6n/BtChAl1y2S60vebhyJyZXBsuAI5G4+lHrT1Ew=
 github.com/texttheater/golang-levenshtein v0.0.0-20180516184445-d188e65d659e h1:T5PdfK/M1xyrHwynxMIVMWLS7f/qHwfslZphxtGnw7s=
 github.com/texttheater/golang-levenshtein v0.0.0-20180516184445-d188e65d659e/go.mod h1:XDKHRm5ThF8YJjx001LtgelzsoaEcvnA7lVWz9EeX3g=


### PR DESCRIPTION
This pull request switches the upstream of `pulumi-azure` from `pulumi/terraform-provider-azurerm` to `terraform-providers/terraform-provider-azurerm`. The only divergence in the fork was related to `ARM_PROVIDER_STRICT` which was enabled unconditionally.

We retain this behaviour by using `go:linkname`, as described in the block comment - repeated here:

The AzureRM Terraform Provider has a setting named ARM_PROVIDER_STRICT, the bulk of which was introduced into terraform-providers/terraform-provider-azurerm in commit 447abecad. The setting prevents accidental adoption of existing resources, and is something we want to opt into - not delegate to user control via the environment.

When we maintained our own fork of terraform-providers-azurerm, we just enabled the setting by modifying the feature flag value directly. Sadly it is unexported, and now we do _not_ depend on a fork but on upstream directly, we need a way to set that.

One option would be to use os.Setenv to set the environment variable for the child processes - but this would put Azure specific bits into the plugin loader which is not desirable. Instead, we use `go:linkname` to make the private package-level variable which controls this behaviour accessible to us.

go:linkname is not widely used outside the standard library, but allows us to effectively alias a particular symbol via an accessible name. Per Ian Lance Taylor's post on golang-dev [1], "it means: every time you are about to write out X in the object file, write out Y instead."

So, by aliasing a local variable `strictMode` to the particular symbol in question in the azure provider (identified via `nm`), we can set the private value here by assigning our own `strictMode` variable. Note that since we build with the vendor/ directory, we must use the qualified vendor path to the symbol.

Unfortunately, `go:linkname` does not give an error if the symbol being aliased does not exist. Since we are aliasing into someone elses package, there is a real risk that an upstream refactor will move or break this variable. To that end, as part of the lint step in Makefile, we verify that the built binary actually has the symbol listed here present. This does not protect against behavioural change, but we can likely write a test for the undesirable behaviour to validate against that.

Changes to this area of code are noted for upstream v1.30.0 (we are adopting this at v1.29.0) but do not affect the way we need to handle this.

[1]: https://groups.google.com/forum/#!topic/golang-dev/j2r7Vq6CBZk

