### PR TITLE
Adding a mixin for Azure Locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Add a mixin to allow Location types
 
 ---
 

--- a/examples/webserver/index.ts
+++ b/examples/webserver/index.ts
@@ -5,7 +5,7 @@ import * as azure from "@pulumi/azure";
 const name = "webserver";
 
 let resourceGroup = new azure.core.ResourceGroup(name, {
-    location: "West US",
+    location: azure.WestUS,
 });
 
 let network = new azure.network.VirtualNetwork(name, {

--- a/resources.go
+++ b/resources.go
@@ -1025,6 +1025,7 @@ func Provider() tfbridge.ProviderInfo {
 			Overlay: &tfbridge.OverlayInfo{
 				Files: []string{},
 				DestFiles: []string{
+					"location.ts",
 					"util.ts",
 				},
 				Modules: map[string]*tfbridge.OverlayInfo{

--- a/sdk/nodejs/index.ts
+++ b/sdk/nodejs/index.ts
@@ -2,6 +2,7 @@
 // *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 // Export members:
+export * from "./location";
 export * from "./provider";
 export * from "./util";
 

--- a/sdk/nodejs/location.ts
+++ b/sdk/nodejs/location.ts
@@ -1,0 +1,80 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export let EastAsia:           Location = "eastasia";
+export let SouthEastAsia:      Location = "southeastasia";
+export let CentralUS:          Location = "centralus";
+export let EastUS:             Location = "eastus";
+export let EastUS2:            Location = "eastus2";
+export let WestUS:             Location = "westus";
+export let WestUS2:            Location = "westus2";
+export let NorthCentralUS:     Location = "northcentralus";
+export let SouthCentralUS:     Location = "southcentralus";
+export let NorthEurope:        Location = "northeurope";
+export let WestEurope:         Location = "westeurope";
+export let JapanWest:          Location = "japanwest";
+export let JapanEast:          Location = "japaneast";
+export let BrazilSouth:        Location = "brazilsouth";
+export let AustraliaEast:      Location = "australiaeast";
+export let AustraliaSouthEast: Location = "australiasoutheast";
+export let AustraliaCentral:   Location  = "australiacentral";
+export let AustraliaCentral2:  Location = "australiacentral2";
+export let SouthIndia:         Location = "southindia";
+export let CentralIndia:       Location = "centralindia";
+export let WestIndia:          Location = "westindia";
+export let CanadaCentral:      Location = "canadacentral";
+export let CanadaEast:         Location = "canadaeast";
+export let UKSouth:            Location = "uksouth";
+export let UKWest:             Location = "ukwest";
+export let WestCentralUS:      Location = "westcentralus";
+export let KoreaCentral:       Location = "koreacentral";
+export let KoreaSouth:         Location = "koreasouth";
+export let FranceCentral:      Location = "francecentral";
+export let FranceSouth:        Location = "francesouth";
+export let SouthAfricaNorth:   Location = "southafricanorth";
+export let SouthAfricaWest:    Location = "southafricawest";
+
+export type Location =
+    "eastasia"           |
+    "southeastasia"      |
+    "centralus"          |
+    "eastus"             |
+    "eastus2"            |
+    "westus"             |
+    "westus2"            |
+    "northcentralus"     |
+    "southcentralus"     |
+    "northeurope"        |
+    "westeurope"         |
+    "japanwest"          |
+    "japaneast"          |
+    "brazilsouth"        |
+    "australiaeast"      |
+    "australiasoutheast" |
+    "australiacentral"   |
+    "australiacentral2"  |
+    "southindia"         |
+    "centralindia"       |
+    "westindia"          |
+    "canadacentral"      |
+    "canadaeast"         |
+    "uksouth"            |
+    "ukwest"             |
+    "westcentralus"      |
+    "koreacentral"       |
+    "koreasouth"         |
+    "francecentral"      |
+    "francesouth"        |
+    "southafricanorth"   |
+    "southafricawest"    ;

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -239,6 +239,7 @@
         "lb/outboundRule.ts",
         "lb/probe.ts",
         "lb/rule.ts",
+        "location.ts",
         "loganalytics/index.ts",
         "loganalytics/linkedService.ts",
         "logicapps/actionCustom.ts",


### PR DESCRIPTION
Fixes #117 	

Allows us to turn this:

```
let resourceGroup = new azure.core.ResourceGroup(name, {
    location: "West US",
});
```

into

```
let resourceGroup = new azure.core.ResourceGroup(name, {
    location: azure.WestUS,
});
```