### PR TITLE
Event Hub Trigger for IoT Hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.18.6 (Unreleased)
 
+## Improvements
+
+- Serverless mixins now support the EventHubTrigger for IoT Hub.
 
 ## 0.18.5 (Released 26th May, 2019)
 

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -39,6 +39,7 @@ func TestExamples(t *testing.T) {
 		base.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "minimal")}),
 		base.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "blob")}),
 		base.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "eventhub")}),
+		base.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "iot")}),
 		base.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "queue")}),
 		base.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "topic")}),
 		base.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "webserver")}),

--- a/examples/iot/Pulumi.yaml
+++ b/examples/iot/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: azure-iot
+runtime: nodejs
+description: Work with Azure IoT Hubs

--- a/examples/iot/index.ts
+++ b/examples/iot/index.ts
@@ -15,7 +15,10 @@ const iotHub = new iot.IoTHub("test", {
         capacity: 1,
         name: "S1",
         tier: "Standard",
-    }
+    }, 
+    fallbackRoute: {
+        enabled: true,
+    },
 });
 
 iotHub.onEvent("test", async (context, arg) => {

--- a/examples/iot/index.ts
+++ b/examples/iot/index.ts
@@ -24,7 +24,7 @@ const iotHub = new iot.IoTHub("test", {
     }
 });
 
-iotHub.onEvent("test", async (context, arg) => {
+iotHub.onEvent("test", async (context, message) => {
     console.log("ctx: " + JSON.stringify(context, null, 4));
-    console.log("arg: " + arg);
+    console.log("arg: " + message);
 });

--- a/examples/iot/index.ts
+++ b/examples/iot/index.ts
@@ -20,5 +20,5 @@ const iotHub = new iot.IoTHub("test", {
 
 iotHub.onEvent("test", async (context, arg) => {
     console.log("ctx: " + JSON.stringify(context, null, 4));
-    console.log("arg: " + JSON.stringify(arg, null, 4));
+    console.log("arg: " + arg);
 });

--- a/examples/iot/index.ts
+++ b/examples/iot/index.ts
@@ -20,8 +20,8 @@ const iotHub = new iot.IoTHub("test", {
         source: "DeviceMessages", 
         enabled: true, 
         endpointNames: ["events"],
-        condition: "true"
-    }
+        condition: "true",
+    },
 });
 
 iotHub.onEvent("test", async (context, message) => {

--- a/examples/iot/index.ts
+++ b/examples/iot/index.ts
@@ -17,8 +17,8 @@ const iotHub = new iot.IoTHub("test", {
         tier: "Standard",
     }, 
     fallbackRoute: {
-        enabled: true,
-    },
+        enabled: true
+    }
 });
 
 iotHub.onEvent("test", async (context, arg) => {

--- a/examples/iot/index.ts
+++ b/examples/iot/index.ts
@@ -1,0 +1,24 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+import * as azure from "@pulumi/azure";
+import * as iot from "@pulumi/azure/iot";
+
+const location = "West US 2";
+
+const resourceGroup = new azure.core.ResourceGroup("test", {
+    location: location,
+});
+
+const iotHub = new iot.IoTHub("test", {
+    resourceGroupName: resourceGroup.name,
+    sku: {
+        capacity: 1,
+        name: "S1",
+        tier: "Standard",
+    }
+});
+
+iotHub.onEvent("test", async (context, arg) => {
+    console.log("ctx: " + JSON.stringify(context, null, 4));
+    console.log("arg: " + JSON.stringify(arg, null, 4));
+});

--- a/examples/iot/index.ts
+++ b/examples/iot/index.ts
@@ -15,9 +15,12 @@ const iotHub = new iot.IoTHub("test", {
         capacity: 1,
         name: "S1",
         tier: "Standard",
-    }, 
+    },
     fallbackRoute: {
-        enabled: true
+        source: "DeviceMessages", 
+        enabled: true, 
+        endpointNames: ["events"],
+        condition: "true"
     }
 });
 

--- a/examples/iot/package.json
+++ b/examples/iot/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "azure-iot",
+    "version": "0.1.0",
+    "main": "bin/index.js",
+    "typings": "bin/index.d.ts",
+    "scripts": {
+        "build": "tsc"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^0.17.8",
+        "mime-types": "^2.1.19"
+    },
+    "devDependencies": {
+        "@types/node": "^10.0.0",
+        "typescript": "^3.4.5"
+    },
+    "peerDependencies": {
+        "@pulumi/azure": "latest"
+    },
+    "license": "Apache 2.0"
+}

--- a/examples/iot/tsconfig.json
+++ b/examples/iot/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/resources.go
+++ b/resources.go
@@ -1040,6 +1040,11 @@ func Provider() tfbridge.ProviderInfo {
 							"zMixins.ts",
 						},
 					},
+					"iot": {
+						DestFiles: []string{
+							"zMixins.ts",
+						},
+					},
 					"storage": {
 						DestFiles: []string{
 							"zMixins.ts",

--- a/sdk/nodejs/eventhub/zMixins.ts
+++ b/sdk/nodejs/eventhub/zMixins.ts
@@ -228,7 +228,7 @@ export class TopicEventSubscription extends appservice.EventSubscription<TopicCo
     }
 }
 
-interface EventHubBindingDefinition extends appservice.BindingDefinition {
+export interface EventHubBindingDefinition extends appservice.BindingDefinition {
     /**
      * The name of the property in the context object to bind the actual event to.
      */

--- a/sdk/nodejs/eventhub/zMixins.ts
+++ b/sdk/nodejs/eventhub/zMixins.ts
@@ -229,6 +229,7 @@ export class TopicEventSubscription extends appservice.EventSubscription<TopicCo
 }
 
 /** @internal */
+/** This is only exported to be used internally by the /iot/zMixins.ts file */
 export interface EventHubBindingDefinition extends appservice.BindingDefinition {
     /**
      * The name of the property in the context object to bind the actual event to.

--- a/sdk/nodejs/eventhub/zMixins.ts
+++ b/sdk/nodejs/eventhub/zMixins.ts
@@ -228,6 +228,7 @@ export class TopicEventSubscription extends appservice.EventSubscription<TopicCo
     }
 }
 
+/** @internal */
 export interface EventHubBindingDefinition extends appservice.BindingDefinition {
     /**
      * The name of the property in the context object to bind the actual event to.

--- a/sdk/nodejs/iot/index.ts
+++ b/sdk/nodejs/iot/index.ts
@@ -5,3 +5,4 @@
 export * from "./consumerGroup";
 export * from "./ioTHub";
 export * from "./sharedAccessPolicy";
+export * from "./zMixins";

--- a/sdk/nodejs/iot/zMixins.ts
+++ b/sdk/nodejs/iot/zMixins.ts
@@ -1,3 +1,17 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import * as pulumi from "@pulumi/pulumi";
 import * as appservice from "../appservice";
 import { IoTHub } from "./ioTHub";

--- a/sdk/nodejs/iot/zMixins.ts
+++ b/sdk/nodejs/iot/zMixins.ts
@@ -77,10 +77,10 @@ export class IoTHubEventSubscription extends appservice.EventSubscription<EventH
         }];
 
         pulumi.all([iotHub.fallbackRoute, iotHub.routes]).apply(([fallbackRoute, routes]) => {
-            if(fallbackRoute && fallbackRoute.enabled){
+            if (fallbackRoute && fallbackRoute.enabled) {
                 return;
             }
-            if(routes && routes.length > 0){
+            if (routes && routes.length > 0) {
                 return;
             }
             throw new pulumi.ResourceError("IoT Hub must have a route or fallback route enabled.", opts.parent);

--- a/sdk/nodejs/iot/zMixins.ts
+++ b/sdk/nodejs/iot/zMixins.ts
@@ -94,7 +94,7 @@ export class IoTHubEventSubscription extends appservice.EventSubscription<EventH
         const appSettings = pulumi.all([args.appSettings, iotHub.eventHubEventsEndpoint, iotHub.sharedAccessPolicies]).apply(
             ([appSettings, eventHubEventsEndpoint, sharedAccessPolicies]) => ({ 
                 ...appSettings, 
-                [bindingConnectionKey]: `Endpoint=${eventHubEventsEndpoint};SharedAccessKeyName=iothubowner;SharedAccessKey=${sharedAccessPolicies.filter(p => p.keyName === "iothubowner")[0].primaryKey}` 
+                [bindingConnectionKey]: `Endpoint=${eventHubEventsEndpoint};SharedAccessKeyName=iothubowner;SharedAccessKey=${sharedAccessPolicies.find(p => p.keyName === "iothubowner")!.primaryKey}` 
             }));
 
         super("azure:eventhub:IoTHubEventSubscription", name, bindings, {

--- a/sdk/nodejs/iot/zMixins.ts
+++ b/sdk/nodejs/iot/zMixins.ts
@@ -88,7 +88,9 @@ export class IoTHubEventSubscription extends appservice.EventSubscription<EventH
 
         // Place the mapping from the well known key name to the Event Hubs account connection string in
         // the 'app settings' object.
-        // The connection string is built from the IoT Hub "event hub compatible endpoint" and the iothubowner access policy key - see https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-read-builtin
+        // The connection string is built from the IoT Hub "event hub compatible endpoint" 
+        // and the iothubowner access policy key
+        // see https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-read-builtin
         const appSettings = pulumi.all([args.appSettings, iotHub.eventHubEventsEndpoint, iotHub.sharedAccessPolicies]).apply(
             ([appSettings, eventHubEventsEndpoint, sharedAccessPolicies]) => ({ 
                 ...appSettings, 

--- a/sdk/nodejs/iot/zMixins.ts
+++ b/sdk/nodejs/iot/zMixins.ts
@@ -54,7 +54,7 @@ export class IoTHubEventSubscription extends appservice.EventSubscription<EventH
         const appSettings = pulumi.all([args.appSettings]).apply(
             ([appSettings]) => ({ ...appSettings, [bindingConnectionKey]: iotHub.eventHubEventsEndpoint }));
 
-        super("azure:eventhub:EventHubSubscription", name, bindings, {
+        super("azure:eventhub:IoTHubEventSubscription", name, bindings, {
             ...args,
             resourceGroupName,
             location,

--- a/sdk/nodejs/iot/zMixins.ts
+++ b/sdk/nodejs/iot/zMixins.ts
@@ -1,0 +1,75 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as appservice from "../appservice";
+import { IoTHub } from "./ioTHub";
+import { EventHubBindingDefinition, EventHubContext, EventHubCallback, EventHubSubscriptionArgs } from '../eventhub';
+
+declare module "./ioTHub" {
+    interface IoTHub {
+        /**
+         * Subscribes to events logged to this Event Hub to the handler provided, along
+         * with options to control the behavior of the subscription.
+         */
+        onEvent(
+            name: string, args: EventHubCallback | EventHubSubscriptionArgs, opts?: pulumi.ComponentResourceOptions): IoTHubEventSubscription;
+    }
+}
+
+IoTHub.prototype.onEvent = function(this: IoTHub, name, args, opts) {
+    const functionArgs = args instanceof Function
+        ? <EventHubSubscriptionArgs>{ callback: args }
+        : args;
+
+    return new IoTHubEventSubscription(name, this, functionArgs, opts);
+}
+
+export class IoTHubEventSubscription extends appservice.EventSubscription<EventHubContext, string, void> {
+    readonly iotHub: IoTHub;
+
+    constructor(
+        name: string, iotHub: IoTHub,
+        args: EventHubSubscriptionArgs, opts: pulumi.ComponentResourceOptions = {}) {
+
+        opts = { parent: iotHub, ...opts };
+
+        const { resourceGroupName, location } = appservice.getResourceGroupNameAndLocation(args, iotHub.resourceGroupName);
+
+        // The event hub binding does not store the Event Hubs connection string directly.  Instead, the
+        // connection string is put into the app settings (under whatever key we want). Then, the
+        // .connection property of the binding contains the *name* of that app setting key.
+        const bindingConnectionKey = "BindingConnectionAppSettingsKey";
+
+        const bindings: EventHubBindingDefinition[] = [{
+            name: "eventHub",
+            direction: "in",
+            type: "eventHubTrigger",
+            eventHubName: iotHub.name,
+            consumerGroup: "$Default", // Other consumer groups will be supported in future version 
+            cardinality: args.cardinality,
+            connection: bindingConnectionKey,
+        }];
+
+        const {accessPolicies, hostname} = pulumi.all(
+            [iotHub.sharedAccessPolicies, iotHub.hostname])
+            .apply(([accessPolicies, hostname]) => ({accessPolicies, hostname}));
+
+        const servicePolicyKey = accessPolicies.get().filter(p => p.keyName == "service").map(p => p.primaryKey)[0];
+        const servicePolicyConnectionString = `HostName=${hostname};SharedAccessKeyName=service;SharedAccessKey=${servicePolicyKey}`;
+      
+        // Place the mapping from the well known key name to the Event Hubs account connection string in
+        // the 'app settings' object.
+
+        const appSettings = pulumi.all([args.appSettings]).apply(
+            ([appSettings]) => ({ ...appSettings, [bindingConnectionKey]: servicePolicyConnectionString }));
+
+        super("azure:eventhub:EventHubSubscription", name, bindings, {
+            ...args,
+            resourceGroupName,
+            location,
+            appSettings
+        }, opts);
+
+        this.iotHub = iotHub;
+
+        this.registerOutputs();
+    }
+}

--- a/sdk/nodejs/iot/zMixins.ts
+++ b/sdk/nodejs/iot/zMixins.ts
@@ -48,12 +48,9 @@ export class IoTHubEventSubscription extends appservice.EventSubscription<EventH
             connection: bindingConnectionKey,
         }];
 
