### PR TITLE
Incorporate queue/topic ID in ServiceBusFunction.

### DIFF
--- a/sdk/nodejs/eventhub/zMixins.ts
+++ b/sdk/nodejs/eventhub/zMixins.ts
@@ -214,6 +214,7 @@ export class EventHubFunction extends appservice.Function<EventHubContext, strin
             connection: bindingConnectionKey,
         } as EventHubBindingDefinition;
 
+        // Fold the event hub ID into the all so we don't attempt to fetch the namespace until we're sure it has been created.
         const namespace = pulumi.all([args.eventHub.namespaceName, args.eventHub.resourceGroupName, args.eventHub.id])
                                .apply(([namespaceName, resourceGroupName]) =>
                                     getEventhubNamespace({ name: namespaceName, resourceGroupName }));

--- a/sdk/nodejs/eventhub/zMixins.ts
+++ b/sdk/nodejs/eventhub/zMixins.ts
@@ -214,7 +214,7 @@ export class EventHubFunction extends appservice.Function<EventHubContext, strin
             connection: bindingConnectionKey,
         } as EventHubBindingDefinition;
 
-        const namespace = pulumi.all([args.eventHub.namespaceName, args.eventHub.resourceGroupName])
+        const namespace = pulumi.all([args.eventHub.namespaceName, args.eventHub.resourceGroupName, args.eventHub.id])
                                .apply(([namespaceName, resourceGroupName]) =>
                                     getEventhubNamespace({ name: namespaceName, resourceGroupName }));
 

--- a/sdk/nodejs/servicebus/zMixins.ts
+++ b/sdk/nodejs/servicebus/zMixins.ts
@@ -305,8 +305,19 @@ export class ServiceBusFunction extends appservice.Function<ServiceBusContext, s
             throw new Error("[subscription] must be specified in combination with [topic]");
         }
 
-        const namespaceName = (args.queue && args.queue.namespaceName) || args.topic!.namespaceName;
-        const resourceGroupName = (args.queue && args.queue.resourceGroupName) || args.topic!.resourceGroupName;
+        let namespaceName;
+        if (args.queue && args.queue.namespaceName) {
+            namespaceName = pulumi.all([args.queue.namespaceName, args.queue.id]).apply(([ns]) => ns);
+        } else {
+            namespaceName = pulumi.all([args.topic!.namespaceName, args.topic!.id]).apply(([ns]) => ns);
+        }
+
+        let resourceGroupName;
+        if (args.queue && args.queue.resourceGroupName) {
+            resourceGroupName = pulumi.all([args.queue.resourceGroupName, args.queue.id]).apply(([rg]) => rg);
+        } else {
+            resourceGroupName = pulumi.all([args.topic!.resourceGroupName, args.topic!.id]).apply(([rg]) => rg);
+        }
 
         // The binding does not store the Service Bus connection string directly.  Instead, the
         // connection string is put into the app settings (under whatever key we want). Then, the

--- a/sdk/nodejs/servicebus/zMixins.ts
+++ b/sdk/nodejs/servicebus/zMixins.ts
@@ -305,10 +305,9 @@ export class ServiceBusFunction extends appservice.Function<ServiceBusContext, s
             throw new Error("[subscription] must be specified in combination with [topic]");
         }
 
+        const queueOrTopicId = (args.queue && args.queue.id) || args.topic!.id;
         const namespaceName = (args.queue && args.queue.namespaceName) || args.topic!.namespaceName;
-        const namespaceId = (args.queue && args.queue.namespaceName) ? args.queue.id : args.topic!.id;
         const resourceGroupName = (args.queue && args.queue.resourceGroupName) || args.topic!.resourceGroupName;
-        const resourceGroupId = (args.queue && args.queue.resourceGroupName) ? args.queue.id : args.topic!.id;
 
         // The binding does not store the Service Bus connection string directly.  Instead, the
         // connection string is put into the app settings (under whatever key we want). Then, the
@@ -325,7 +324,8 @@ export class ServiceBusFunction extends appservice.Function<ServiceBusContext, s
             connection: bindingConnectionKey,
         } as ServiceBusBindingDefinition;
 
-        const namespace = pulumi.all([namespaceName, resourceGroupName, namespaceId, resourceGroupId])
+        // Fold the queue/topic ID into the all so we don't attempt to fetch the namespace until we're sure it has been created.
+        const namespace = pulumi.all([namespaceName, resourceGroupName, queueOrTopicId])
                                .apply(([namespaceName, resourceGroupName]) =>
                                     getNamespace({ name: namespaceName, resourceGroupName }));
 

--- a/sdk/nodejs/servicebus/zMixins.ts
+++ b/sdk/nodejs/servicebus/zMixins.ts
@@ -305,19 +305,10 @@ export class ServiceBusFunction extends appservice.Function<ServiceBusContext, s
             throw new Error("[subscription] must be specified in combination with [topic]");
         }
 
-        let namespaceName;
-        if (args.queue && args.queue.namespaceName) {
-            namespaceName = pulumi.all([args.queue.namespaceName, args.queue.id]).apply(([ns]) => ns);
-        } else {
-            namespaceName = pulumi.all([args.topic!.namespaceName, args.topic!.id]).apply(([ns]) => ns);
-        }
-
-        let resourceGroupName;
-        if (args.queue && args.queue.resourceGroupName) {
-            resourceGroupName = pulumi.all([args.queue.resourceGroupName, args.queue.id]).apply(([rg]) => rg);
-        } else {
-            resourceGroupName = pulumi.all([args.topic!.resourceGroupName, args.topic!.id]).apply(([rg]) => rg);
-        }
+        const namespaceName = (args.queue && args.queue.namespaceName) || args.topic!.namespaceName;
+        const namespaceId = (args.queue && args.queue.namespaceName) ? args.queue.id : args.topic!.id;
+        const resourceGroupName = (args.queue && args.queue.resourceGroupName) || args.topic!.resourceGroupName;
+        const resourceGroupId = (args.queue && args.queue.resourceGroupName) ? args.queue.id : args.topic!.id;
 
         // The binding does not store the Service Bus connection string directly.  Instead, the
         // connection string is put into the app settings (under whatever key we want). Then, the
@@ -334,7 +325,7 @@ export class ServiceBusFunction extends appservice.Function<ServiceBusContext, s
             connection: bindingConnectionKey,
         } as ServiceBusBindingDefinition;
 
-        const namespace = pulumi.all([namespaceName, resourceGroupName])
+        const namespace = pulumi.all([namespaceName, resourceGroupName, namespaceId, resourceGroupId])
                                .apply(([namespaceName, resourceGroupName]) =>
                                     getNamespace({ name: namespaceName, resourceGroupName }));
 


### PR DESCRIPTION
We cannot call `getNamespace` until we are sure the namespace we want to
retrieve exists. Ensure that this is the case by incorporating the id of
the Queue or Topic that we're pulling the namespace and resource group name
off of into our `apply`.

Fixes #416.