### PR TITLE
Remove the usage of deprecated properties

### DIFF
--- a/examples/blob/index.ts
+++ b/examples/blob/index.ts
@@ -13,7 +13,6 @@ const storageAccount = new azure.storage.Account("storage", {
 
 // And a container to use to upload images into
 const storageContainer = new azure.storage.Container("images-container", {
-   resourceGroupName: resourceGroup.name,
    storageAccountName: storageAccount.name,
    name: "images",
 });

--- a/examples/eventgrid/index.ts
+++ b/examples/eventgrid/index.ts
@@ -37,7 +37,6 @@ azure.eventgrid.events.onGridBlobCreated("OnNewBlob", {
 
 // A queue to log events to
 const logQueue = new azure.storage.Queue("log", {
-    resourceGroupName: resourceGroup.name,
     storageAccountName: storageAccount.name,
 });
 

--- a/examples/multi-callback-all/index.ts
+++ b/examples/multi-callback-all/index.ts
@@ -23,7 +23,6 @@ const storageAccount = new azure.storage.Account("storage", {
 });
 
 const queue = new azure.storage.Queue("queue", {
-    resourceGroupName: resourceGroup.name,
     storageAccountName: storageAccount.name,
 });
 
@@ -34,7 +33,6 @@ const storageQueueFunc = queue.getEventFunction("storage-queue",
 
 // Storage Blobs
 const container = new azure.storage.Container("container", {
-    resourceGroupName: resourceGroup.name,
     storageAccountName: storageAccount.name,
     name: "blobs",
 });

--- a/examples/queue/index.ts
+++ b/examples/queue/index.ts
@@ -13,13 +13,11 @@ const storageAccount = new azure.storage.Account("storage", {
 
 // And an input queue to send messages into
 const queue1 = new azure.storage.Queue("queue1", {
-   resourceGroupName: resourceGroup.name,
    storageAccountName: storageAccount.name,
 });
 
 // And an input queue to send messages into
 const queue2 = new azure.storage.Queue("queue2", {
-    resourceGroupName: resourceGroup.name,
     storageAccountName: storageAccount.name,
  });
 

--- a/examples/table/index.ts
+++ b/examples/table/index.ts
@@ -13,7 +13,6 @@ const storageAccount = new azure.storage.Account("storage", {
 
  // A table to store value lookups
 const values = new azure.storage.Table("values", {
-    resourceGroupName: resourceGroup.name,
     storageAccountName: storageAccount.name,
 });
 

--- a/sdk/nodejs/appservice/zMixins.ts
+++ b/sdk/nodejs/appservice/zMixins.ts
@@ -541,7 +541,6 @@ function createFunctionAppParts(name: string,
     }, opts);
 
     const container = args.container || new storageMod.Container(makeSafeStorageContainerName(name), {
-        resourceGroupName,
         storageAccountName: account.name,
         containerAccessType: "private",
     }, opts);


### PR DESCRIPTION
Remove the usage of deprecated `resourceGroupName` properties in storage containers (blob/table/queue). Terraform deprecated them after the SDK version change (containers can't really be in their own resource groups after all).