### PR TITLE
Remove an extra read of resource group for location in mixins

### DIFF
--- a/sdk/nodejs/appservice/zMixins.ts
+++ b/sdk/nodejs/appservice/zMixins.ts
@@ -516,9 +516,9 @@ function createFunctionAppParts(name: string,
         throw new Error("Deployment [archive] must be provided.");
     }
 
-    const { resourceGroupName, location } = getResourceGroupNameAndLocation(args, undefined);
+    const resourceGroupName = getResourceGroupName(args, undefined);
 
-    const resourceGroupArgs = { resourceGroupName, location };
+    const resourceGroupArgs = { resourceGroupName, location: args.location };
 
     const plan = args.plan || new appservice.Plan(name, {
         ...resourceGroupArgs,
@@ -767,21 +767,18 @@ interface BaseSubscriptionArgs {
 }
 
 /** @internal */
-export function getResourceGroupNameAndLocation(
+export function getResourceGroupName(
         args: BaseSubscriptionArgs, fallbackResourceGroupName: pulumi.Output<string> | undefined) {
 
     if (args.resourceGroup) {
-        return { resourceGroupName: args.resourceGroup.name, location: args.location || args.resourceGroup.location };
+        return args.resourceGroup.name;
     }
 
     if (!args.resourceGroupName && !fallbackResourceGroupName) {
         throw new Error("Either [args.resourceGroup] or [args.resourceGroupName] must be provided.");
     }
 
-    const resourceGroupName = util.ifUndefined(args.resourceGroupName, fallbackResourceGroupName!);
-
-    const location = args.location || resourceGroupName.apply(n => core.getResourceGroup({ name: n })).location;
-    return { resourceGroupName, location };
+    return util.ifUndefined(args.resourceGroupName, fallbackResourceGroupName!);
 }
 
 function combineAppSettings(settings: pulumi.Input<{[key: string]: string}>[]): pulumi.Output<{[key: string]: string}> {

--- a/sdk/nodejs/cosmosdb/zMixins.ts
+++ b/sdk/nodejs/cosmosdb/zMixins.ts
@@ -172,12 +172,12 @@ export class CosmosChangeFeedSubscription extends appservice.EventSubscription<C
     constructor(
         name: string, account: Account,
         args: CosmosChangeFeedSubscriptionArgs, opts: pulumi.ComponentResourceOptions = {}) {
-        const { resourceGroupName, location } = appservice.getResourceGroupNameAndLocation(args, account.resourceGroupName);
+        const resourceGroupName = appservice.getResourceGroupName(args, account.resourceGroupName);
 
         super("azure:eventhub:CosmosChangeFeedSubscription",
             name,
             new CosmosDBFunction(name, { ...args, account }),
-            { ...args, resourceGroupName, location },
+            { ...args, resourceGroupName },
             { parent: account, ...opts });
 
         this.account = account;

--- a/sdk/nodejs/eventgrid/zMixins.ts
+++ b/sdk/nodejs/eventgrid/zMixins.ts
@@ -119,13 +119,12 @@ export class EventGridCallbackSubscription<T> extends appservice.EventSubscripti
                 args: EventGridCallbackSubscriptionArgs<T>,
                 opts: pulumi.ComponentResourceOptions = {}) {
 
-        const { resourceGroupName, location } =
-            appservice.getResourceGroupNameAndLocation(args, pulumi.output(scope.resourceGroupName));
+        const resourceGroupName = appservice.getResourceGroupName(args, pulumi.output(scope.resourceGroupName));
 
         super("azure:eventgrid:EventGridCallbackSubscription",
               name,
               new EventGridFunction(name, args),
-              { ...args, resourceGroupName, location },
+              { ...args, resourceGroupName },
               pulumi.mergeOptions(opts, {
                   aliases: [{ type: "azure:eventhub:EventGridCallbackSubscription" }],
               }));

--- a/sdk/nodejs/eventhub/zMixins.ts
+++ b/sdk/nodejs/eventhub/zMixins.ts
@@ -177,12 +177,12 @@ export class EventHubSubscription extends appservice.EventSubscription<EventHubC
 
         opts = { parent: eventHub, ...opts };
 
-        const { resourceGroupName, location } = appservice.getResourceGroupNameAndLocation(args, eventHub.resourceGroupName);
+        const resourceGroupName = appservice.getResourceGroupName(args, eventHub.resourceGroupName);
 
         super("azure:eventhub:EventHubSubscription",
             name,
             new EventHubFunction(name, { ...args, eventHub }),
-            { ...args, resourceGroupName, location },
+            { ...args, resourceGroupName },
             opts);
 
         this.eventHub = eventHub;

--- a/sdk/nodejs/iot/zMixins.ts
+++ b/sdk/nodejs/iot/zMixins.ts
@@ -89,12 +89,12 @@ export class IoTHubEventSubscription extends appservice.EventSubscription<EventH
     constructor(
         name: string, iotHub: IoTHub,
         args: IoTHubSubscriptionArgs, opts: pulumi.ComponentResourceOptions = {}) {
-        const { resourceGroupName, location } = appservice.getResourceGroupNameAndLocation(args, iotHub.resourceGroupName);
+        const resourceGroupName = appservice.getResourceGroupName(args, iotHub.resourceGroupName);
 
         super("azure:eventhub:IoTHubEventSubscription",
             name,
             new IoTHubFunction(name, { ...args, iotHub }),
-            { ...args, resourceGroupName, location },
+            { ...args, resourceGroupName },
             { parent: iotHub, ...opts });
 
         this.iotHub = iotHub;

--- a/sdk/nodejs/servicebus/zMixins.ts
+++ b/sdk/nodejs/servicebus/zMixins.ts
@@ -190,12 +190,12 @@ export class QueueEventSubscription extends appservice.EventSubscription<Service
     constructor(
         name: string, queue: Queue,
         args: QueueEventSubscriptionArgs, opts: pulumi.ComponentResourceOptions = {}) {
-        const { resourceGroupName, location } = appservice.getResourceGroupNameAndLocation(args, queue.resourceGroupName);
+        const resourceGroupName = appservice.getResourceGroupName(args, queue.resourceGroupName);
 
         super("azure:servicehub:QueueEventSubscription",
             name,
             new ServiceBusFunction(name, { ...args, queue }),
-            { ...args, resourceGroupName, location },
+            { ...args, resourceGroupName },
             pulumi.mergeOptions(
                 { parent: queue, ...opts },
                 { aliases: [{ type: "azure:eventhub:QueueEventSubscription" }]}));
@@ -261,7 +261,7 @@ export class TopicEventSubscription extends appservice.EventSubscription<Service
 
         opts = { parent: topic, ...opts };
 
-        const { resourceGroupName, location } = appservice.getResourceGroupNameAndLocation(args, topic.resourceGroupName);
+        const resourceGroupName = appservice.getResourceGroupName(args, topic.resourceGroupName);
 
         const subscription = args.subscription || new Subscription(name, {
             resourceGroupName,
@@ -273,7 +273,7 @@ export class TopicEventSubscription extends appservice.EventSubscription<Service
         super("azure:servicehub:TopicEventSubscription",
             name,
             new ServiceBusFunction(name, { ...args, topic, subscription }),
-            { ...args, resourceGroupName, location },
+            { ...args, resourceGroupName },
             pulumi.mergeOptions(opts, {
                 aliases: [{ type: "azure:eventhub:TopicEventSubscription" }] }));
 

--- a/sdk/nodejs/storage/zMixins.ts
+++ b/sdk/nodejs/storage/zMixins.ts
@@ -247,13 +247,12 @@ export class BlobEventSubscription extends appservice.EventSubscription<BlobCont
     constructor(
         name: string, container: storage.Container,
         args: BlobEventSubscriptionArgs, opts: pulumi.ComponentResourceOptions = {}) {
-        const { resourceGroupName, location } =
-            appservice.getResourceGroupNameAndLocation(args, container.resourceGroupName);
+        const resourceGroupName = appservice.getResourceGroupName(args, container.resourceGroupName);
 
         super("azure:storage:BlobEventSubscription",
             name,
             new BlobFunction(name, { ...args, container }),
-            { ...args, resourceGroupName, location },
+            { ...args, resourceGroupName },
             { parent: container, ...opts });
 
         this.registerOutputs();
@@ -524,12 +523,11 @@ export class QueueEventSubscription extends appservice.EventSubscription<QueueCo
 
         opts = { parent: queue, ...opts };
 
-        const { resourceGroupName, location } = appservice.getResourceGroupNameAndLocation(args, queue.resourceGroupName);
+        const resourceGroupName = appservice.getResourceGroupName(args, queue.resourceGroupName);
 
         super("azure:storage:QueueEventSubscription", name, new QueueFunction(name, { ...args, queue }), {
             ...args,
             resourceGroupName,
-            location,
         }, opts);
 
         this.registerOutputs();


### PR DESCRIPTION
Currently, we read the resource group to populate the location of the callback function infra. This is not required since a long time ago: `location` is automatically populated from the resource group for all Azure resources. Remove the superfluous read which also causes some instability in tests ("resource group not found").