### PR TITLE
Add explicit names for all C# namespaces

### DIFF
--- a/resources.go
+++ b/resources.go
@@ -44,79 +44,83 @@ const (
 	azurePkg = "azure"
 	// modules; in general, we took naming inspiration from the Azure SDK for Go:
 	// https://godoc.org/github.com/Azure/azure-sdk-for-go
-	azureAD                  = "ad"                  // Active Directory (AAD)
-	azureAnalysisServices    = "analysisservices"    // Analysis Services
-	azureAPIManagement       = "apimanagement"       // API Management
-	azureAppInsights         = "appinsights"         // AppInsights
-	azureAppService          = "appservice"          // App Service
-	azureAutomation          = "automation"          // Automatio
-	azureAuthorization       = "authorization"       // Authorization
-	azureAutoscale           = "autoscale"           // Autoscale
-	azureBatch               = "batch"               // Batch
-	azureBot                 = "bot"                 // Bot
-	azureCDN                 = "cdn"                 // CDN
-	azureCognitive           = "cognitive"           // Cognitive
-	azureCompute             = "compute"             // Virtual Machines
-	azureContainerService    = "containerservice"    // Azure Container Service
-	azureCore                = "core"                // Base Resources
-	azureCosmosDB            = "cosmosdb"            // Cosmos DB
-	azureDashboard           = "dashboard"           // Dashboard
-	azureDataFactory         = "datafactory"         // Data Factory
-	azureDatalake            = "datalake"            // Data Lake
-	azureDataBricks          = "databricks"          // DataBricks
-	azureDdosProtection      = "ddosprotection"      // DDOS Protection
-	azureDevSpace            = "devspace"            // DevSpace
-	azureDevTest             = "devtest"             // Dev Test Labs
-	azureDNS                 = "dns"                 // DNS
-	azureFrontdoor           = "frontdoor"           // Frontdoor
-	azureHdInsight           = "hdinsight"           // nolint:misspell // HDInsight
-	azureHealthcare          = "healthcare"          // HealthCare
-	azureIot                 = "iot"                 // IoT resource
-	azureKeyVault            = "keyvault"            // Key Vault
-	azureKusto               = "kusto"               // Kusto
-	azureLogAnalytics        = "loganalytics"        // Log Analytics
-	azureLogicApps           = "logicapps"           // Logic Apps
-	azureLB                  = "lb"                  // Load Balancer
-	azureMariaDB             = "mariadb"             // MariaDB
-	azureEventGrid           = "eventgrid"           // Event Grid
-	azureEventHub            = "eventhub"            // Event Hub
-	azureManagement          = "management"          // Management Resources
-	azureMaps                = "maps"                // Maps
-	azureMarketPlace         = "marketplace"         // Marketplace
-	azureMediaServices       = "mediaservices"       // Media Services
-	azureMonitoring          = "monitoring"          // Metrics/monitoring resources
-	azureMSSQL               = "mssql"               // MS Sql
-	azureMySQL               = "mysql"               // MySql
-	azureNetapp              = "netapp"              // NetApp
-	azureNetwork             = "network"             // Networking
-	azureNotificationHub     = "notificationhub"     // Notification Hub
-	azureOperationalInsights = "operationalinsights" // Operational Insights
-	azurePostgresql          = "postgresql"          // Postgress SQL
-	azurePolicy              = "policy"              // Policy
-	azureProximity           = "proximity"           // Proximity
-	azurePrivateDNS          = "privatedns"          // Private DNS
-	azurePrivateLink         = "privatelink"         // PrivateLink
-	azureRecoveryServices    = "recoveryservices"    // Recovery Services
-	azureRedis               = "redis"               // RedisCache
-	azureRelay               = "relay"               // Relay
-	azureScheduler           = "scheduler"           // Scheduler
-	azureSecurityCenter      = "securitycenter"      // Security Center
-	azureServiceBus          = "servicebus"          // ServiceBus
-	azureServiceFabric       = "servicefabric"       // Service Fabric
-	azureSearch              = "search"              // Search
-	azureSignalr             = "signalr"             // SignalR
-	azureSQL                 = "sql"                 // SQL
-	azureStorage             = "storage"             // Storage
-	azureStreamAnalytics     = "streamanalytics"     // StreamAnalytics
-	azureWaf                 = "waf"                 // WAF
+	azureAD                  = "AD"                  // Active Directory (AAD)
+	azureAnalysisServices    = "AnalysisServices"    // Analysis Services
+	azureAPIManagement       = "ApiManagement"       // API Management
+	azureAppInsights         = "AppInsights"         // AppInsights
+	azureAppService          = "AppService"          // App Service
+	azureAutomation          = "Automation"          // Automation
+	azureAuthorization       = "Authorization"       // Authorization
+	azureAutoscale           = "Autoscale"           // Autoscale
+	azureBatch               = "Batch"               // Batch
+	azureBot                 = "Bot"                 // Bot
+	azureCDN                 = "Cdn"                 // CDN
+	azureCognitive           = "Cognitive"           // Cognitive
+	azureCompute             = "Compute"             // Virtual Machines
+	azureContainerService    = "ContainerService"    // Azure Container Service
+	azureCore                = "Core"                // Base Resources
+	azureCosmosDB            = "CosmosDB"            // Cosmos DB
+	azureDashboard           = "Dashboard"           // Dashboard
+	azureDataFactory         = "DataFactory"         // Data Factory
+	azureDatalake            = "DataLake"            // Data Lake
+	azureDataBricks          = "DataBricks"          // DataBricks
+	azureDdosProtection      = "DdosProtection"      // DDOS Protection
+	azureDevSpace            = "DevSpace"            // DevSpace
+	azureDevTest             = "DevTest"             // Dev Test Labs
+	azureDNS                 = "Dns"                 // DNS
+	azureFrontdoor           = "FrontDoor"           // Frontdoor
+	azureHdInsight           = "HDInsight"           // nolint:misspell // HDInsight
+	azureHealthcare          = "Healthcare"          // HealthCare
+	azureIot                 = "Iot"                 // IoT resource
+	azureKeyVault            = "KeyVault"            // Key Vault
+	azureKusto               = "Kusto"               // Kusto
+	azureLogAnalytics        = "LogAnalytics"        // Log Analytics
+	azureLogicApps           = "LogicApps"           // Logic Apps
+	azureLB                  = "Lb"                  // Load Balancer
+	azureMariaDB             = "MariaDB"             // MariaDB
+	azureEventGrid           = "EventGrid"           // Event Grid
+	azureEventHub            = "EventHub"            // Event Hub
+	azureManagement          = "Management"          // Management Resources
+	azureMaps                = "Maps"                // Maps
+	azureMarketPlace         = "Marketplace"         // Marketplace
+	azureMediaServices       = "MediaServices"       // Media Services
+	azureMonitoring          = "Monitoring"          // Metrics/monitoring resources
+	azureMSSQL               = "MSSql"               // MS Sql
+	azureMySQL               = "MySql"               // MySql
+	azureNetapp              = "NetApp"              // NetApp
+	azureNetwork             = "Network"             // Networking
+	azureNotificationHub     = "NotificationHub"     // Notification Hub
+	azureOperationalInsights = "OperationalInsights" // Operational Insights
+	azurePostgresql          = "PostgreSql"          // Postgress SQL
+	azurePolicy              = "Policy"              // Policy
+	azureProximity           = "Proximity"           // Proximity
+	azurePrivateDNS          = "PrivateDns"          // Private DNS
+	azurePrivateLink         = "PrivateLink"         // PrivateLink
+	azureRecoveryServices    = "RecoveryServices"    // Recovery Services
+	azureRedis               = "Redis"               // RedisCache
+	azureRelay               = "Relay"               // Relay
+	azureScheduler           = "Scheduler"           // Scheduler
+	azureSecurityCenter      = "SecurityCenter"      // Security Center
+	azureServiceBus          = "ServiceBus"          // ServiceBus
+	azureServiceFabric       = "ServiceFabric"       // Service Fabric
+	azureSearch              = "Search"              // Search
+	azureSignalr             = "SignalR"             // SignalR
+	azureSQL                 = "Sql"                 // SQL
+	azureStorage             = "Storage"             // Storage
+	azureStreamAnalytics     = "StreamAnalytics"     // StreamAnalytics
+	azureWaf                 = "Waf"                 // WAF
 
 	// Legacy Module Names
-	azureLegacyRole             = "role"               // Azure Role (Legacy)
-	azureLegacyMSI              = "msi"                // Managed Service Identity / MSI (Legacy)
-	azureLegacyManagementGroups = "managementgroups"   // Management Groups (Legacy)
-	azureLegacyMgmtResource     = "managementresource" // Management Resource (Legacy)
-	azureLegacyTrafficManager   = "trafficmanager"     // Traffic Manager (Legacy)
+	azureLegacyRole             = "Role"               // Azure Role (Legacy)
+	azureLegacyMSI              = "Msi"                // Managed Service Identity / MSI (Legacy)
+	azureLegacyManagementGroups = "ManagementGroups"   // Management Groups (Legacy)
+	azureLegacyMgmtResource     = "ManagementResource" // Management Resource (Legacy)
+	azureLegacyTrafficManager   = "TrafficManager"     // Traffic Manager (Legacy)
 )
