### PR TITLE
Add functions to list keys of Function Apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-___NULL___
-
+* Introduce `listHostKeys` and `listFunctionKeys` mix-in functions to retrieve Azure Functions management keys
 
 ---
 

--- a/resources.go
+++ b/resources.go
@@ -1044,6 +1044,11 @@ func Provider() tfbridge.ProviderInfo {
 							"zMixins_timer.ts",
 						},
 					},
+					"core": {
+						DestFiles: []string{
+							"zMixins.ts",
+						},
+					},
 					"cosmosdb": {
 						DestFiles: []string{
 							"zMixins.ts",

--- a/resources.go
+++ b/resources.go
@@ -1028,6 +1028,8 @@ func Provider() tfbridge.ProviderInfo {
 			Dependencies: map[string]string{
 				"@pulumi/pulumi":                "^0.17.12",
 				"@azure/functions":              "^1.0.3",
+				"@azure/ms-rest-azure-js":       "^1.3.8",
+				"@azure/ms-rest-nodeauth":       "^2.0.2",
 				"azure-functions-ts-essentials": "^1.3.2",
 			},
 			Overlay: &tfbridge.OverlayInfo{

--- a/sdk/nodejs/appservice/zMixins.ts
+++ b/sdk/nodejs/appservice/zMixins.ts
@@ -355,8 +355,8 @@ async function produceDeploymentArchiveAsync(args: MultiCallbackFunctionAppArgs)
 
         const body = await serializeFunctionCallback(func.callback);
 
-        map[`${func.name}/index.js`] = new pulumi.asset.StringAsset(`module.exports = require("./handler").handler`),
-            map[`${func.name}/handler.js`] = new pulumi.asset.StringAsset(body.text);
+        map[`${func.name}/index.js`] = new pulumi.asset.StringAsset(`module.exports = require("./handler").handler`);
+        map[`${func.name}/handler.js`] = new pulumi.asset.StringAsset(body.text);
     }
 
     return new pulumi.asset.AssetArchive(map);
@@ -436,10 +436,9 @@ export interface ArchiveFunctionAppArgs extends FunctionAppArgsBase {
     archive: pulumi.Input<pulumi.asset.Archive>;
 };
 
-function createFunctionAppParts(
-    name: string,
-    args: ArchiveFunctionAppArgs,
-    opts: pulumi.CustomResourceOptions = {}) {
+function createFunctionAppParts(name: string,
+                                args: ArchiveFunctionAppArgs,
+                                opts: pulumi.CustomResourceOptions = {}) {
 
     if (!args.archive) {
         throw new Error("Deployment [archive] must be provided.");
@@ -541,7 +540,7 @@ export class CallbackFunctionApp<C extends Context<R>, E, R extends Result> exte
     public readonly endpoint: pulumi.Output<string>;
 
     constructor(name: string, bindingsOrFunc: pulumi.Input<BindingDefinition[]> | Function<C, E, R>,
-        args: CallbackFunctionAppArgs<C, E, R>, opts: pulumi.CustomResourceOptions = {}) {
+                args: CallbackFunctionAppArgs<C, E, R>, opts: pulumi.CustomResourceOptions = {}) {
 
         const functions = bindingsOrFunc instanceof Function ? [bindingsOrFunc] : [<Function<C, E, R>>{ name, bindings: bindingsOrFunc, callback: args }];
         const parts = createFunctionAppParts(name, {
@@ -596,9 +595,9 @@ export abstract class PackagedFunctionApp extends pulumi.ComponentResource {
     public readonly endpoint: pulumi.Output<string>;
 
     constructor(type: string,
-        name: string,
-        args: ArchiveFunctionAppArgs,
-        opts: pulumi.ComponentResourceOptions = {}) {
+                name: string,
+                args: ArchiveFunctionAppArgs,
+                opts: pulumi.ComponentResourceOptions = {}) {
         super(type, name, undefined, opts);
 
         const parentOpts = { parent: this };
@@ -636,8 +635,8 @@ export class ArchiveFunctionApp extends PackagedFunctionApp {
  */
 export class MultiCallbackFunctionApp extends PackagedFunctionApp {
     constructor(name: string,
-        args: MultiCallbackFunctionAppArgs,
-        opts: pulumi.ComponentResourceOptions = {}) {
+                args: MultiCallbackFunctionAppArgs,
+                opts: pulumi.ComponentResourceOptions = {}) {
 
         if (args.functions.length == 0) {
             throw new Error("At least one function must be provided.");
@@ -668,9 +667,9 @@ export abstract class EventSubscription<C extends Context<R>, E, R extends Resul
     public readonly functionApp: CallbackFunctionApp<C, E, R>;
 
     constructor(type: string, name: string,
-        bindingsOrFunc: pulumi.Input<BindingDefinition[]> | Function<C, E, R>,
-        args: CallbackFunctionAppArgs<C, E, R>,
-        opts: pulumi.ComponentResourceOptions = {}) {
+                bindingsOrFunc: pulumi.Input<BindingDefinition[]> | Function<C, E, R>,
+                args: CallbackFunctionAppArgs<C, E, R>,
+                opts: pulumi.ComponentResourceOptions = {}) {
         super(type, name, undefined, opts);
 
         this.functionApp = new CallbackFunctionApp(name, bindingsOrFunc, args, { parent: this });
@@ -698,7 +697,7 @@ interface BaseSubscriptionArgs {
 
 /** @internal */
 export function getResourceGroupNameAndLocation(
-    args: BaseSubscriptionArgs, fallbackResourceGroupName: pulumi.Output<string> | undefined) {
+        args: BaseSubscriptionArgs, fallbackResourceGroupName: pulumi.Output<string> | undefined) {
 
     if (args.resourceGroup) {
         return { resourceGroupName: args.resourceGroup.name, location: args.resourceGroup.location };

--- a/sdk/nodejs/appservice/zMixins.ts
+++ b/sdk/nodejs/appservice/zMixins.ts
@@ -767,10 +767,10 @@ FunctionApp.prototype.getHostKeys = function(this: FunctionApp) {
 };
 
 FunctionApp.prototype.getFunctionKeys = function(this: FunctionApp, functionName) {
-    return pulumi.all([this.id, functionName]).apply(async ([id, name]) => {
+    return pulumi.all([this.id, functionName]).apply(async ([id, functionName]) => {
         const credentials = await core.getServiceClientCredentials();
         const client = new AzureServiceClient(credentials);
-        const url = `https://management.azure.com${id}/functions/${name}/listkeys?api-version=2018-02-01`;
+        const url = `https://management.azure.com${id}/functions/${functionName}/listkeys?api-version=2018-02-01`;
 
         const response = await client.sendRequest({ method: "POST", url });
         if (response.status >= 400) {

--- a/sdk/nodejs/core/index.ts
+++ b/sdk/nodejs/core/index.ts
@@ -9,3 +9,4 @@ export * from "./getSubscriptions";
 export * from "./getUserAssignedIdentity";
 export * from "./resourceGroup";
 export * from "./templateDeployment";
+export * from "./zMixins";

--- a/sdk/nodejs/core/zMixins.ts
+++ b/sdk/nodejs/core/zMixins.ts
@@ -1,0 +1,37 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as msnodeauth from "@azure/ms-rest-nodeauth";
+import { ServiceClientCredentials } from "@azure/ms-rest-js";
+import * as config from "../config";
+
+/**
+ * Obtain credentials to query Azure Management API. Depending on the environment configuration, this
+ * are either based on MSI, a service principal, or Azure CLI user credentials.
+ */
+export async function getServiceClientCredentials(): Promise<ServiceClientCredentials> {
+    let credentials: ServiceClientCredentials;
+
+    if (config.useMsi) {
+        credentials = await msnodeauth.loginWithAppServiceMSI({ msiEndpoint: config.msiEndpoint });
+    } else if (config.clientId && config.clientSecret && config.tenantId) {
+        credentials = await msnodeauth.loginWithServicePrincipalSecret(config.clientId, config.clientSecret, config.tenantId);
+    } else {
+        // `create()` will throw an error if the Az CLI is not installed or `az login` has never been run.
+        const cliCredentials = await msnodeauth.AzureCliCredentials.create();
+        credentials = cliCredentials;
+    }
+
+    return credentials;
+}

--- a/sdk/nodejs/core/zMixins.ts
+++ b/sdk/nodejs/core/zMixins.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as msnodeauth from "@azure/ms-rest-nodeauth";
 import { ServiceClientCredentials } from "@azure/ms-rest-js";
+import * as msnodeauth from "@azure/ms-rest-nodeauth";
 import * as config from "../config";
 
 /**
@@ -26,7 +26,8 @@ export async function getServiceClientCredentials(): Promise<ServiceClientCreden
     if (config.useMsi) {
         credentials = await msnodeauth.loginWithAppServiceMSI({ msiEndpoint: config.msiEndpoint });
     } else if (config.clientId && config.clientSecret && config.tenantId) {
-        credentials = await msnodeauth.loginWithServicePrincipalSecret(config.clientId, config.clientSecret, config.tenantId);
+        credentials = await msnodeauth.loginWithServicePrincipalSecret(
+            config.clientId, config.clientSecret, config.tenantId);
     } else {
         // `create()` will throw an error if the Az CLI is not installed or `az login` has never been run.
         credentials = await msnodeauth.AzureCliCredentials.create();

--- a/sdk/nodejs/core/zMixins.ts
+++ b/sdk/nodejs/core/zMixins.ts
@@ -29,8 +29,7 @@ export async function getServiceClientCredentials(): Promise<ServiceClientCreden
         credentials = await msnodeauth.loginWithServicePrincipalSecret(config.clientId, config.clientSecret, config.tenantId);
     } else {
         // `create()` will throw an error if the Az CLI is not installed or `az login` has never been run.
-        const cliCredentials = await msnodeauth.AzureCliCredentials.create();
-        credentials = cliCredentials;
+        credentials = await msnodeauth.AzureCliCredentials.create();
     }
 
     return credentials;

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -14,6 +14,8 @@
     },
     "dependencies": {
         "@azure/functions": "^1.0.3",
+        "@azure/ms-rest-azure-js": "^1.3.8",
+        "@azure/ms-rest-nodeauth": "^2.0.2",
         "@pulumi/pulumi": "^0.17.12",
         "azure-functions-ts-essentials": "^1.3.2"
     },

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -132,6 +132,7 @@
         "core/index.ts",
         "core/resourceGroup.ts",
         "core/templateDeployment.ts",
+        "core/zMixins.ts",
         "cosmosdb/account.ts",
         "cosmosdb/cassandraKeyspace.ts",
         "cosmosdb/getAccount.ts",


### PR DESCRIPTION
Adds mixin functions to wrap ARM API calls to List Keys of Function Apps, as described in [this issue](https://github.com/Azure/azure-functions-host/issues/3994).

Required for #295 or in case we want to support non-anonymous HTTP callback functions.

A function `getServiceClientCredentials` got introduced in `core` package. It might be useful for any REST interaction with the Azure Management API.

I enabled "format on save" in my VS Code, so some old lines got re-formated. Let me know if that's too annoying.