### PR TITLE
Attempt to workaround Azure resource group issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ install:
     - export PATH=$HOME/.pulumi/bin:$PATH
 before_script:
     - ${PULUMI_SCRIPTS}/ci/ensure-dependencies
+    # Attempt to work around issues with cross-region replication of resource group state in Azure.
+    # See https://github.com/pulumi/pulumi-azure/issues/373#issuecomment-545158789.
+    - echo "$(getent hosts $ARM_LOCATION.management.azure.com | awk '{ print $1 }') management.azure.com" | sudo tee --append /etc/hosts
 script:
     - make travis_${TRAVIS_EVENT_TYPE}
 after_failure:


### PR DESCRIPTION
Starting a couple months ago, we've been seeing frequent intermittent test failures across all our Azure testing in TravisCI.  Many different kinds of individual resources were failing to create, but in all cases, the error messages included something along the lines of "resource group not found".

We tried several things to try to isolate this, but had not had any luck.  Finally - we got a tip from an Azure engineer.  Apparently there are delays in cross-region replication of resource group information.  By itself this wouldn't be a problem, as our tests create all resources in the same region.  But apparently also the `management.azure.com` endpoint will resolve to regional endpoints based on best performance (via TrafficManager), and that regional endpoint will try to look up the resource group in the region that the request got routed to, not the region the resource is asking to be created in, and can potentially serve stale/wrong answers as a result.

In this PR, we work around this by writing a `hosts` file entry to force redirect `management.azure.com` traffic to `<region>.management.azure.com` where `<region>` is the same region we will be creating our resources in.

We've seen four consecutive green builds against this PR, so it appears this successfully works around the issue.

Fixes https://github.com/pulumi/pulumi-azure/issues/373 (though we should escalate the underlying issue with Azure - it does not seem reasonable that this workaround should be required).