+
+var namespaceMap = map[string]string {
+	"azure": "Azure",
+}
 
 // azureMember manufactures a type token for the Azure package and the given module and type.
 func azureMember(mod string, mem string) tokens.ModuleMember {
@@ -130,16 +134,20 @@ func azureType(mod string, typ string) tokens.Type {
 
 // azureDataSource manufactures a standard resource token given a module and resource name.  It automatically uses the
 // Azure package and names the file by simply lower casing the data source's first character.
-func azureDataSource(mod string, res string) tokens.ModuleMember {
+func azureDataSource(title string, res string) tokens.ModuleMember {
+	name := strings.ToLower(title)
+	namespaceMap[name] = title
 	fn := string(unicode.ToLower(rune(res[0]))) + res[1:]
-	return azureMember(mod+"/"+fn, res)
+	return azureMember(name+"/"+fn, res)
 }
 
 // azureResource manufactures a standard resource token given a module and resource name.  It automatically uses the
 // Azure package and names the file by simply lower casing the resource's first character.
-func azureResource(mod string, res string) tokens.Type {
+func azureResource(title string, res string) tokens.Type {
+	name := strings.ToLower(title)
+	namespaceMap[name] = title
 	fn := string(unicode.ToLower(rune(res[0]))) + res[1:]
-	return azureType(mod+"/"+fn, res)
+	return azureType(name+"/"+fn, res)
 }
 
 // boolRef returns a reference to the bool argument.
@@ -1432,48 +1440,7 @@ func Provider() tfbridge.ProviderInfo {
 					},
 				},
 			},
-			Namespaces: map[string]string{
-				"ad":                  "AD",
-				"analysisservices":    "AnalysisServices",
-				"apimanagement":       "ApiManagement",
-				"appinsights":         "AppInsights",
-				"appservice":          "AppService",
-				"containerservice":    "ContainerService",
-				"cosmosdb":            "CosmosDB",
-				"datafactory":         "DataFactory",
-				"datalake":            "DataLake",
-				"databricks":          "DataBricks",
-				"ddosprotection":      "DdosProtection",
-				"devspace":            "DevSpace",
-				"devtest":             "DevTest",
-				"frontdoor":           "FrontDoor",
-				"hdinsight":           "HDInsight",
-				"keyvault":            "KeyVault",
-				"loganalytics":        "LogAnalytics",
-				"logicapps":           "LogicApps",
-				"mariadb":             "MariaDB",
-				"eventgrid":           "EventGrid",
-				"eventhub":            "EventHub",
-				"mediaservices":       "MediaServices",
-				"mssql":               "MSSql",
-				"mysql":               "MySql",
-				"netapp":              "NetApp",
-				"notificationhub":     "NotificationHub",
-				"operationalinsights": "OperationalInsights",
-				"postgresql":          "PostgreSql",
-				"privatedns":          "PrivateDns",
-				"privatelink":         "PrivateLink",
-				"recoveryservices":    "RecoveryServices",
-				"securitycenter":      "SecurityCenter",
-				"servicebus":          "ServiceBus",
-				"servicefabric":       "ServiceFabric",
-				"signalr":             "SignalR",
-				"streamanalytics":     "StreamAnalytics",
-				// legacy
-				"managementgroups":   "ManagementGroups",
-				"managementresource": "ManagementResource",
-				"trafficmanager":     "TrafficManager",
-			},
+			Namespaces: namespaceMap,
 		},
 	}
 

