### PR TITLE
Bump default Azure Functions and node versions to the latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ CHANGELOG
   Please note that a number of the old deprecated resources have been removed as well as
   a number of deprecated properties on resources. You can check the full list of
   changes in the [upstream CHANGELOG](https://github.com/terraform-providers/terraform-provider-azurerm/blob/master/CHANGELOG.md)
+* Set the default version of Azure Functions runtime to ~3 and Node.js to ~12.
+  ([#478](https://github.com/pulumi/pulumi-azure/pull/478))
 
 ---
 

--- a/sdk/nodejs/appservice/zMixins.ts
+++ b/sdk/nodejs/appservice/zMixins.ts
@@ -166,7 +166,7 @@ interface FunctionAppArgsBase {
 
     /**
      * Controls the value of WEBSITE_NODE_DEFAULT_VERSION in `appSettings`.  If not provided,
-     * defaults to `8.11.1`.
+     * defaults to `~12`.
      */
     readonly nodeVersion?: pulumi.Input<string>;
 
@@ -202,7 +202,7 @@ interface FunctionAppArgsBase {
     readonly tags?: pulumi.Input<{ [key: string]: any }>;
 
     /**
-     * The runtime version associated with the Function App. Defaults to `~2`.
+     * The runtime version associated with the Function App. Defaults to `~3`.
      */
     readonly version?: pulumi.Input<string>;
 }
@@ -562,13 +562,13 @@ function createFunctionAppParts(name: string,
 
         appServicePlanId: plan.id,
         storageConnectionString: account.primaryConnectionString,
-        version: args.version || "~2",
+        version: args.version || "~3",
 
         appSettings: pulumi.output(args.appSettings).apply(settings => {
             return {
                 ...settings,
                 WEBSITE_RUN_FROM_PACKAGE: codeBlobUrl,
-                WEBSITE_NODE_DEFAULT_VERSION: util.ifUndefined(args.nodeVersion, "8.11.1"),
+                WEBSITE_NODE_DEFAULT_VERSION: util.ifUndefined(args.nodeVersion, "~12"),
             };
         }),
     };


### PR DESCRIPTION
Use the move to a new major version 2.0 to bump the defaults for Azure Functions runtime and node versions to the latest