### PR TITLE
HTTP, Timer, and Queue functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 * Add constants for the Azure Location types
 * Introduce MultiCallbackFunctionApp which can hold several callback functions in the same Function App
 * Introduce ArchiveFunctionApp which accept an archive of an Azure Functions deployment artifact
+* Introduce HttpFunction, TimerFunction, and QueueFunction - to be hosted within MultiCallbackFunctionApp
 
 ---
 

--- a/examples/http-multi/index.ts
+++ b/examples/http-multi/index.ts
@@ -3,15 +3,15 @@ import * as azure from "@pulumi/azure";
 const resourceGroup = new azure.core.ResourceGroup("example", { location: azure.Locations.WestUS2 });
 
 // Define 3 HTTP Functions which only differ by number and the hello message
-const http = [1, 2, 3].map(i => 
-    new azure.appservice.HttpFunction(`F${i}`, { 
-        callback: async (context, request) => ({ status: 200, body: `Hi from F${i}` }) 
+const http = [1, 2, 3].map(i =>
+    new azure.appservice.HttpFunction(`F${i}`, {
+        callback: async (context, request) => ({ status: 200, body: `Hi from F${i}` }),
     }),
 );
 
 // Define a timer function which will trigger every minute to keep other Function from being disposed on idle
 const warmer = new azure.appservice.TimerFunction("Warmer", {
-    schedule: { second: 0 }, 
+    schedule: { second: 0 },
     callback: async (context, timer) => {
         // Do nothing, it's just a warmer
     },

--- a/examples/http-multi/index.ts
+++ b/examples/http-multi/index.ts
@@ -6,7 +6,7 @@ const resourceGroup = new azure.core.ResourceGroup("example", { location: azure.
 const http = [1, 2, 3].map(i => 
     new azure.appservice.HttpFunction(`F${i}`, { 
         callback: async (context, request) => ({ status: 200, body: `Hi from F${i}` }) 
-    })
+    }),
 );
 
 // Define a timer function which will trigger every minute to keep other Function from being disposed on idle
@@ -14,7 +14,7 @@ const warmer = new azure.appservice.TimerFunction("Warmer", {
     schedule: { second: 0 }, 
     callback: async (context, timer) => {
         // Do nothing, it's just a warmer
-    } 
+    },
 });
 
 // Create a Function App containing multiple functions

--- a/examples/http-multi/index.ts
+++ b/examples/http-multi/index.ts
@@ -1,34 +1,26 @@
 import * as azure from "@pulumi/azure";
 
-const resourceGroup = new azure.core.ResourceGroup("example", { location: "West US 2" });
+const resourceGroup = new azure.core.ResourceGroup("example", { location: azure.Locations.WestUS2 });
 
-function makeHttpFunction(name: string, callback: azure.appservice.Callback<azure.appservice.Context<azure.appservice.HttpResponse>, azure.appservice.HttpRequest, azure.appservice.HttpResponse>) {
-    const bindings = [{
-        authLevel: "anonymous",
-        type: "httpTrigger",
-        direction: "in",
-        name: "req",
-    }, {
-        type: "http",
-        direction: "out",
-        name: "$return",
-    }];
+// Define 3 HTTP Functions which only differ by number and the hello message
+const http = [1, 2, 3].map(i => 
+    new azure.appservice.HttpFunction(`F${i}`, { 
+        callback: async (context, request) => ({ status: 200, body: `Hi from F${i}` }) 
+    })
+);
 
-    return <azure.appservice.Function>{
-        name,
-        bindings,
-        callback: { callback },
-    };
-}
+// Define a timer function which will trigger every minute to keep other Function from being disposed on idle
+const warmer = new azure.appservice.TimerFunction("Warmer", {
+    schedule: { second: 0 }, 
+    callback: async (context, timer) => {
+        // Do nothing, it's just a warmer
+    } 
+});
 
 // Create a Function App containing multiple functions
 const app = new azure.appservice.MultiCallbackFunctionApp("http-multi", {
     resourceGroupName: resourceGroup.name,
-    functions: [
-        makeHttpFunction("F1", async (c, r) => ({ status: 200, body: "Hi from F1" })),
-        makeHttpFunction("F2", async (c, r) => ({ status: 200, body: "Hi from F2" }))
-    ]
+    functions: [ ...http, warmer],
 });
 
-export const url1 = app.endpoint.apply(ep => `${ep}F1`);
-export const url2 = app.endpoint.apply(ep => `${ep}F2`);
+export const urls = http.map(f => app.endpoint.apply(ep => `${ep}${f.name}`));

--- a/sdk/nodejs/appservice/zMixins.ts
+++ b/sdk/nodejs/appservice/zMixins.ts
@@ -392,7 +392,7 @@ export interface Function {
     /**
      * Function callback.
      */
-    callback: CallbackArgs<any, any, any>;
+    callback: CallbackArgs<Context<any>, any, any>;
 
     /**
      * Application settings required by the function.
@@ -403,6 +403,42 @@ export interface Function {
 // Type guard for Function interface
 function isFunction(object: any): object is Function {
     return 'name' in object && 'bindings' in object && 'callback' in object;
+}
+
+/**
+ * Azure Function base class.
+ */
+export abstract class FunctionBase<C extends Context<R>, E, R extends Result> implements Function {
+    /**
+     * Function name.
+     */
+    public readonly name: string;
+
+    /**
+     * An array of function binding definitions.
+     */
+    public readonly bindings: pulumi.Input<BindingDefinition[]>;
+
+    /**
+     * Function callback.
+     */
+    public readonly callback: CallbackArgs<Context<any>, E, R>;
+
+    /**
+     * Application settings required by the function.
+     */
+    public readonly appSettings?: pulumi.Input<{ [key: string]: string }>;
+
+    constructor(name: string, 
+        trigger: pulumi.Input<BindingDefinition>,
+        inputOutputBindings: pulumi.Input<BindingDefinition[]>,
+        callback: CallbackArgs<C, E, R>,
+        appSettings?: pulumi.Input<{ [key: string]: string }>) {
+        this.name = name;
+        this.bindings = pulumi.all([trigger, inputOutputBindings]).apply(([t, iob]) => [t, ...iob]);
+        this.callback = <CallbackArgs<Context<any>, E, R>>callback;
+        this.appSettings = appSettings;
+    }
 }
 
 /**

--- a/sdk/nodejs/appservice/zMixins.ts
+++ b/sdk/nodejs/appservice/zMixins.ts
@@ -405,21 +405,6 @@ function isFunction(object: any): object is Function {
     return 'name' in object && 'bindings' in object && 'callback' in object;
 }
 
-/** @internal */
-function makeFunction<C extends Context<R>, E, R extends Result>(
-    name: string, 
-    trigger: pulumi.Input<BindingDefinition>,
-    inputOutputBindings: pulumi.Input<BindingDefinition[]>,
-    callback: CallbackArgs<C, E, R>,
-    appSettings?: pulumi.Input<{ [key: string]: string }>): Function {
-    return {
-        name,
-        bindings: pulumi.all([trigger, inputOutputBindings]).apply(([t, iob]) => [t, ...iob]),
-        callback: <CallbackArgs<Context<any>, E, R>>callback,
-        appSettings,
-    };
-}
-
 /**
  * Azure Function base class.
  */

--- a/sdk/nodejs/appservice/zMixins.ts
+++ b/sdk/nodejs/appservice/zMixins.ts
@@ -405,10 +405,24 @@ function isFunction(object: any): object is Function {
     return 'name' in object && 'bindings' in object && 'callback' in object;
 }
 
+/** @internal */
+function makeFunction<C extends Context<R>, E, R extends Result>(
+    name: string, 
+    trigger: pulumi.Input<BindingDefinition>,
+    inputOutputBindings: pulumi.Input<BindingDefinition[]>,
+    callback: CallbackArgs<C, E, R>,
+    appSettings?: pulumi.Input<{ [key: string]: string }>): Function {
+    return {
+        name,
+        bindings: pulumi.all([trigger, inputOutputBindings]).apply(([t, iob]) => [t, ...iob]),
+        callback: <CallbackArgs<Context<any>, E, R>>callback,
+        appSettings,
+    };
+}
+
 /**
  * Azure Function base class.
  */
-/** @internal */
 export abstract class FunctionBase<C extends Context<R>, E, R extends Result> implements Function {
     /**
      * Function name.
@@ -431,12 +445,11 @@ export abstract class FunctionBase<C extends Context<R>, E, R extends Result> im
     public readonly appSettings?: pulumi.Input<{ [key: string]: string }>;
 
     constructor(name: string, 
-        trigger: pulumi.Input<BindingDefinition>,
-        inputOutputBindings: pulumi.Input<BindingDefinition[]>,
+        bindings: pulumi.Input<BindingDefinition[]>,
         callback: CallbackArgs<C, E, R>,
         appSettings?: pulumi.Input<{ [key: string]: string }>) {
         this.name = name;
-        this.bindings = pulumi.all([trigger, inputOutputBindings]).apply(([t, iob]) => [t, ...iob]);
+        this.bindings = bindings;
         this.callback = <CallbackArgs<Context<any>, E, R>>callback;
         this.appSettings = appSettings;
     }

--- a/sdk/nodejs/appservice/zMixins.ts
+++ b/sdk/nodejs/appservice/zMixins.ts
@@ -408,6 +408,7 @@ function isFunction(object: any): object is Function {
 /**
  * Azure Function base class.
  */
+/** @internal */
 export abstract class FunctionBase<C extends Context<R>, E, R extends Result> implements Function {
     /**
      * Function name.

--- a/sdk/nodejs/appservice/zMixins.ts
+++ b/sdk/nodejs/appservice/zMixins.ts
@@ -404,7 +404,7 @@ export abstract class Function<C extends Context<R>, E, R extends Result> {
      */
     public readonly appSettings?: pulumi.Input<{ [key: string]: string }>;
 
-    constructor(name: string, 
+    constructor(name: string,
         bindings: pulumi.Input<BindingDefinition[]>,
         callback: CallbackArgs<C, E, R>,
         appSettings?: pulumi.Input<{ [key: string]: string }>) {

--- a/sdk/nodejs/appservice/zMixins_http.ts
+++ b/sdk/nodejs/appservice/zMixins_http.ts
@@ -134,14 +134,14 @@ export class HttpEventSubscription extends mod.EventSubscription<mod.Context<Htt
  */
 export class HttpFunction extends mod.FunctionBase<mod.Context<HttpResponse>, HttpRequest, HttpResponse> {
     constructor(name: string, args: HttpFunctionArgs) {
-        super(name, <HttpBindingDefinition>{
+        super(name, [<HttpBindingDefinition>{
             authLevel: "anonymous",
             type: "httpTrigger",
             direction: "in",
             name: "req",
             route: args.route,
             methods: args.methods,
-        }, [{
+        }, {
             type: "http",
             direction: "out",
             name: "$return",

--- a/sdk/nodejs/appservice/zMixins_http.ts
+++ b/sdk/nodejs/appservice/zMixins_http.ts
@@ -45,9 +45,9 @@ export interface HttpHostExtensions {
     maxConcurrentRequests?: number,
 
     /**
-     * When enabled, this setting causes the request processing pipeline to periodically check system performance 
-     * counters like connections/threads/processes/memory/cpu/etc. and if any of those counters are over a built-in 
-     * high threshold (80%), requests will be rejected with a 429 "Too Busy" response until the counter(s) return 
+     * When enabled, this setting causes the request processing pipeline to periodically check system performance
+     * counters like connections/threads/processes/memory/cpu/etc. and if any of those counters are over a built-in
+     * high threshold (80%), requests will be rejected with a 429 "Too Busy" response until the counter(s) return
      * to normal levels.
      */
     dynamicThrottlesEnabled?: boolean,
@@ -73,9 +73,9 @@ export interface HttpFunctionArgs extends mod.CallbackArgs<mod.Context<HttpRespo
 }
 
 export interface HttpEventSubscriptionArgs extends HttpFunctionArgs, mod.CallbackFunctionAppArgs<mod.Context<HttpResponse>, HttpRequest, HttpResponse> {
-        /** 
-     * Host settings specific to the HTTP plugin. These values can be provided here, or defaults will 
-     * be used in their place. 
+    /**
+     * Host settings specific to the HTTP plugin. These values can be provided here, or defaults will
+     * be used in their place.
      */
     hostSettings?: HttpHostSettings;
 };
@@ -102,7 +102,6 @@ export class HttpEventSubscription extends mod.EventSubscription<mod.Context<Htt
         super("azure:appservice:HttpEventSubscription", name, new HttpFunction(name, args), args, opts);
 
         this.url = pulumi.interpolate`${this.functionApp.endpoint}${args.route || name}`;
-
         this.registerOutputs();
     }
 }

--- a/sdk/nodejs/appservice/zMixins_http.ts
+++ b/sdk/nodejs/appservice/zMixins_http.ts
@@ -132,7 +132,7 @@ export class HttpEventSubscription extends mod.EventSubscription<mod.Context<Htt
 /**
  * Azure Function triggered by HTTP requests.
  */
-export class HttpFunction extends mod.FunctionBase<mod.Context<HttpResponse>, HttpRequest, HttpResponse> {
+export class HttpFunction extends mod.Function<mod.Context<HttpResponse>, HttpRequest, HttpResponse> {
     constructor(name: string, args: HttpFunctionArgs) {
         super(name, [<HttpBindingDefinition>{
             authLevel: "anonymous",

--- a/sdk/nodejs/appservice/zMixins_http.ts
+++ b/sdk/nodejs/appservice/zMixins_http.ts
@@ -132,36 +132,19 @@ export class HttpEventSubscription extends mod.EventSubscription<mod.Context<Htt
 /**
  * Azure Function triggered by HTTP requests.
  */
-export class HttpFunction implements mod.Function {
-    /**
-     * Function name.
-     */
-    public readonly name: string;
-
-    /**
-     * An array of function binding definitions.
-     */
-    public readonly bindings: pulumi.Input<HttpBindingDefinition[]>;
-
-    /**
-     * Function callback.
-     */
-    public readonly callback: mod.CallbackArgs<mod.Context<HttpResponse>, HttpRequest, HttpResponse>;
-
+export class HttpFunction extends mod.FunctionBase<mod.Context<HttpResponse>, HttpRequest, HttpResponse> {
     constructor(name: string, args: HttpFunctionArgs) {
-        this.name = name;
-        this.bindings = [{
+        super(name, <HttpBindingDefinition>{
             authLevel: "anonymous",
             type: "httpTrigger",
             direction: "in",
             name: "req",
             route: args.route,
             methods: args.methods,
-        }, {
+        }, [{
             type: "http",
             direction: "out",
             name: "$return",
-        }];
-        this.callback = args;
+        }], args);
     }
 }

--- a/sdk/nodejs/appservice/zMixins_timer.ts
+++ b/sdk/nodejs/appservice/zMixins_timer.ts
@@ -240,12 +240,12 @@ export class TimerFunction extends mod.FunctionBase<TimerContext, TimerInfo, voi
     constructor(name: string, args: TimerFunctionArgs) {
         const schedule = pulumi.output(args.schedule).apply(s => typeof s === "string" ? s : cronExpression(s));
 
-        super(name, <TimerBindingDefinition>{
+        super(name, [<TimerBindingDefinition>{
             type: "timerTrigger",
             direction: "in",
             name: "timer",
             runOnStartup: args.runOnStartup,
             schedule,
-        }, [], args);
+        }], args);
     }
 }

--- a/sdk/nodejs/appservice/zMixins_timer.ts
+++ b/sdk/nodejs/appservice/zMixins_timer.ts
@@ -236,33 +236,16 @@ export class TimerSubscription extends mod.EventSubscription<TimerContext, Timer
 /**
  * Azure Function triggered on a CRON schedule.
  */
-export class TimerFunction implements mod.Function {
-        /**
-     * Function name.
-     */
-    public readonly name: string;
-
-    /**
-     * An array of function binding definitions.
-     */
-    public readonly bindings: pulumi.Input<TimerBindingDefinition[]>;
-
-    /**
-     * Serialized function callback.
-     */
-    public readonly callback: mod.CallbackArgs<TimerContext, TimerInfo, void>;
-
+export class TimerFunction extends mod.FunctionBase<TimerContext, TimerInfo, void> {
     constructor(name: string, args: TimerFunctionArgs) {
         const schedule = pulumi.output(args.schedule).apply(s => typeof s === "string" ? s : cronExpression(s));
 
-        this.name = name;
-        this.bindings = [{
+        super(name, <TimerBindingDefinition>{
             type: "timerTrigger",
             direction: "in",
             name: "timer",
             runOnStartup: args.runOnStartup,
             schedule,
-        }];
-        this.callback = args;
+        }, [], args);
     }
 }

--- a/sdk/nodejs/appservice/zMixins_timer.ts
+++ b/sdk/nodejs/appservice/zMixins_timer.ts
@@ -209,7 +209,6 @@ export class TimerSubscription extends mod.EventSubscription<TimerContext, Timer
                 args: TimerSubscriptionArgs,
                 opts: pulumi.CustomResourceOptions = {}) {
         super("azure:appservice:TimerSubscription", name, new TimerFunction(name, args), args, opts);
-
         this.registerOutputs();
     }
 }

--- a/sdk/nodejs/appservice/zMixins_timer.ts
+++ b/sdk/nodejs/appservice/zMixins_timer.ts
@@ -236,7 +236,7 @@ export class TimerSubscription extends mod.EventSubscription<TimerContext, Timer
 /**
  * Azure Function triggered on a CRON schedule.
  */
-export class TimerFunction extends mod.FunctionBase<TimerContext, TimerInfo, void> {
+export class TimerFunction extends mod.Function<TimerContext, TimerInfo, void> {
     constructor(name: string, args: TimerFunctionArgs) {
         const schedule = pulumi.output(args.schedule).apply(s => typeof s === "string" ? s : cronExpression(s));
 

--- a/sdk/nodejs/cosmosdb/zMixins.ts
+++ b/sdk/nodejs/cosmosdb/zMixins.ts
@@ -44,13 +44,13 @@ interface CosmosBindingDefinition extends appservice.BindingDefinition {
     collectionName: pulumi.Input<string>;
 
     /**
-     * When set, it adds a prefix to the leases created in the Lease collection for this Function, effectively allowing 
+     * When set, it adds a prefix to the leases created in the Lease collection for this Function, effectively allowing
      * two separate Azure Functions to share the same Lease collection by using different prefixes.
      */
     leaseCollectionPrefix: pulumi.Input<string>;
 
     /**
-     * When set to true, the leases collection is automatically created when it doesn't already exist. 
+     * When set to true, the leases collection is automatically created when it doesn't already exist.
      * The default value is false.
      */
     createLeaseCollectionIfNotExists: boolean;
@@ -66,8 +66,8 @@ interface CosmosBindingDefinition extends appservice.BindingDefinition {
     maxItemsPerInvocation?: pulumi.Input<number>;
 
     /**
-     * When set, it tells the Trigger to start reading changes from the beginning of the history of the collection instead of the current time. 
-     * This only works the first time the Trigger starts, as in subsequent runs, the checkpoints are already stored. Setting this to true when 
+     * When set, it tells the Trigger to start reading changes from the beginning of the history of the collection instead of the current time.
+     * This only works the first time the Trigger starts, as in subsequent runs, the checkpoints are already stored. Setting this to true when
      * there are leases already created has no effect.
      */
     startFromBeginning?: pulumi.Input<boolean>;
@@ -121,8 +121,8 @@ export interface CosmosChangeFeedSubscriptionArgs extends appservice.CallbackFun
     maxItemsPerInvocation?: pulumi.Input<number>;
 
     /**
-     * When set, it tells the Trigger to start reading changes from the beginning of the history of the collection instead of the current time. 
-     * This only works the first time the Trigger starts, as in subsequent runs, the checkpoints are already stored. Setting this to true when 
+     * When set, it tells the Trigger to start reading changes from the beginning of the history of the collection instead of the current time.
+     * This only works the first time the Trigger starts, as in subsequent runs, the checkpoints are already stored. Setting this to true when
      * there are leases already created has no effect.
      */
     startFromBeginning?: pulumi.Input<boolean>;
@@ -165,7 +165,7 @@ export class CosmosChangeFeedSubscription extends appservice.EventSubscription<C
             collectionName: args.collectionName,
             maxItemsPerInvocation: args.maxItemsPerInvocation,
             startFromBeginning: args.startFromBeginning,
-            
+
             // We take an opiniated approach here: use the default "leases" collection as
             // a shared lease collection for all Cosmos DB triggered functions. With multiple
             // functions, this is both the simplest and the cheapest solution. The collection

--- a/sdk/nodejs/eventhub/zMixins.ts
+++ b/sdk/nodejs/eventhub/zMixins.ts
@@ -87,14 +87,14 @@ export interface TopicContext extends appservice.Context<void> {
 export interface ServiceBusHostExtensions extends appservice.HostSettings {
     /** The default PrefetchCount that will be used by the underlying MessageReceiver. */
     prefetchCount?: number,
-    
+
     messageHandlerOptions?: {
         /** Whether the trigger should immediately mark as complete (autocomplete) or wait for processing to call complete. */
         autoComplete?: boolean,
 
-        /** The maximum number of concurrent calls to the callback that the message pump should initiate. 
-         * By default, the Functions runtime processes multiple messages concurrently. To direct the runtime to process only 
-         * a single queue or topic message at a time, set maxConcurrentCalls to 1. 
+        /** The maximum number of concurrent calls to the callback that the message pump should initiate.
+         * By default, the Functions runtime processes multiple messages concurrently. To direct the runtime to process only
+         * a single queue or topic message at a time, set maxConcurrentCalls to 1.
          */
         maxConcurrentCalls?: number,
 
@@ -105,7 +105,7 @@ export interface ServiceBusHostExtensions extends appservice.HostSettings {
 export interface TopicHostSettings extends appservice.HostSettings {
     extensions?: {
         serviceBus: ServiceBusHostExtensions,
-    }    
+    }
 }
 
 /**
@@ -131,9 +131,9 @@ export interface TopicEventSubscriptionArgs extends appservice.CallbackFunctionA
      */
     maxDeliveryCount?: pulumi.Input<number>;
 
-    /** 
-     * Host settings specific to the Service Bus Topic/Subscription plugin. These values can be provided here, or defaults will 
-     * be used in their place. 
+    /**
+     * Host settings specific to the Service Bus Topic/Subscription plugin. These values can be provided here, or defaults will
+     * be used in their place.
      */
     hostSettings?: TopicHostSettings;
 };
@@ -238,7 +238,7 @@ export interface EventHubBindingDefinition extends appservice.BindingDefinition 
     eventHubName: pulumi.Input<string>;
 
     /**
-     * An optional property that sets the consumer group used to subscribe to events in the hub. 
+     * An optional property that sets the consumer group used to subscribe to events in the hub.
      * If not present, a new Consumer Group resource will be created.
      */
     consumerGroup?: pulumi.Input<string>;
@@ -266,22 +266,22 @@ export interface EventHubContext extends appservice.Context<void> {
     };
     bindings: { eventHub: string };
     bindingData: {
-        partitionContext: { 
+        partitionContext: {
             consumerGroupName: string;
             eventHubPath: string;
             partitionId: string;
             owner: string;
-            runtimeInformation: { 
+            runtimeInformation: {
                 partitionId: string;
                 lastSequenceNumber: number;
                 lastEnqueuedTimeUtc: string;
                 retrievalTime: string;
             };
-        }, 
+        },
         partitionKey: string;
-        offset: number, 
+        offset: number,
         sequenceNumber: number;
-        enqueuedTimeUtc: string; 
+        enqueuedTimeUtc: string;
         properties: Record<string, any>;
         systemProperties: Record<string, any>;
         sys: {

--- a/sdk/nodejs/iot/zMixins.ts
+++ b/sdk/nodejs/iot/zMixins.ts
@@ -93,13 +93,13 @@ export class IoTHubEventSubscription extends appservice.EventSubscription<EventH
 
         // Place the mapping from the well known key name to the Event Hubs account connection string in
         // the 'app settings' object.
-        // The connection string is built from the IoT Hub "event hub compatible endpoint" 
+        // The connection string is built from the IoT Hub "event hub compatible endpoint"
         // and the iothubowner access policy key
         // see https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-read-builtin
         const appSettings = pulumi.all([args.appSettings, iotHub.eventHubEventsEndpoint, iotHub.sharedAccessPolicies]).apply(
-            ([appSettings, eventHubEventsEndpoint, sharedAccessPolicies]) => ({ 
-                ...appSettings, 
-                [bindingConnectionKey]: `Endpoint=${eventHubEventsEndpoint};SharedAccessKeyName=iothubowner;SharedAccessKey=${sharedAccessPolicies.find(p => p.keyName === "iothubowner")!.primaryKey}` 
+            ([appSettings, eventHubEventsEndpoint, sharedAccessPolicies]) => ({
+                ...appSettings,
+                [bindingConnectionKey]: `Endpoint=${eventHubEventsEndpoint};SharedAccessKeyName=iothubowner;SharedAccessKey=${sharedAccessPolicies.find(p => p.keyName === "iothubowner")!.primaryKey}`
             }));
 
         super("azure:eventhub:IoTHubEventSubscription", name, bindings, {

--- a/sdk/nodejs/storage/zMixins.ts
+++ b/sdk/nodejs/storage/zMixins.ts
@@ -275,7 +275,7 @@ interface QueueBindingDefinition extends appservice.BindingDefinition {
     /**
      * The storage connection string for the storage account containing the queue.
      */
-    connection: string;
+    connection: pulumi.Input<string>;
 }
 
 /**
@@ -336,6 +336,13 @@ export interface QueueHostSettings extends appservice.HostSettings {
  */
 export type QueueCallback = appservice.Callback<QueueContext, Buffer, void>;
 
+export interface QueueFunctionArgs extends appservice.CallbackArgs<QueueContext, Buffer, void> {
+    /**
+     * Defines the queue to trigger the function.
+     */
+    queue: Queue;
+};
+
 export type QueueEventSubscriptionArgs = util.Overwrite<appservice.CallbackFunctionAppArgs<QueueContext, Buffer, void>, {
     /**
      * The resource group in which to create the event subscription.  If not supplied, the
@@ -384,40 +391,59 @@ export class QueueEventSubscription extends appservice.EventSubscription<QueueCo
 
         const { resourceGroupName, location } = appservice.getResourceGroupNameAndLocation(args, queue.resourceGroupName);
 
-        // The queue binding does not store the storage connection string directly.  Instead, the
-        // connection string is put into the app settings (under whatever key we want). Then, the
-        // .connection property of the binding contains the *name* of that app setting key.
-        const bindingConnectionKey = "BindingConnectionAppSettingsKey";
+        super("azure:storage:QueueEventSubscription", name, new QueueFunction(name, { ...args, queue }), {
+            ...args,
+            resourceGroupName,
+            location,
+        }, opts);
 
-        const bindings: QueueBindingDefinition[] = [{
+        this.registerOutputs();
+    }
+}
+
+/**
+ * Azure Function triggered by a Storage Queue.
+ */
+export class QueueFunction implements appservice.Function {
+    /**
+     * Function name.
+     */
+    public readonly name: string;
+
+    /**
+     * An array of function binding definitions.
+     */
+    public readonly bindings: pulumi.Input<QueueBindingDefinition[]>;
+
+    /**
+     * Serialized function callback.
+     */
+    public readonly callback: appservice.CallbackArgs<appservice.Context<any>, Buffer, void>;
+
+    /**
+     * Application settings required by the function.
+     */
+    public readonly appSettings: pulumi.Input<{ [key: string]: string }>;
+
+    constructor(name: string, args: QueueFunctionArgs) {
+        this.name = name;
+        this.callback = <appservice.CallbackArgs<appservice.Context<any>, Buffer, void>>args;
+
+        const bindingConnectionKey = pulumi.interpolate`${args.queue.storageAccountName}ConnectionStringKey`;
+        this.bindings = [{
             name: "queue",
             type: "queueTrigger",
             direction: "in",
             dataType: "binary",
-            queueName: queue.name,
+            queueName: args.queue.name,
             connection: bindingConnectionKey,
         }];
-
-        // Place the mapping from the well known key name to the storage account connection string in
-        // the 'app settings' object.
-        const appSettingsOutput = args.appSettings || pulumi.output({});
-
-        // Place the mapping from the well known key name to the storage account connection string in
-        // the 'app settings' object.
-        const account = pulumi.all([resourceGroupName, queue.storageAccountName])
-                                .apply(([resourceGroupName, storageAccountName]) =>
+    
+        const account = pulumi.all([args.queue.resourceGroupName, args.queue.storageAccountName])
+                            .apply(([resourceGroupName, storageAccountName]) =>
                                 storage.getAccount({ resourceGroupName, name: storageAccountName }));
-
-        const appSettings = pulumi.all([args.appSettings, account.primaryConnectionString]).apply(
-            ([appSettings, connectionString]) => ({ ...appSettings, [bindingConnectionKey]: connectionString }));
-
-        super("azure:storage:QueueEventSubscription", name, bindings, {
-            ...args,
-            resourceGroupName,
-            location,
-            appSettings,
-        }, opts);
-
-        this.registerOutputs();
+    
+        this.appSettings = pulumi.all([account.primaryConnectionString, bindingConnectionKey]).apply(
+            ([connectionString, key]) => ({ [key]: connectionString }));
     }
 }

--- a/sdk/nodejs/storage/zMixins.ts
+++ b/sdk/nodejs/storage/zMixins.ts
@@ -350,9 +350,9 @@ export interface QueueEventSubscriptionArgs extends appservice.CallbackFunctionA
      */
     resourceGroupName?: pulumi.Input<string>;
 
-    /** 
-     * Host settings specific to the Storage Queue plugin. These values can be provided here, or defaults will 
-     * be used in their place. 
+    /**
+     * Host settings specific to the Storage Queue plugin. These values can be provided here, or defaults will
+     * be used in their place.
      */
     hostSettings?: QueueHostSettings;
 };

--- a/sdk/nodejs/storage/zMixins.ts
+++ b/sdk/nodejs/storage/zMixins.ts
@@ -415,13 +415,13 @@ export class QueueFunction extends appservice.FunctionBase<QueueContext, Buffer,
         const appSettings = pulumi.all([account.primaryConnectionString, bindingConnectionKey]).apply(
             ([connectionString, key]) => ({ [key]: connectionString }));
 
-        super(name, <QueueBindingDefinition>{
+        super(name, [<QueueBindingDefinition>{
             name: "queue",
             type: "queueTrigger",
             direction: "in",
             dataType: "binary",
             queueName: args.queue.name,
             connection: bindingConnectionKey,
-        }, [], args, appSettings);
+        }], args, appSettings);
     }
 }

--- a/sdk/nodejs/storage/zMixins.ts
+++ b/sdk/nodejs/storage/zMixins.ts
@@ -404,7 +404,7 @@ export class QueueEventSubscription extends appservice.EventSubscription<QueueCo
 /**
  * Azure Function triggered by a Storage Queue.
  */
-export class QueueFunction extends appservice.FunctionBase<QueueContext, Buffer, void> {
+export class QueueFunction extends appservice.Function<QueueContext, Buffer, void> {
     constructor(name: string, args: QueueFunctionArgs) {
         const bindingConnectionKey = pulumi.interpolate`${args.queue.storageAccountName}ConnectionStringKey`;
 


### PR DESCRIPTION
Introduce `HttpFunction`, `TimerFunction`, and `QueueFunction` - to be hosted within `MultiCallbackFunctionApp`. More functions to follow in a separate PR once we agree on the details of these three.

Two important changes that I made that we might want to iterate on:

1. `CallbackFunctionApp` and `EventSubscription` can accept a `Function` as a direct constructor parameter:

``` ts
constructor(type: string, name: string,
       bindings: pulumi.Input<BindingDefinition[]> | Function,
```

`bindings` name looks a bit ugly here, but the change allows reusing `XyzFunction` classes to pass everything needed down the callback app without duplication:

``` ts
super("azure:appservice:TimerSubscription", name, new TimerFunction(name, args), {
```

2. Added a dumb `FunctionBase` class which implements `Function` interface. Or should we design our Functions as factory functions instead of classes?