--- a/resources.go
+++ b/resources.go
@@ -132,22 +132,29 @@ func azureType(mod string, typ string) tokens.Type {
 	return tokens.Type(azureMember(mod, typ))
 }
 
+// azureSubType manufactures a type token for the Azure package and the given module, submodule, and type.
+func azureSubType(moduleTitle, sub, typ string) tokens.Type {
+	moduleName := strings.ToLower(moduleTitle)
+	namespaceMap[moduleName] = moduleTitle
+	return azureType(moduleName + "/" + sub, typ)
+}
+
 // azureDataSource manufactures a standard resource token given a module and resource name.  It automatically uses the
 // Azure package and names the file by simply lower casing the data source's first character.
-func azureDataSource(title string, res string) tokens.ModuleMember {
-	name := strings.ToLower(title)
-	namespaceMap[name] = title
+func azureDataSource(moduleTitle string, res string) tokens.ModuleMember {
+	moduleName := strings.ToLower(moduleTitle)
+	namespaceMap[moduleName] = moduleTitle
 	fn := string(unicode.ToLower(rune(res[0]))) + res[1:]
-	return azureMember(name+"/"+fn, res)
+	return azureMember(moduleName+"/"+fn, res)
 }
 
 // azureResource manufactures a standard resource token given a module and resource name.  It automatically uses the
 // Azure package and names the file by simply lower casing the resource's first character.
-func azureResource(title string, res string) tokens.Type {
-	name := strings.ToLower(title)
-	namespaceMap[name] = title
+func azureResource(moduleTitle string, res string) tokens.Type {
+	moduleName := strings.ToLower(moduleTitle)
+	namespaceMap[moduleName] = moduleTitle
 	fn := string(unicode.ToLower(rune(res[0]))) + res[1:]
-	return azureType(name+"/"+fn, res)
+	return azureType(moduleName+"/"+fn, res)
 }
 
 // boolRef returns a reference to the bool argument.
@@ -419,7 +426,7 @@ func Provider() tfbridge.ProviderInfo {
 					}),
 					"kind": {
 						Type:     "string",
-						AltTypes: []tokens.Type{azureType(azureAppService+"/kind", "Kind")},
+						AltTypes: []tokens.Type{azureSubType(azureAppService, "kind", "Kind")},
 					},
 				}},
 			"azurerm_app_service_slot":        {Tok: azureResource(azureAppService, "Slot")},

