### PR TITLE
Enable custom http output binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 * Fix `error404document` mapping on `azure.storage.Account`
 * Upgrade to v2.9.0 of the AzureRM Terraform Provider
 * Update ArchiveFunctionApp to pass correct params to FunctionApp
+* Allow users to specify their own http output binding for HTTP triggered Azure Functions
 
 ---
 

--- a/examples/http-multi/index.ts
+++ b/examples/http-multi/index.ts
@@ -1,6 +1,6 @@
 import * as azure from "@pulumi/azure";
 
-const resourceGroup = new azure.core.ResourceGroup("example");
+const resourceGroup = new azure.core.ResourceGroup("example", { location: azure.Locations.WestEurope });
 
 // Define 3 HTTP Functions which only differ by number and the hello message
 const http = [1, 2, 3].map(i =>
@@ -8,6 +8,21 @@ const http = [1, 2, 3].map(i =>
         callback: async (context, request) => ({ status: 200, body: `Hi from F${i}` }),
     }),
 );
+
+// Define another HTTP function that defines a custom http output binding
+http.push(new azure.appservice.HttpFunction(`F4`, {
+    callback: async (context, request) => {
+        context.bindings.myResponse = { status: 200, body: `Hi from F4` };
+    },
+    outputs: [{
+        binding: {
+            type: "http",
+            direction: "out",
+            name: "myResponse",
+        },
+        settings: {},
+    }],
+}));
 
 // Define a timer function which will trigger every minute to keep other Function from being disposed on idle
 const warmer = new azure.appservice.TimerFunction("Warmer", {
@@ -20,7 +35,7 @@ const warmer = new azure.appservice.TimerFunction("Warmer", {
 // Create a Function App containing multiple functions
 const app = new azure.appservice.MultiCallbackFunctionApp("http-multi", {
     resourceGroupName: resourceGroup.name,
-    functions: [ ...http, warmer],
+    functions: [...http, warmer],
 });
 
 export const urls = http.map(f => app.endpoint.apply(ep => `${ep}${f.name}`));

--- a/examples/http-multi/index.ts
+++ b/examples/http-multi/index.ts
@@ -1,6 +1,6 @@
 import * as azure from "@pulumi/azure";
 
-const resourceGroup = new azure.core.ResourceGroup("example", { location: azure.Locations.WestEurope });
+const resourceGroup = new azure.core.ResourceGroup("example");
 
 // Define 3 HTTP Functions which only differ by number and the hello message
 const http = [1, 2, 3].map(i =>

--- a/sdk/nodejs/appservice/zMixins.ts
+++ b/sdk/nodejs/appservice/zMixins.ts
@@ -493,9 +493,9 @@ export abstract class Function<C extends Context<R>, E, R extends Result> {
     public readonly appSettings?: pulumi.Input<{ [key: string]: string }>;
 
     constructor(name: string,
-        trigger: pulumi.Input<InputBindingDefinition>,
-        args: CallbackFunctionArgs<C, E, R>,
-        settings?: pulumi.Input<{ [key: string]: string }>) {
+                trigger: pulumi.Input<InputBindingDefinition>,
+                args: CallbackFunctionArgs<C, E, R>,
+                settings?: pulumi.Input<{ [key: string]: string }>) {
         const triggerSettings = { binding: trigger, settings: settings || {} };
         const { bindings, appSettings } = combineBindingSettings(triggerSettings, args.inputs, args.outputs);
         this.name = name;
@@ -526,9 +526,8 @@ export interface ArchiveFunctionAppArgs extends FunctionAppArgsBase {
 };
 
 function createFunctionAppParts(name: string,
-    args: ArchiveFunctionAppArgs,
-    opts: pulumi.CustomResourceOptions = {}) {
-
+                                args: ArchiveFunctionAppArgs,
+                                opts: pulumi.CustomResourceOptions = {}) {
     if (!args.archive) {
         throw new Error("Deployment [archive] must be provided.");
     }
@@ -628,7 +627,7 @@ export class CallbackFunctionApp<C extends Context<R>, E, R extends Result> exte
     public readonly endpoint: pulumi.Output<string>;
 
     constructor(name: string, bindingsOrFunc: pulumi.Input<BindingDefinition[]> | Function<C, E, R>,
-        args: CallbackFunctionAppArgs<C, E, R>, opts: pulumi.CustomResourceOptions = {}) {
+                args: CallbackFunctionAppArgs<C, E, R>, opts: pulumi.CustomResourceOptions = {}) {
 
         const functions = bindingsOrFunc instanceof Function ? [bindingsOrFunc] : [<Function<C, E, R>>{ name, bindings: bindingsOrFunc, callback: args }];
         const parts = createFunctionAppParts(name, {
@@ -683,9 +682,9 @@ export abstract class PackagedFunctionApp extends pulumi.ComponentResource {
     public readonly endpoint: pulumi.Output<string>;
 
     constructor(type: string,
-        name: string,
-        args: ArchiveFunctionAppArgs,
-        opts: pulumi.ComponentResourceOptions = {}) {
+                name: string,
+                args: ArchiveFunctionAppArgs,
+                opts: pulumi.ComponentResourceOptions = {}) {
         super(type, name, undefined, opts);
 
         const parentOpts = { parent: this };
@@ -707,8 +706,8 @@ export abstract class PackagedFunctionApp extends pulumi.ComponentResource {
  */
 export class ArchiveFunctionApp extends PackagedFunctionApp {
     constructor(name: string,
-        args: ArchiveFunctionAppArgs,
-        opts: pulumi.ComponentResourceOptions = {}) {
+                args: ArchiveFunctionAppArgs,
+                opts: pulumi.ComponentResourceOptions = {}) {
         super("azure:appservice:ArchiveFunctionApp", name, args, opts);
         this.registerOutputs();
     }
@@ -723,8 +722,8 @@ export class ArchiveFunctionApp extends PackagedFunctionApp {
  */
 export class MultiCallbackFunctionApp extends PackagedFunctionApp {
     constructor(name: string,
-        args: MultiCallbackFunctionAppArgs,
-        opts: pulumi.ComponentResourceOptions = {}) {
+                args: MultiCallbackFunctionAppArgs,
+                opts: pulumi.ComponentResourceOptions = {}) {
 
         if (args.functions.length == 0) {
             throw new Error("At least one function must be provided.");
@@ -755,9 +754,9 @@ export abstract class EventSubscription<C extends Context<R>, E, R extends Resul
     public readonly functionApp: CallbackFunctionApp<C, E, R>;
 
     constructor(type: string, name: string,
-        bindingsOrFunc: pulumi.Input<BindingDefinition[]> | Function<C, E, R>,
-        args: CallbackFunctionAppArgs<C, E, R>,
-        opts: pulumi.ComponentResourceOptions = {}) {
+                bindingsOrFunc: pulumi.Input<BindingDefinition[]> | Function<C, E, R>,
+                args: CallbackFunctionAppArgs<C, E, R>,
+                opts: pulumi.ComponentResourceOptions = {}) {
         super(type, name, undefined, opts);
 
         this.functionApp = new CallbackFunctionApp(name, bindingsOrFunc, args, { parent: this });
@@ -785,7 +784,7 @@ interface BaseSubscriptionArgs {
 
 /** @internal */
 export function getResourceGroupName(
-    args: BaseSubscriptionArgs, fallbackResourceGroupName: pulumi.Output<string> | undefined) {
+        args: BaseSubscriptionArgs, fallbackResourceGroupName: pulumi.Output<string> | undefined) {
 
     if (args.resourceGroup) {
         return args.resourceGroup.name;
@@ -798,13 +797,13 @@ export function getResourceGroupName(
     return util.ifUndefined(args.resourceGroupName, fallbackResourceGroupName!);
 }
 
-function combineAppSettings(settings: pulumi.Input<{ [key: string]: string }>[]): pulumi.Output<{ [key: string]: string }> {
+function combineAppSettings(settings: pulumi.Input<{[key: string]: string}>[]): pulumi.Output<{[key: string]: string}> {
     return pulumi.all(settings).apply(items => items.reduce((a, b) => ({ ...a, ...b }), {}));
 }
 
 function combineBindingSettings(trigger: BindingSettings<BindingDefinition>,
-    inputs?: pulumi.Input<InputBindingSettings[]>,
-    outputs?: pulumi.Input<OutputBindingSettings[]>) {
+                                inputs?: pulumi.Input<InputBindingSettings[]>,
+                                outputs?: pulumi.Input<OutputBindingSettings[]>) {
     return pulumi.all([inputs, outputs]).apply(([i, o]) => {
         const all = [trigger, ...i || [], ...o || []];
 

--- a/sdk/nodejs/appservice/zMixins.ts
+++ b/sdk/nodejs/appservice/zMixins.ts
@@ -450,12 +450,12 @@ export interface InputOutputsArgs {
     /**
      * Input bindings.
      */
-    inputs?: InputBindingSettings[];
+    inputs?: pulumi.Input<InputBindingSettings[]>;
 
     /**
      * Output bindings.
      */
-    outputs?: OutputBindingSettings[];
+    outputs?: pulumi.Input<OutputBindingSettings[]>;
 }
 
 /**
@@ -493,9 +493,9 @@ export abstract class Function<C extends Context<R>, E, R extends Result> {
     public readonly appSettings?: pulumi.Input<{ [key: string]: string }>;
 
     constructor(name: string,
-                trigger: pulumi.Input<InputBindingDefinition>,
-                args: CallbackFunctionArgs<C, E, R>,
-                settings?: pulumi.Input<{ [key: string]: string }>) {
+        trigger: pulumi.Input<InputBindingDefinition>,
+        args: CallbackFunctionArgs<C, E, R>,
+        settings?: pulumi.Input<{ [key: string]: string }>) {
         const triggerSettings = { binding: trigger, settings: settings || {} };
         const { bindings, appSettings } = combineBindingSettings(triggerSettings, args.inputs, args.outputs);
         this.name = name;
@@ -526,8 +526,8 @@ export interface ArchiveFunctionAppArgs extends FunctionAppArgsBase {
 };
 
 function createFunctionAppParts(name: string,
-                                args: ArchiveFunctionAppArgs,
-                                opts: pulumi.CustomResourceOptions = {}) {
+    args: ArchiveFunctionAppArgs,
+    opts: pulumi.CustomResourceOptions = {}) {
 
     if (!args.archive) {
         throw new Error("Deployment [archive] must be provided.");
@@ -628,7 +628,7 @@ export class CallbackFunctionApp<C extends Context<R>, E, R extends Result> exte
     public readonly endpoint: pulumi.Output<string>;
 
     constructor(name: string, bindingsOrFunc: pulumi.Input<BindingDefinition[]> | Function<C, E, R>,
-                args: CallbackFunctionAppArgs<C, E, R>, opts: pulumi.CustomResourceOptions = {}) {
+        args: CallbackFunctionAppArgs<C, E, R>, opts: pulumi.CustomResourceOptions = {}) {
 
         const functions = bindingsOrFunc instanceof Function ? [bindingsOrFunc] : [<Function<C, E, R>>{ name, bindings: bindingsOrFunc, callback: args }];
         const parts = createFunctionAppParts(name, {
@@ -683,9 +683,9 @@ export abstract class PackagedFunctionApp extends pulumi.ComponentResource {
     public readonly endpoint: pulumi.Output<string>;
 
     constructor(type: string,
-                name: string,
-                args: ArchiveFunctionAppArgs,
-                opts: pulumi.ComponentResourceOptions = {}) {
+        name: string,
+        args: ArchiveFunctionAppArgs,
+        opts: pulumi.ComponentResourceOptions = {}) {
         super(type, name, undefined, opts);
 
         const parentOpts = { parent: this };
@@ -707,8 +707,8 @@ export abstract class PackagedFunctionApp extends pulumi.ComponentResource {
  */
 export class ArchiveFunctionApp extends PackagedFunctionApp {
     constructor(name: string,
-                args: ArchiveFunctionAppArgs,
-                opts: pulumi.ComponentResourceOptions = {}) {
+        args: ArchiveFunctionAppArgs,
+        opts: pulumi.ComponentResourceOptions = {}) {
         super("azure:appservice:ArchiveFunctionApp", name, args, opts);
         this.registerOutputs();
     }
@@ -723,8 +723,8 @@ export class ArchiveFunctionApp extends PackagedFunctionApp {
  */
 export class MultiCallbackFunctionApp extends PackagedFunctionApp {
     constructor(name: string,
-                args: MultiCallbackFunctionAppArgs,
-                opts: pulumi.ComponentResourceOptions = {}) {
+        args: MultiCallbackFunctionAppArgs,
+        opts: pulumi.ComponentResourceOptions = {}) {
 
         if (args.functions.length == 0) {
             throw new Error("At least one function must be provided.");
@@ -755,9 +755,9 @@ export abstract class EventSubscription<C extends Context<R>, E, R extends Resul
     public readonly functionApp: CallbackFunctionApp<C, E, R>;
 
     constructor(type: string, name: string,
-                bindingsOrFunc: pulumi.Input<BindingDefinition[]> | Function<C, E, R>,
-                args: CallbackFunctionAppArgs<C, E, R>,
-                opts: pulumi.ComponentResourceOptions = {}) {
+        bindingsOrFunc: pulumi.Input<BindingDefinition[]> | Function<C, E, R>,
+        args: CallbackFunctionAppArgs<C, E, R>,
+        opts: pulumi.ComponentResourceOptions = {}) {
         super(type, name, undefined, opts);
 
         this.functionApp = new CallbackFunctionApp(name, bindingsOrFunc, args, { parent: this });
@@ -785,7 +785,7 @@ interface BaseSubscriptionArgs {
 
 /** @internal */
 export function getResourceGroupName(
-        args: BaseSubscriptionArgs, fallbackResourceGroupName: pulumi.Output<string> | undefined) {
+    args: BaseSubscriptionArgs, fallbackResourceGroupName: pulumi.Output<string> | undefined) {
 
     if (args.resourceGroup) {
         return args.resourceGroup.name;
@@ -798,19 +798,21 @@ export function getResourceGroupName(
     return util.ifUndefined(args.resourceGroupName, fallbackResourceGroupName!);
 }
 
-function combineAppSettings(settings: pulumi.Input<{[key: string]: string}>[]): pulumi.Output<{[key: string]: string}> {
+function combineAppSettings(settings: pulumi.Input<{ [key: string]: string }>[]): pulumi.Output<{ [key: string]: string }> {
     return pulumi.all(settings).apply(items => items.reduce((a, b) => ({ ...a, ...b }), {}));
 }
 
 function combineBindingSettings(trigger: BindingSettings<BindingDefinition>,
-                                inputs?: InputBindingSettings[],
-                                outputs?: OutputBindingSettings[]) {
-    const all = [trigger, ...inputs || [], ...outputs || []];
+    inputs?: pulumi.Input<InputBindingSettings[]>,
+    outputs?: pulumi.Input<OutputBindingSettings[]>) {
+    return pulumi.all([inputs, outputs]).apply(([i, o]) => {
+        const all = [trigger, ...i || [], ...o || []];
 
-    const bindings = pulumi.all(all.map(bs => bs.binding));
-    const appSettings = combineAppSettings(all.map(bs => bs.settings));
+        const bindings = pulumi.all(all.map(bs => bs.binding));
+        const appSettings = combineAppSettings(all.map(bs => bs.settings));
 
-    return { bindings, appSettings };
+        return { bindings, appSettings };
+    });
 }
 
 /**


### PR DESCRIPTION
This PR adds he ability for users of the HTTP triggered functions in pulumi to specify their custom output binding for the http response. This is useful in 2 scenarios:

- The caller wants to define a custom name for the binding
- The caller needs to force pulumi to use an output binding name different than `$return`, e.g. to workaroud issues like this: https://github.com/Azure/azure-functions-nodejs-worker/issues/232