### PR TITLE
Support Azure Cloud Shell without requiring any extra configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-___NULL___
-
+* Out-of-the-box Azure Cloud Shell support ([#74](https://github.com/pulumi/pulumi-azure/issues/74))
 ___
 
 ## 0.19.3 (2019-07-22)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	git.apache.org/thrift.git v0.12.0 // indirect
+	github.com/Azure/go-autorest v11.7.0+incompatible
 	github.com/chzyer/logex v1.1.11-0.20160617073814-96a4d311aa9b // indirect
 	github.com/coreos/bbolt v1.3.1-coreos.1 // indirect
 	github.com/djherbis/times v1.2.0 // indirect

--- a/resources.go
+++ b/resources.go
@@ -16,9 +16,11 @@ package azure
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"unicode"
 
+	"github.com/Azure/go-autorest/autorest/azure/cli"
 	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
@@ -122,6 +124,52 @@ func boolRef(b bool) *bool {
 	return &b
 }
 
+type cloudShellProfile struct {
+	useMSI         bool
+	msiEndpoint    string
+	subscriptionId string
+	tenantId       string
+}
+
+// Azure Cloud Shell is a special case in terms of config: it provides authentication via
+// an MSI endpoint, but it also has Azure CLI installed. Therefore, to make Pulumi CLI work
+// out of the box with no actions required from a user, we combine the MSI endpoint authentication
+// with retrieving the subscription information from the current profile. If both are found,
+// we switch the provider to the endpoint/subscriptoin by default.
+func detectCloudShell() cloudShellProfile {
+	negative := cloudShellProfile{
+		useMSI: false,
+	}
+
+	msiEndpoint := os.Getenv("MSI_ENDPOINT")
+	if msiEndpoint == "" {
+		return negative
+	}
+
+	profilePath, err := cli.ProfilePath()
+	if err != nil {
+		return negative
+	}
+
+	profile, err := cli.LoadProfile(profilePath)
+	if err != nil {
+		return negative
+	}
+
+	for _, subscription := range profile.Subscriptions {
+		if subscription.IsDefault {
+			return cloudShellProfile{
+				useMSI:         true,
+				msiEndpoint:    msiEndpoint,
+				subscriptionId: subscription.ID,
+				tenantId:       subscription.TenantID,
+			}
+		}
+	}
+
+	return negative
+}
+
 // Provider returns additional overlaid schema and metadata associated with the azure package.
 //
 // nolint: lll
@@ -132,6 +180,10 @@ func Provider() tfbridge.ProviderInfo {
 	)
 
 	p := azurerm.Provider().(*schema.Provider)
+
+	// Adjust the defaults if running in Azure Cloud Shell.
+	// Environment variables still take preference, e.g. USE_MSI=false disables the MSI endpoint.
+	cloudShell := detectCloudShell()
 
 	prov := tfbridge.ProviderInfo{
 		P:           p,
@@ -144,7 +196,7 @@ func Provider() tfbridge.ProviderInfo {
 		Config: map[string]*tfbridge.SchemaInfo{
 			"subscription_id": {
 				Default: &tfbridge.DefaultInfo{
-					Value:   "",
+					Value:   cloudShell.subscriptionId,
 					EnvVars: []string{"ARM_SUBSCRIPTION_ID"},
 				},
 			},
@@ -156,7 +208,7 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			"tenant_id": {
 				Default: &tfbridge.DefaultInfo{
-					Value:   "",
+					Value:   cloudShell.tenantId,
 					EnvVars: []string{"ARM_TENANT_ID"},
 				},
 			},
@@ -204,13 +256,13 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			"use_msi": {
 				Default: &tfbridge.DefaultInfo{
-					Value:   false,
+					Value:   cloudShell.useMSI,
 					EnvVars: []string{"ARM_USE_MSI"},
 				},
 			},
 			"msi_endpoint": {
 				Default: &tfbridge.DefaultInfo{
-					Value:   "",
+					Value:   cloudShell.msiEndpoint,
 					EnvVars: []string{"ARM_MSI_ENDPOINT"},
 				},
 			},

--- a/resources.go
+++ b/resources.go
@@ -127,8 +127,8 @@ func boolRef(b bool) *bool {
 type cloudShellProfile struct {
 	useMSI         bool
 	msiEndpoint    string
-	subscriptionId string
-	tenantId       string
+	subscriptionID string
+	tenantID       string
 }
 
 // Azure Cloud Shell is a special case in terms of config: it provides authentication via
@@ -161,8 +161,8 @@ func detectCloudShell() cloudShellProfile {
 			return cloudShellProfile{
 				useMSI:         true,
 				msiEndpoint:    msiEndpoint,
-				subscriptionId: subscription.ID,
-				tenantId:       subscription.TenantID,
+				subscriptionID: subscription.ID,
+				tenantID:       subscription.TenantID,
 			}
 		}
 	}
@@ -196,7 +196,7 @@ func Provider() tfbridge.ProviderInfo {
 		Config: map[string]*tfbridge.SchemaInfo{
 			"subscription_id": {
 				Default: &tfbridge.DefaultInfo{
-					Value:   cloudShell.subscriptionId,
+					Value:   cloudShell.subscriptionID,
 					EnvVars: []string{"ARM_SUBSCRIPTION_ID"},
 				},
 			},
@@ -208,7 +208,7 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			"tenant_id": {
 				Default: &tfbridge.DefaultInfo{
-					Value:   cloudShell.tenantId,
+					Value:   cloudShell.tenantID,
 					EnvVars: []string{"ARM_TENANT_ID"},
 				},
 			},


### PR DESCRIPTION
Fixes #74 

Checks if `MSI_ENDPOINT` environment variable is defined AND there are Azure CLI profiles with a default subscription available. If so, sets the TF provider in `use_msi=true` mode with proper values for MSI endpoint, subscription ID and tenant ID.

Tested by copying the compiled provider to Azure cloud shell's `.pulumi/plugins` and running a pulumi application without any configuration in the stack or extra env.

Output:

```
mikhail@Azure:~/p$ pulumi destroy
Previewing destroy (dev):

     Type                         Name           Plan
 -   pulumi:pulumi:Stack          p-dev          delete
 -   ├─ azure:storage:Account     storage        delete
 -   └─ azure:core:ResourceGroup  resourceGroup  delete

Resources:
    - 3 to delete

Do you want to perform this destroy? yes
Destroying (dev):

     Type                         Name           Status
 -   pulumi:pulumi:Stack          p-dev          deleted
 -   ├─ azure:storage:Account     storage        deleted
 -   └─ azure:core:ResourceGroup  resourceGroup  deleted

Resources:
    - 3 deleted

Duration: 1m15s
```

the old plugin version was failing with

```
pulumi up
Previewing update (dev):

     Type                         Name           Plan     Info
     pulumi:pulumi:Stack          p-dev
     └─ azure:core:ResourceGroup  resourceGroup           1 error

Diagnostics:
  azure:core:ResourceGroup (resourceGroup):
    error: Error building AzureRM Client: Error populating Client ID from the Azure CLI: No Authorization Tokens were found - please ensure the Azure CLI is installed and then log-in with `az login`.
```