-        const {accessPolicies, hostname} = pulumi.all(
+        const servicePolicyConnectionString = pulumi.all(
             [iotHub.sharedAccessPolicies, iotHub.hostname])
-            .apply(([accessPolicies, hostname]) => ({accessPolicies, hostname}));
-
-        const servicePolicyKey = accessPolicies.get().filter(p => p.keyName == "service").map(p => p.primaryKey)[0];
-        const servicePolicyConnectionString = `HostName=${hostname};SharedAccessKeyName=service;SharedAccessKey=${servicePolicyKey}`;
+            .apply(([accessPolicies, hostname]) => `HostName=${hostname};SharedAccessKeyName=service;SharedAccessKey=${accessPolicies.filter(p =>  p.keyName == "service").map(p => p.primaryKey)[0]}`);
       
         // Place the mapping from the well known key name to the Event Hubs account connection string in
         // the 'app settings' object.

--- a/sdk/nodejs/iot/zMixins.ts
+++ b/sdk/nodejs/iot/zMixins.ts
@@ -77,7 +77,7 @@ export class IoTHubEventSubscription extends appservice.EventSubscription<EventH
         }];
 
         pulumi.all([iotHub.fallbackRoute, iotHub.routes]).apply(([fallbackRoute, routes]) => {
-            if(fallbackRoute.enabled){
+            if(fallbackRoute && fallbackRoute.enabled){
                 return;
             }
             if(routes && routes.length > 0){
@@ -88,7 +88,7 @@ export class IoTHubEventSubscription extends appservice.EventSubscription<EventH
 
         // Place the mapping from the well known key name to the Event Hubs account connection string in
         // the 'app settings' object.
-
+        // The connection string is built from the IoT Hub "event hub compatible endpoint" and the iothubowner access policy key - see https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-read-builtin
         const appSettings = pulumi.all([args.appSettings, iotHub.eventHubEventsEndpoint, iotHub.sharedAccessPolicies]).apply(
             ([appSettings, eventHubEventsEndpoint, sharedAccessPolicies]) => ({ 
                 ...appSettings, 

--- a/sdk/nodejs/iot/zMixins.ts
+++ b/sdk/nodejs/iot/zMixins.ts
@@ -48,15 +48,11 @@ export class IoTHubEventSubscription extends appservice.EventSubscription<EventH
             connection: bindingConnectionKey,
         }];
 
-        const servicePolicyConnectionString = pulumi.all(
-            [iotHub.sharedAccessPolicies, iotHub.hostname])
-            .apply(([accessPolicies, hostname]) => `HostName=${hostname};SharedAccessKeyName=service;SharedAccessKey=${accessPolicies.filter(p =>  p.keyName == "service").map(p => p.primaryKey)[0]}`);
-      
         // Place the mapping from the well known key name to the Event Hubs account connection string in
         // the 'app settings' object.
 
         const appSettings = pulumi.all([args.appSettings]).apply(
-            ([appSettings]) => ({ ...appSettings, [bindingConnectionKey]: servicePolicyConnectionString }));
+            ([appSettings]) => ({ ...appSettings, [bindingConnectionKey]: iotHub.eventHubEventsEndpoint }));
 
         super("azure:eventhub:EventHubSubscription", name, bindings, {
             ...args,

--- a/sdk/nodejs/iot/zMixins.ts
+++ b/sdk/nodejs/iot/zMixins.ts
@@ -51,8 +51,8 @@ export class IoTHubEventSubscription extends appservice.EventSubscription<EventH
         // Place the mapping from the well known key name to the Event Hubs account connection string in
         // the 'app settings' object.
 
-        const appSettings = pulumi.all([args.appSettings]).apply(
-            ([appSettings]) => ({ ...appSettings, [bindingConnectionKey]: iotHub.eventHubEventsEndpoint }));
+        const appSettings = pulumi.all([args.appSettings, iotHub.eventHubEventsEndpoint]).apply(
+            ([appSettings,eventHubEventsEndpoint]) => ({ ...appSettings, [bindingConnectionKey]: eventHubEventsEndpoint }));
 
         super("azure:eventhub:IoTHubEventSubscription", name, bindings, {
             ...args,

--- a/sdk/nodejs/iot/zMixins.ts
+++ b/sdk/nodejs/iot/zMixins.ts
@@ -14,7 +14,7 @@ declare module "./ioTHub" {
     }
 }
 
-IoTHub.prototype.onEvent = function(this: IoTHub, name, args, opts) {
+IoTHub.prototype.onEvent = function (this: IoTHub, name, args, opts) {
     const functionArgs = args instanceof Function
         ? <EventHubSubscriptionArgs>{ callback: args }
         : args;
@@ -52,7 +52,7 @@ export class IoTHubEventSubscription extends appservice.EventSubscription<EventH
         // the 'app settings' object.
 
         const appSettings = pulumi.all([args.appSettings, iotHub.eventHubEventsEndpoint]).apply(
-            ([appSettings,eventHubEventsEndpoint]) => ({ ...appSettings, [bindingConnectionKey]: eventHubEventsEndpoint }));
+            ([appSettings, eventHubEventsEndpoint]) => ({ ...appSettings, [bindingConnectionKey]: eventHubEventsEndpoint }));
 
         super("azure:eventhub:IoTHubEventSubscription", name, bindings, {
             ...args,

--- a/sdk/nodejs/iot/zMixins.ts
+++ b/sdk/nodejs/iot/zMixins.ts
@@ -76,6 +76,16 @@ export class IoTHubEventSubscription extends appservice.EventSubscription<EventH
             connection: bindingConnectionKey,
         }];
 
+        pulumi.all([iotHub.fallbackRoute, iotHub.routes]).apply(([fallbackRoute, routes]) => {
+            if(fallbackRoute.enabled){
+                return;
+            }
+            if(routes && routes.length > 0){
+                return;
+            }
+            throw new pulumi.ResourceError("IoT Hub must have a route or fallback route enabled.", opts.parent);
+        });
+
         // Place the mapping from the well known key name to the Event Hubs account connection string in
         // the 'app settings' object.
 

--- a/sdk/nodejs/iot/zMixins.ts
+++ b/sdk/nodejs/iot/zMixins.ts
@@ -51,8 +51,11 @@ export class IoTHubEventSubscription extends appservice.EventSubscription<EventH
         // Place the mapping from the well known key name to the Event Hubs account connection string in
         // the 'app settings' object.
 
-        const appSettings = pulumi.all([args.appSettings, iotHub.eventHubEventsEndpoint]).apply(
-            ([appSettings, eventHubEventsEndpoint]) => ({ ...appSettings, [bindingConnectionKey]: eventHubEventsEndpoint }));
+        const appSettings = pulumi.all([args.appSettings, iotHub.eventHubEventsEndpoint, iotHub.sharedAccessPolicies]).apply(
+            ([appSettings, eventHubEventsEndpoint, sharedAccessPolicies]) => ({ 
+                ...appSettings, 
+                [bindingConnectionKey]: `Endpoint=${eventHubEventsEndpoint};SharedAccessKeyName=iothubowner;SharedAccessKey=${sharedAccessPolicies.filter(p => p.keyName === "iothubowner")[0].primaryKey}` 
+            }));
 
         super("azure:eventhub:IoTHubEventSubscription", name, bindings, {
             ...args,

--- a/sdk/nodejs/iot/zMixins.ts
+++ b/sdk/nodejs/iot/zMixins.ts
@@ -14,7 +14,7 @@ declare module "./ioTHub" {
     }
 }
 
-IoTHub.prototype.onEvent = function (this: IoTHub, name, args, opts) {
+IoTHub.prototype.onEvent = function(this: IoTHub, name, args, opts) {
     const functionArgs = args instanceof Function
         ? <EventHubSubscriptionArgs>{ callback: args }
         : args;

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -218,6 +218,7 @@
         "iot/index.ts",
         "iot/ioTHub.ts",
         "iot/sharedAccessPolicy.ts",
+        "iot/zMixins.ts",
         "keyvault/accessPolicy.ts",
         "keyvault/certifiate.ts",
         "keyvault/getAccessPolicy.ts",


### PR DESCRIPTION
This PR adds the same functionality (triggering serverless azure functions) that is already available for Event Hubs also for usages of the Azure IoT Hub.

Intended usage:

`const iotHub = new IoTHub();
iotHub .onEvent("test", async (context, arg) => {
    console.log("message received");
});`

As this is my first PR to pulumi, I'm not quite sure on contribution requirements - how testing & documentation is done. So please, give feedback :-)