### PR TITLE
Don't run update test for non-released code

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -30,7 +30,7 @@ func TestAccDurableFunctions(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: path.Join(getCwd(t), "durable-functions"),
-			RunUpdateTest: true,
+			RunUpdateTest: false,
 		})
 
 	integration.ProgramTest(t, &test)


### PR DESCRIPTION
I keep forgetting the modes of our tests, but I think update tests aren't allowed until a piece of functionality is released. Switch it off for now to fix https://travis-ci.com/github/pulumi/pulumi-azure/builds/164557586#L3596