### PR TITLE
Fix package install on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Fix an issue where `pulumi-azure` would fail to install on Windows (fixes [#356](https://github.com/pulumi/pulumi-azure/issues/356))
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build:: provider tfgen install_plugins
 		sed -i.bak "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 	cd ${PACKDIR}/python/ && \
 		if [ $$(command -v pandoc) ]; then \
-			pandoc --from=markdown --to=rst --output=README.rst ../../README.md; \
+			pandoc --from=markdown-smart --to=rst-smart --output=README.rst ../../README.md; \
 		else \
 			echo "warning: pandoc not found, not generating README.rst"; \
 			echo "" > README.rst; \


### PR DESCRIPTION
Our README.rst (which is generated from README.md) has smart quotes in
it, which can break install of the package on Windows (since reading
the README.rst fails because it is not valid in the current windows
code-page).

This change ensures we don't generate such `.rst` files. This is the
quickest thing to to address the issue - a longer term fix I'll land
everywhere soon is to just always open these files as UTF-8, and
hopefully remove the need to use `.rst` files at all.

Fixes: #356