### PR TITLE
Support input and output bindings for all trigger types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 * BREAKING: Default data type of a Storage Queue-triggered Callback Function is changed from 'binary' to 'string'.
   This means that the type of second argument of a callback changes from 'Buffer' to 'string' or 'object' depending on the payload.
   To restore the past behavior, pass `dataType: "binary"` to the arguments of `QueueFunction` class or `queue.onEvent` function.
-* Support Input and Output bindings for callback-based Azure Functions (HTTP and Storage Queue/Blob/Table only)
+* Support Input and Output bindings for callback-based Azure Functions (all triggers, but inputs and outputs to/from Queue/Blob/Table only)
 * Introduce `listHostKeys` and `listFunctionKeys` mix-in functions to retrieve Azure Functions management keys
 
 ---

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -43,6 +43,8 @@ func TestExamples(t *testing.T) {
 		base.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "http-multi")}),
 		base.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "iot")}),
 		base.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "queue")}),
+		base.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "table")}),
+		base.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "timer")}),
 		base.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "topic")}),
 		base.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "webserver")}),
 		base.With(integration.ProgramTestOptions{

--- a/sdk/nodejs/appservice/zMixins_timer.ts
+++ b/sdk/nodejs/appservice/zMixins_timer.ts
@@ -169,7 +169,7 @@ export interface TimerInfo {
 /**
  * Data that will be passed along in the context object to the timer callback.
  */
-export interface TimerContext extends mod.Context<void> {
+export interface TimerContext extends mod.Context<mod.FunctionDefaultResponse> {
     invocationId: string;
     executionContext: {
         invocationId: string;
@@ -187,11 +187,9 @@ export interface TimerContext extends mod.Context<void> {
     };
 }
 
-export interface TimerFunctionArgs extends mod.CallbackArgs<TimerContext, TimerInfo, void> {
+export interface TimerFunctionArgs extends mod.CallbackFunctionArgs<TimerContext, TimerInfo, mod.FunctionDefaultResponse> {
     /**
      * A schedule or a CRON expression for the timer schedule, e.g. '0 * * * * *'.
-    /**
-     * A CRON expression for the timer schedule, e.g. '0 * * * * *'.
      */
     schedule: pulumi.Input<string | ScheduleArgs>;
 
@@ -201,10 +199,10 @@ export interface TimerFunctionArgs extends mod.CallbackArgs<TimerContext, TimerI
     runOnStartup?: pulumi.Input<boolean>;
 };
 
-export interface TimerSubscriptionArgs extends TimerFunctionArgs, mod.CallbackFunctionAppArgs<TimerContext, TimerInfo, void> {
+export interface TimerSubscriptionArgs extends TimerFunctionArgs, mod.CallbackFunctionAppArgs<TimerContext, TimerInfo, mod.FunctionDefaultResponse> {
 }
 
-export class TimerSubscription extends mod.EventSubscription<TimerContext, TimerInfo, void> {
+export class TimerSubscription extends mod.EventSubscription<TimerContext, TimerInfo, mod.FunctionDefaultResponse> {
     constructor(name: string,
                 args: TimerSubscriptionArgs,
                 opts: pulumi.CustomResourceOptions = {}) {
@@ -216,18 +214,18 @@ export class TimerSubscription extends mod.EventSubscription<TimerContext, Timer
 /**
  * Azure Function triggered on a CRON schedule.
  */
-export class TimerFunction extends mod.Function<TimerContext, TimerInfo, void> {
+export class TimerFunction extends mod.Function<TimerContext, TimerInfo, mod.FunctionDefaultResponse> {
     constructor(name: string, args: TimerFunctionArgs) {
         const schedule = pulumi.output(args.schedule).apply(s => typeof s === "string" ? s : cronExpression(s));
 
-        const bindings = [<TimerBindingDefinition>{
+        const trigger = {
             type: "timerTrigger",
             direction: "in",
             name: "timer",
             runOnStartup: args.runOnStartup,
             schedule,
-        }];
+        } as TimerBindingDefinition;
 
-        super(name, bindings, args);
+        super(name, trigger, args);
     }
 }

--- a/sdk/nodejs/storage/zMixins.ts
+++ b/sdk/nodejs/storage/zMixins.ts
@@ -126,7 +126,7 @@ export interface BlobInputBindingDefinition extends BlobBindingDefinition {
 /**
  * Data that will be passed along in the context object to the BlobCallback.
  */
-export interface BlobContext extends appservice.Context<void> {
+export interface BlobContext extends appservice.Context<appservice.FunctionDefaultResponse> {
     executionContext: {
         invocationId: string;
         functionName: string;
@@ -167,10 +167,9 @@ export interface BlobContext extends appservice.Context<void> {
 /**
  * Signature of the callback that can receive blob notifications.
  */
-export type BlobCallback = appservice.Callback<BlobContext, Buffer, void>;
+export type BlobCallback = appservice.Callback<BlobContext, Buffer, appservice.FunctionDefaultResponse>;
 
-export interface BlobFunctionArgs extends appservice.CallbackArgs<BlobContext, Buffer, void>,
-                                          appservice.InputOutputsArgs {
+export interface BlobFunctionArgs extends appservice.CallbackFunctionArgs<BlobContext, Buffer, appservice.FunctionDefaultResponse> {
     /**
      * Storage Blob Container to subscribe for events of.
      */
@@ -185,8 +184,7 @@ export interface BlobFunctionArgs extends appservice.CallbackArgs<BlobContext, B
     filterSuffix?: pulumi.Input<string>;
 };
 
-export interface BlobEventSubscriptionArgs extends appservice.CallbackFunctionAppArgs<BlobContext, Buffer, void>,
-                                                   appservice.InputOutputsArgs {
+export interface BlobEventSubscriptionArgs extends appservice.CallbackFunctionAppArgs<BlobContext, Buffer, appservice.FunctionDefaultResponse> {
     /**
      * The name of the resource group in which to create the event subscription. [resourceGroup] takes precedence
      * over [resourceGroupName]. If none of the two is supplied, the resource group of the Storage Account will be used.
@@ -231,7 +229,7 @@ Container.prototype.input = function(this: Container, name, args) {
     return new BlobInputBinding(name, this, args);
 };
 
-export class BlobEventSubscription extends appservice.EventSubscription<BlobContext, Buffer, void> {
+export class BlobEventSubscription extends appservice.EventSubscription<BlobContext, Buffer, appservice.FunctionDefaultResponse> {
     constructor(
         name: string, container: storage.Container,
         args: BlobEventSubscriptionArgs, opts: pulumi.ComponentResourceOptions = {}) {
@@ -251,7 +249,7 @@ export class BlobEventSubscription extends appservice.EventSubscription<BlobCont
 /**
  * Azure Function triggered by changes in a Storage Blob Container.
  */
-export class BlobFunction extends appservice.Function<BlobContext, Buffer, void> {
+export class BlobFunction extends appservice.Function<BlobContext, Buffer, appservice.FunctionDefaultResponse> {
     constructor(name: string, args: BlobFunctionArgs) {
         const { connectionKey, settings } = resolveAccount(args.container);
 
@@ -259,7 +257,7 @@ export class BlobFunction extends appservice.Function<BlobContext, Buffer, void>
         const suffix = args.filterSuffix || "";
         const path = pulumi.interpolate`${args.container.name}/${prefix}{blobName}${suffix}`;
 
-        const binding: BlobTriggerDefinition = {
+        const trigger: BlobTriggerDefinition = {
             path,
             name: "blob",
             type: "blobTrigger",
@@ -268,10 +266,7 @@ export class BlobFunction extends appservice.Function<BlobContext, Buffer, void>
             connection: connectionKey,
         };
 
-        const { bindings, appSettings } =
-            appservice.combineBindingSettings({binding, settings}, args.inputs, args.outputs);
-
-        super(name, bindings, args, appSettings);
+        super(name, trigger, args, settings);
     }
 }
 
@@ -362,7 +357,7 @@ interface QueueOutputBindingDefinition extends QueueBindingDefinition {
 /**
  * Data that will be passed along in the context object to the QueueContext.
  */
-export interface QueueContext extends appservice.Context<void> {
+export interface QueueContext extends appservice.Context<appservice.FunctionDefaultResponse> {
     executionContext: {
         invocationId: string;
         functionName: string;
@@ -421,8 +416,7 @@ export interface QueueHostSettings extends appservice.HostSettings {
  */
 export type QueueCallback = appservice.Callback<QueueContext, any, appservice.FunctionDefaultResponse>;
 
-export interface QueueFunctionArgs extends appservice.CallbackArgs<QueueContext, any, appservice.FunctionDefaultResponse>,
-                                           appservice.InputOutputsArgs {
+export interface QueueFunctionArgs extends appservice.CallbackFunctionArgs<QueueContext, any, appservice.FunctionDefaultResponse> {
     /**
      * Defines the queue to trigger the function.
      */
@@ -436,8 +430,7 @@ export interface QueueFunctionArgs extends appservice.CallbackArgs<QueueContext,
     dataType?: "binary" | "string";
 }
 
-export interface QueueEventSubscriptionArgs extends appservice.CallbackFunctionAppArgs<QueueContext, any, appservice.FunctionDefaultResponse>,
-                                                    appservice.InputOutputsArgs {
+export interface QueueEventSubscriptionArgs extends appservice.CallbackFunctionAppArgs<QueueContext, any, appservice.FunctionDefaultResponse> {
     /**
      * The resource group in which to create the event subscription.  If not supplied, the
      * Queue's resource group will be used.
@@ -532,7 +525,7 @@ export class QueueFunction extends appservice.Function<QueueContext, any, appser
     constructor(name: string, args: QueueFunctionArgs) {
         const { connectionKey, settings } = resolveAccount(args.queue);
 
-        const binding: QueueTriggerBindingDefinition = {
+        const trigger: QueueTriggerBindingDefinition = {
             name: "queue",
             type: "queueTrigger",
             direction: "in",
@@ -541,10 +534,7 @@ export class QueueFunction extends appservice.Function<QueueContext, any, appser
             connection: connectionKey,
         };
 
-        const { bindings, appSettings } =
-            appservice.combineBindingSettings({binding, settings}, args.inputs, args.outputs);
-
-        super(name, bindings, args, appSettings);
+        super(name, trigger, args, settings);
     }
 }
 


### PR DESCRIPTION
Input and output bindings are now supported by all trigger types of callback-based Azure Functions, including single-function subscriptions and multi-function apps.

Related wiring has been moved to the base types, so each concrete function type has minimal work to do.

Added two missing samples to the test suite.

Fixes #232 