### PR TITLE
Use Blob SAS instead of Account SAS for better security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 * Upgrade to v1.35.0 of the Azurerm Terraform Provider
+* Use Blob Container SAS instead of Account SAS for zip packages for Function App deployments
+  [#378](https://github.com/pulumi/pulumi-azure/pull/378)
 
 ---
 
@@ -13,6 +15,8 @@ CHANGELOG
 * Upgrade to support go1.13
 * Upgrade to v1.34.0 of the Azurerm Terraform Provider
 * Regenerate SDK against tf2pulumi 0.6.0
+
+---
 
 ## 1.0.0 (2019-09-03)
 * Use 1.0 version of Pulumi dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@ CHANGELOG
 * Upgrade to v1.34.0 of the Azurerm Terraform Provider
 * Regenerate SDK against tf2pulumi 0.6.0
 
----
-
 ## 1.0.0 (2019-09-03)
 * Use 1.0 version of Pulumi dependency
 

--- a/sdk/nodejs/appservice/zMixins.ts
+++ b/sdk/nodejs/appservice/zMixins.ts
@@ -546,7 +546,6 @@ function createFunctionAppParts(name: string,
     }, opts);
 
     const zipBlob = new storageMod.ZipBlob(name, {
-        resourceGroupName,
         storageAccountName: account.name,
         storageContainerName: container.name,
         type: "block",

--- a/sdk/nodejs/storage/zMixins.ts
+++ b/sdk/nodejs/storage/zMixins.ts
@@ -13,19 +13,16 @@
 // limitations under the License.
 
 import * as pulumi from "@pulumi/pulumi";
-import * as eventgrid from "azure-eventgrid/lib/models";
 
 import { Account } from "./account";
 import { Blob } from "./blob";
 import { Container } from "./container";
-import { getAccountSAS } from "./getAccountSAS";
 import { Queue } from "./queue";
 import { Table } from "./table";
 import { ZipBlob } from "./zipBlob";
 
 import * as appservice from "../appservice";
 import * as core from "../core";
-import * as eventhub from "../eventhub";
 import * as storage from "../storage";
 
 /**
@@ -43,21 +40,11 @@ export function signedBlobReadUrl(blob: Blob | ZipBlob, account: Account): pulum
 
     return pulumi.all([account.name, account.primaryConnectionString, blob.storageContainerName, blob.name]).apply(
         async ([accountName, connectionString, containerName, blobName]) => {
-            const sas = await getAccountSAS({
+            const sas = await storage.getAccountBlobContainerSAS({
                 connectionString,
+                containerName,
                 start: "2019-01-01",
                 expiry: signatureExpiration,
-                services: {
-                    blob: true,
-                    queue: false,
-                    table: false,
-                    file: false,
-                },
-                resourceTypes: {
-                    service: false,
-                    container: false,
-                    object: true,
-                },
                 permissions: {
                     read: true,
                     write: false,
@@ -65,8 +52,6 @@ export function signedBlobReadUrl(blob: Blob | ZipBlob, account: Account): pulum
                     list: false,
                     add: false,
                     create: false,
-                    update: false,
-                    process: false,
                 },
             });
 


### PR DESCRIPTION
The latest version of Terraform introduced a data source for Blob Container-level Shared Access Signature. It has a smaller scope than the Account-level SAS, so let's use it for our zip files for function packages.