--- a/resources.go
+++ b/resources.go
@@ -122,7 +122,8 @@ var namespaceMap = map[string]string{
 	"azure": "Azure",
 }
 
-// azureMember manufactures a type token for the Azure package and the given module and type.
+// azureMember manufactures a member for the Azure package and the given module and type. It automatically
+// names the file by simply lower casing the member's first character.
 func azureMember(moduleTitle, mem string) tokens.ModuleMember {
 	moduleName := strings.ToLower(moduleTitle)
 	namespaceMap[moduleName] = moduleTitle
@@ -132,18 +133,16 @@ func azureMember(moduleTitle, mem string) tokens.ModuleMember {
 }
 
 // azureType manufactures a type token for the Azure package and the given module and type.
-func azureType(mod, typ string) tokens.Type {
+func azureType(mod string, typ string) tokens.Type {
 	return tokens.Type(azureMember(mod, typ))
 }
 
-// azureDataSource manufactures a standard resource token given a module and resource name.  It automatically uses the
-// Azure package and names the file by simply lower casing the data source's first character.
+// azureDataSource manufactures a standard member given a module and data source name.
 func azureDataSource(mod string, res string) tokens.ModuleMember {
 	return azureMember(mod, res)
 }
 
-// azureResource manufactures a standard resource token given a module and resource name.  It automatically uses the
-// Azure package and names the file by simply lower casing the resource's first character.
+// azureResource manufactures a standard resource token given a module and resource name.
 func azureResource(mod string, res string) tokens.Type {
 	return azureType(mod, res)
 }

--- a/resources.go
+++ b/resources.go
@@ -118,7 +118,7 @@ const (
 	azureLegacyTrafficManager   = "TrafficManager"     // Traffic Manager (Legacy)
 )
 
-var namespaceMap = map[string]string {
+var namespaceMap = map[string]string{
 	"azure": "Azure",
 }
 
@@ -136,7 +136,7 @@ func azureType(mod string, typ string) tokens.Type {
 func azureSubType(moduleTitle, sub, typ string) tokens.Type {
 	moduleName := strings.ToLower(moduleTitle)
 	namespaceMap[moduleName] = moduleTitle
-	return azureType(moduleName + "/" + sub, typ)
+	return azureType(moduleName+"/"+sub, typ)
 }
 
 // azureDataSource manufactures a standard resource token given a module and resource name.  It automatically uses the

--- a/resources.go
+++ b/resources.go
@@ -123,38 +123,29 @@ var namespaceMap = map[string]string{
 }
 
 // azureMember manufactures a type token for the Azure package and the given module and type.
-func azureMember(mod string, mem string) tokens.ModuleMember {
-	return tokens.ModuleMember(azurePkg + ":" + mod + ":" + mem)
+func azureMember(moduleTitle, mem string) tokens.ModuleMember {
+	moduleName := strings.ToLower(moduleTitle)
+	namespaceMap[moduleName] = moduleTitle
+	fn := string(unicode.ToLower(rune(mem[0]))) + mem[1:]
+	token := moduleName + "/" + fn
+	return tokens.ModuleMember(azurePkg + ":" + token + ":" + mem)
 }
 
 // azureType manufactures a type token for the Azure package and the given module and type.
-func azureType(mod string, typ string) tokens.Type {
+func azureType(mod, typ string) tokens.Type {
 	return tokens.Type(azureMember(mod, typ))
-}
-
-// azureSubType manufactures a type token for the Azure package and the given module, submodule, and type.
-func azureSubType(moduleTitle, sub, typ string) tokens.Type {
-	moduleName := strings.ToLower(moduleTitle)
-	namespaceMap[moduleName] = moduleTitle
-	return azureType(moduleName+"/"+sub, typ)
 }
 
 // azureDataSource manufactures a standard resource token given a module and resource name.  It automatically uses the
 // Azure package and names the file by simply lower casing the data source's first character.
-func azureDataSource(moduleTitle string, res string) tokens.ModuleMember {
-	moduleName := strings.ToLower(moduleTitle)
-	namespaceMap[moduleName] = moduleTitle
-	fn := string(unicode.ToLower(rune(res[0]))) + res[1:]
-	return azureMember(moduleName+"/"+fn, res)
+func azureDataSource(mod string, res string) tokens.ModuleMember {
+	return azureMember(mod, res)
 }
 
 // azureResource manufactures a standard resource token given a module and resource name.  It automatically uses the
 // Azure package and names the file by simply lower casing the resource's first character.
-func azureResource(moduleTitle string, res string) tokens.Type {
-	moduleName := strings.ToLower(moduleTitle)
-	namespaceMap[moduleName] = moduleTitle
-	fn := string(unicode.ToLower(rune(res[0]))) + res[1:]
-	return azureType(moduleName+"/"+fn, res)
+func azureResource(mod string, res string) tokens.Type {
+	return azureType(mod, res)
 }
 
 // boolRef returns a reference to the bool argument.
@@ -426,7 +417,7 @@ func Provider() tfbridge.ProviderInfo {
 					}),
 					"kind": {
 						Type:     "string",
-						AltTypes: []tokens.Type{azureSubType(azureAppService, "kind", "Kind")},
+						AltTypes: []tokens.Type{azureType(azureAppService, "Kind")},
 					},
 				}},
 			"azurerm_app_service_slot":        {Tok: azureResource(azureAppService, "Slot")},


### PR DESCRIPTION
A follow-up on https://github.com/pulumi/pulumi-terraform/pull/510 and a step towards https://github.com/pulumi/pulumi-terraform/issues/511
This adds explicit names for all C# namespaces in Azure.

Further plan:
1. Approve this PR.
2. Do a similar change for all providers.
3. Change TF Gen to remove the fallback to `Titlecase` and require the namespace to be explicitly provided.
4. Promote `Namespaces` property from `CSharpInfo` to top-level `Modules`, allowing any new language generator to rely on it.
5. Optionally, retrofit this definition to old language gens to make ToLower on a module name instead of using `Tok` directly.