### PR TITLE
Adapt package publishing for new repo layout

### DIFF
--- a/scripts/publish-plugin.sh
+++ b/scripts/publish-plugin.sh
@@ -16,10 +16,10 @@ if [ "$(go env GOOS)" = "windows" ]; then
     BIN_SUFFIX=".exe"
 fi
 
-go build \
+(cd "${ROOT}/provider" && go build \
    -ldflags "-X github.com/pulumi/pulumi-azure/provider/pkg/version.Version=${VERSION}" \
    -o "${WORK_PATH}/pulumi-resource-azure${BIN_SUFFIX}" \
-   "${ROOT}/provider/cmd/pulumi-resource-azure"
+   "${ROOT}/cmd/pulumi-resource-azure")
 
 # Tar up the plugin
 tar -czf ${PLUGIN_PACKAGE_PATH} -C ${WORK_PATH} .


### PR DESCRIPTION
This is required due to the new go mod module layout