### PR TITLE
Bump modules to v2 structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Bump consumable git modules to v2 as per [go documentation](https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher)
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,10 @@ generate_schema:: tfgen
 
 provider::
 	go generate ${PROJECT}/provider/cmd/${PROVIDER}
-	cd provider && go install -ldflags "-X github.com/pulumi/pulumi-azure/provider/pkg/version.Version=${VERSION}" ${PROJECT}/provider/cmd/${PROVIDER}
+	cd provider && go install -ldflags "-X github.com/pulumi/pulumi-azure/provider/v2/pkg/version.Version=${VERSION}" ${PROJECT}/provider/v2/cmd/${PROVIDER}
 
 tfgen::
-	cd provider && go install -ldflags "-X github.com/pulumi/pulumi-azure/provider/pkg/version.Version=${VERSION}" ${PROJECT}/provider/cmd/${TFGEN}
+	cd provider && go install -ldflags "-X github.com/pulumi/pulumi-azure/provider/v2/pkg/version.Version=${VERSION}" ${PROJECT}/provider/v2/cmd/${TFGEN}
 
 install_plugins::
 	[ -x "$(shell which pulumi)" ] || curl -fsSL https://get.pulumi.com | sh

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/pulumi-azure/examples
+module github.com/pulumi/pulumi-azure/examples/v2
 
 go 1.13
 

--- a/provider/cmd/pulumi-resource-azure/main.go
+++ b/provider/cmd/pulumi-resource-azure/main.go
@@ -19,10 +19,9 @@ package main
 import (
 	_ "unsafe" // Import go:linkname
 
+	azure "github.com/pulumi/pulumi-azure/provider/v2"
+	"github.com/pulumi/pulumi-azure/provider/v2/pkg/version"
 	"github.com/pulumi/pulumi-terraform-bridge/pkg/tfbridge"
-
-	azure "github.com/pulumi/pulumi-azure/provider"
-	"github.com/pulumi/pulumi-azure/provider/pkg/version"
 )
 
 // The AzureRM Terraform Provider has a setting named ARM_PROVIDER_STRICT, the bulk

--- a/provider/cmd/pulumi-tfgen-azure/main.go
+++ b/provider/cmd/pulumi-tfgen-azure/main.go
@@ -15,8 +15,8 @@
 package main
 
 import (
-	azure "github.com/pulumi/pulumi-azure/provider"
-	"github.com/pulumi/pulumi-azure/provider/pkg/version"
+	azure "github.com/pulumi/pulumi-azure/provider/v2"
+	"github.com/pulumi/pulumi-azure/provider/v2/pkg/version"
 	"github.com/pulumi/pulumi-terraform-bridge/pkg/tfgen"
 )
 

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/pulumi-azure/provider
+module github.com/pulumi/pulumi-azure/provider/v2
 
 go 1.13
 

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -456,7 +456,6 @@ github.com/pulumi/pulumi-terraform-bridge v1.8.4/go.mod h1:EGMJtAh9rdqiqO0B5P458
 github.com/pulumi/pulumi/pkg v0.0.0-20200325225746-80f1989600a3 h1:CUswHMz3r5GBJHeGL5p4NtAGwqoelFyv54KW1A1XQfk=
 github.com/pulumi/pulumi/pkg v0.0.0-20200325225746-80f1989600a3/go.mod h1:iX8/aPGtI3VhJnIUqHoT2iy3/0wQJySIRMs9y2TBILw=
 github.com/pulumi/pulumi/sdk v0.0.0-20200321193742-f095e64d0f8e/go.mod h1:ZCVEM4V8vr5IogqUhSu28+FEEn3bIjGYpEOSHRureO0=
-github.com/pulumi/pulumi/sdk v0.0.0-20200325225746-80f1989600a3 h1:O7Kt01GMn4lP61yHLg97TIl2D7l8BoBp4eawjqwefxY=
 github.com/pulumi/pulumi/sdk v0.0.0-20200325225746-80f1989600a3/go.mod h1:0jjygtqEwLnjNEL3zIn3ynjT/37ZJ42DZE6k2+2NAUM=
 github.com/pulumi/pulumi/sdk v1.13.1 h1:BX0ttL/g5ofKxkK2VY/gp8SdBxJi4eIyIG34JRn9ENU=
 github.com/pulumi/pulumi/sdk v1.13.1/go.mod h1:0jjygtqEwLnjNEL3zIn3ynjT/37ZJ42DZE6k2+2NAUM=

--- a/provider/resource.go
+++ b/provider/resource.go
@@ -20,18 +20,16 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/pulumi/pulumi/sdk/go/common/resource"
-
 	"github.com/Azure/go-autorest/autorest/azure/cli"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/pulumi/pulumi-azure/provider/v2/pkg/version"
 	"github.com/pulumi/pulumi-terraform-bridge/pkg/tfbridge"
+	"github.com/pulumi/pulumi/sdk/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/go/common/util/contract"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
-
-	"github.com/pulumi/pulumi-azure/provider/pkg/version"
 )
 
 const (

--- a/scripts/publish-plugin.sh
+++ b/scripts/publish-plugin.sh
@@ -17,7 +17,7 @@ if [ "$(go env GOOS)" = "windows" ]; then
 fi
 
 (cd "${ROOT}/provider" && go build \
-   -ldflags "-X github.com/pulumi/pulumi-azure/provider/pkg/version.Version=${VERSION}" \
+   -ldflags "-X github.com/pulumi/pulumi-azure/provider/pkg/v2/version.Version=${VERSION}" \
    -o "${WORK_PATH}/pulumi-resource-azure${BIN_SUFFIX}" \
    "${ROOT}/cmd/pulumi-resource-azure")
 

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/pulumi-azure/sdk
+module github.com/pulumi/pulumi-azure/sdk/v2
 
 go 1.13
 


### PR DESCRIPTION
This is required so that users can run go get and the version without
needing to know the individual Git SHA