### PR TITLE
Remove explicit location assignments from examples

### DIFF
--- a/examples/aci-multi/index.ts
+++ b/examples/aci-multi/index.ts
@@ -2,9 +2,7 @@
 
 import * as azure from "@pulumi/azure";
 
-const resourceGroup = new azure.core.ResourceGroup("resourcegroup", {
-    location: "West US",
-});
+const resourceGroup = new azure.core.ResourceGroup("resourcegroup");
 
 const containerGroup = new azure.containerservice.Group("containergroup", {
     resourceGroupName: resourceGroup.name,

--- a/examples/aci-volume-mount/index.ts
+++ b/examples/aci-volume-mount/index.ts
@@ -2,9 +2,7 @@
 
 import * as azure from "@pulumi/azure";
 
-const resourceGroup = new azure.core.ResourceGroup("resourcegroup", {
-    location: "West US",
-});
+const resourceGroup = new azure.core.ResourceGroup("resourcegroup");
 
 const storageAccount = new azure.storage.Account("storageaccount", {
     resourceGroupName: resourceGroup.name,

--- a/examples/aks/index.ts
+++ b/examples/aks/index.ts
@@ -8,9 +8,7 @@ const sshPublicKey = config.require("sshPublicKey");
 const clientId = config.require("clientId");
 const clientSecret = config.require("clientSecret");
 
-const resourceGroup = new azure.core.ResourceGroup("aks", {
-    location: "East US",
-});
+const resourceGroup = new azure.core.ResourceGroup("aks");
 
 const kubernetesService = new azure.containerservice.KubernetesCluster("kubernetes", {
     resourceGroupName: resourceGroup.name,

--- a/examples/blob/index.ts
+++ b/examples/blob/index.ts
@@ -2,9 +2,7 @@
 
 import * as azure from "@pulumi/azure";
 
-const resourceGroup = new azure.core.ResourceGroup("resourcegroup", {
-    location: "West US 2",
-});
+const resourceGroup = new azure.core.ResourceGroup("resourcegroup");
 
 // Create a storage account for our images
 const storageAccount = new azure.storage.Account("storage", {

--- a/examples/cosmosdb/index.ts
+++ b/examples/cosmosdb/index.ts
@@ -3,11 +3,7 @@
 import * as azure from "@pulumi/azure";
 import * as cosmosdb from "@pulumi/azure/cosmosdb";
 
-const location = "West US 2";
-
-const resourceGroup = new azure.core.ResourceGroup("test", {
-    location: location,
-});
+const resourceGroup = new azure.core.ResourceGroup("test");
 
 let db = new cosmosdb.Account("test", {
     resourceGroupName: resourceGroup.name,
@@ -17,7 +13,7 @@ let db = new cosmosdb.Account("test", {
         maxIntervalInSeconds: 5,
         maxStalenessPrefix: 100,
     },
-    geoLocations: [{ location, failoverPriority: 0 }],
+    geoLocations: [{ location: resourceGroup.location, failoverPriority: 0 }],
 });
 
 db.onChange("test", {

--- a/examples/eventgrid/index.ts
+++ b/examples/eventgrid/index.ts
@@ -2,9 +2,7 @@
 
 import * as azure from "@pulumi/azure";
 
-const resourceGroup = new azure.core.ResourceGroup("eveentgrid-rg", {
-    location: azure.Locations.WestUS2,
-});
+const resourceGroup = new azure.core.ResourceGroup("eveentgrid-rg");
 
 // Subscribe to events in resource group, e.g. when a new resource is created
 azure.eventhub.events.onResourceGroupEvent("OnResourceChange", {

--- a/examples/eventhub/index.ts
+++ b/examples/eventhub/index.ts
@@ -3,11 +3,7 @@
 import * as azure from "@pulumi/azure";
 import * as eventhub from "@pulumi/azure/eventhub";
 
-const location = "West US 2";
-
-const resourceGroup = new azure.core.ResourceGroup("test", {
-    location: location,
-});
+const resourceGroup = new azure.core.ResourceGroup("test");
 
 const namespace = new eventhub.EventHubNamespace("test", {
     resourceGroupName: resourceGroup.name,

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -3,6 +3,7 @@
 package examples
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -20,6 +20,11 @@ func TestExamples(t *testing.T) {
 	if environ == "" {
 		t.Skipf("Skipping test due to missing ARM_ENVIRONMENT variable")
 	}
+	azureLocation := os.Getenv("ARM_LOCATION")
+	if azureLocation == "" {
+		azureLocation = "westus"
+		fmt.Println("Defaulting ARM_LOCATION to 'westus'.  You can override using the ARM_LOCATION variable")
+	}
 	cwd, err := os.Getwd()
 	if !assert.NoError(t, err, "expected a valid working directory: %v", err) {
 		return
@@ -29,6 +34,7 @@ func TestExamples(t *testing.T) {
 	base := integration.ProgramTestOptions{
 		Config: map[string]string{
 			"azure:environment": environ,
+			"azure:location":    azureLocation,
 		},
 		Dependencies: []string{
 			"@pulumi/azure",

--- a/examples/http-external/index.ts
+++ b/examples/http-external/index.ts
@@ -1,7 +1,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as azure from "@pulumi/azure";
 
-const resourceGroup = new azure.core.ResourceGroup('example', { location: 'West US 2' });
+const resourceGroup = new azure.core.ResourceGroup('example');
 
 // Create a Function App implemented in PowerShell with source code from 'funcapp' folder
 const app = new azure.appservice.ArchiveFunctionApp("http-ps", {

--- a/examples/http-multi/index.ts
+++ b/examples/http-multi/index.ts
@@ -1,6 +1,6 @@
 import * as azure from "@pulumi/azure";
 
-const resourceGroup = new azure.core.ResourceGroup("example", { location: azure.Locations.WestUS2 });
+const resourceGroup = new azure.core.ResourceGroup("example");
 
 // Define 3 HTTP Functions which only differ by number and the hello message
 const http = [1, 2, 3].map(i =>

--- a/examples/http/index.ts
+++ b/examples/http/index.ts
@@ -1,6 +1,6 @@
 import * as azure from '@pulumi/azure';
 
-const resourceGroup = new azure.core.ResourceGroup('example', { location: 'West US 2' });
+const resourceGroup = new azure.core.ResourceGroup('example');
 
 const greeting = new azure.appservice.HttpEventSubscription('greeting', {
   resourceGroup,

--- a/examples/iot/index.ts
+++ b/examples/iot/index.ts
@@ -3,11 +3,7 @@
 import * as azure from "@pulumi/azure";
 import * as iot from "@pulumi/azure/iot";
 
-const location = "West US 2";
-
-const resourceGroup = new azure.core.ResourceGroup("test", {
-    location: location,
-});
+const resourceGroup = new azure.core.ResourceGroup("test");
 
 const iotHub = new iot.IoTHub("test", {
     resourceGroupName: resourceGroup.name,

--- a/examples/loadbalancer/index.ts
+++ b/examples/loadbalancer/index.ts
@@ -3,9 +3,7 @@
 import * as azure from "@pulumi/azure";
 import * as pulumi from "@pulumi/pulumi"
 
-const resourceGroup = new azure.core.ResourceGroup("resourcegroup", {
-    location: "West US",
-});
+const resourceGroup = new azure.core.ResourceGroup("resourcegroup");
 
 const storageaccount = new azure.storage.Account("storageaccount", {
     resourceGroupName: resourceGroup.name,

--- a/examples/multi-callback-all/index.ts
+++ b/examples/multi-callback-all/index.ts
@@ -1,6 +1,6 @@
 import * as azure from "@pulumi/azure";
 
-const resourceGroup = new azure.core.ResourceGroup("example", { location: azure.Locations.WestUS2 });
+const resourceGroup = new azure.core.ResourceGroup("example");
 
 // HTTP
 const httpFunc = new azure.appservice.HttpFunction("http", {

--- a/examples/queue/index.ts
+++ b/examples/queue/index.ts
@@ -2,9 +2,7 @@
 
 import * as azure from "@pulumi/azure";
 
-const resourceGroup = new azure.core.ResourceGroup("resourcegroup", {
-    location: "West US 2",
-});
+const resourceGroup = new azure.core.ResourceGroup("resourcegroup");
 
 // Create a storage account for our queues
 const storageAccount = new azure.storage.Account("storage", {

--- a/examples/table/index.ts
+++ b/examples/table/index.ts
@@ -2,9 +2,7 @@
 
 import * as azure from "@pulumi/azure";
 
-const resourceGroup = new azure.core.ResourceGroup("resourcegroup", {
-    location: azure.Locations.WestUS2,
-});
+const resourceGroup = new azure.core.ResourceGroup("resourcegroup");
 
 // Create a storage account for our queues
 const storageAccount = new azure.storage.Account("storage", {

--- a/examples/timer/index.ts
+++ b/examples/timer/index.ts
@@ -1,6 +1,6 @@
 import * as azure from '@pulumi/azure';
 
-const resourceGroup = new azure.core.ResourceGroup('example', { location: 'West US 2' });
+const resourceGroup = new azure.core.ResourceGroup('example');
 
 new azure.appservice.TimerSubscription('everyminute', {
     resourceGroup,

--- a/examples/topic/index.ts
+++ b/examples/topic/index.ts
@@ -3,11 +3,7 @@
 import * as azure from "@pulumi/azure";
 import * as eventhub from "@pulumi/azure/eventhub";
 
-const location = "West US 2";
-
-const resourceGroup = new azure.core.ResourceGroup("test", {
-    location: location,
-});
+const resourceGroup = new azure.core.ResourceGroup("test");
 
 const namespace = new eventhub.Namespace("test", {
     resourceGroupName: resourceGroup.name,

--- a/examples/webserver/index.ts
+++ b/examples/webserver/index.ts
@@ -4,9 +4,7 @@ import * as azure from "@pulumi/azure";
 
 const name = "webserver";
 
-let resourceGroup = new azure.core.ResourceGroup(name, {
-    location: azure.Locations.WestUS,
-});
+let resourceGroup = new azure.core.ResourceGroup(name);
 
 let network = new azure.network.VirtualNetwork(name, {
     resourceGroupName: resourceGroup.name,


### PR DESCRIPTION
We want to steer users away from hard-coding locations in their programs, so we remove those from our own examples