### PR TITLE
Fix the usage of NsRecord.records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 * Fix an issue where `pulumi-azure` would fail to install on Windows (fixes [#356](https://github.com/pulumi/pulumi-azure/issues/356))
+* Fix an issue where `records` property of `dns.NsRecord` was mistakenly mapped to the deprecated `record` property (fixes [#243](https://github.com/pulumi/pulumi-azure/issues/243))
+  [#361](https://github.com/pulumi/pulumi-azure/pull/361)
 
 ---
 

--- a/resources.go
+++ b/resources.go
@@ -539,9 +539,12 @@ func Provider() tfbridge.ProviderInfo {
 			"azurerm_dns_ns_record": {
 				Tok: azureResource(azureDNS, "NsRecord"),
 				Fields: map[string]*tfbridge.SchemaInfo{
-					// This property is deprecated and renamed to `records`.  Don't pluralize this depreacted
+					// This property is deprecated and renamed to `records`.  Don't pluralize this deprecated
 					// version so that it doesn't conflict with the replacement.
 					"record": {Name: "record"},
+					// We need this explicit mapping to avoid automatic singularization when converting Pulumi
+					// to Terraform name, so that the deprecated singular property isn't picked up.
+					"records": {Name: "records"},
 				},
 			},
 			"azurerm_dns_ptr_record": {Tok: azureResource(azureDNS, "PtrRecord")},


### PR DESCRIPTION
Fixes #243 
Technically, this seems a breaking change. Somebody could have used `records` to assign `record`-compatible array and that would probably work. Hopefully, that's marginal enough to actually include the fix into the next version.