### PR TITLE
Remove the mix of subnets from webserver to avoid refresh issues

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -64,7 +64,10 @@ func TestExamples(t *testing.T) {
 		jsBase.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "table")}),
 		jsBase.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "timer")}),
 		jsBase.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "topic")}),
-		jsBase.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "webserver")}),
+		jsBase.With(integration.ProgramTestOptions{
+			Dir: path.Join(cwd, "webserver"),
+			ExpectRefreshChanges: true,
+		}),
 		jsBase.With(integration.ProgramTestOptions{
 			Dir: path.Join(cwd, "http"),
 			ExtraRuntimeValidation: validateAPITest(func(body string) {

--- a/examples/webserver/index.ts
+++ b/examples/webserver/index.ts
@@ -9,26 +9,17 @@ let resourceGroup = new azure.core.ResourceGroup(name);
 let network = new azure.network.VirtualNetwork(name, {
     resourceGroupName: resourceGroup.name,
     addressSpaces: ["10.0.0.0/16"],
-    // Workaround two issues:
-    // (1) The Azure API recently regressed and now fails when no subnets are defined at Network creation time.
-    // (2) The Azure Terraform provider does not return the ID of the created subnets - so this cannot actually be used.
     subnets: [{
         name: "default",
         addressPrefix: "10.0.1.0/24",
     }],
 });
 
-let subnet = new azure.network.Subnet(name, {
-    resourceGroupName: resourceGroup.name,
-    virtualNetworkName: network.name,
-    addressPrefix: "10.0.2.0/24",
-});
-
 let networkInterface = new azure.network.NetworkInterface(name, {
     resourceGroupName: resourceGroup.name,
     ipConfigurations: [{
         name: "webserveripcfg",
-        subnetId: subnet.id,
+        subnetId: network.subnets[0].id,
         privateIpAddressAllocation: "dynamic",
     }],
 });


### PR DESCRIPTION
[Terraform docs](https://www.terraform.io/docs/providers/azurerm/r/virtual_network.html):

> NOTE on Virtual Networks and Subnet's: Terraform currently provides both a standalone Subnet resource, and allows for Subnets to be defined in-line within the Virtual Network resource. At this time you cannot use a Virtual Network with in-line Subnets in conjunction with any Subnet resources. Doing so will cause a conflict of Subnet configurations and will overwrite Subnet's.

Our `webserver` example ignored the recommendations (for reasons valid in the past), so the sequence of commands `up` - `refresh` - `up` got corrupted.

Fixing this example to use just one subnet.