### PR TITLE
Add function to compute CosmosDB Connection string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 * Fix `error404document` mapping on `azure.storage.Account`
 * Upgrade to v2.9.0 of the AzureRM Terraform Provider
 * Update ArchiveFunctionApp to pass correct params to FunctionApp
+* Add NodeJS function to build CosmosDB Primary Connection String for SQL Accounts
 
 ---
 

--- a/sdk/nodejs/cosmosdb/zMixins.ts
+++ b/sdk/nodejs/cosmosdb/zMixins.ts
@@ -167,7 +167,7 @@ declare module "./account" {
          * Computes the primary connection string for a CosmosDB account. When using the default GlobalDocumentDB as 
          * kind for a CosmosDB account this value is empty. Refer to https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/azure/cosmosdb/#Account-connectionStrings
          */
-        getPrimaryConnectionString(args: GetCosmosDBPrimaryConnectionStringArgs): string;
+        getPrimaryConnectionString(args: GetCosmosDBPrimaryConnectionStringArgs): pulumi.Output<string>;
     }
 }
 

--- a/sdk/nodejs/cosmosdb/zMixins.ts
+++ b/sdk/nodejs/cosmosdb/zMixins.ts
@@ -137,6 +137,13 @@ export interface CosmosChangeFeedSubscriptionArgs extends GetCosmosDBFunctionArg
     resourceGroupName?: pulumi.Input<string>;
 }
 
+export interface GetCosmosDBPrimaryConnectionStringArgs {
+    /**
+     * CosmosDB Account.
+     */
+    account: Account;
+}
+
 declare module "./account" {
     interface Account {
         /**
@@ -155,6 +162,12 @@ declare module "./account" {
          * Function.
          */
         getChangeFeedFunction(name: string, args: GetCosmosDBFunctionArgs): CosmosDBFunction;
+        
+        /**
+         * Computes the primary connection string for a CosmosDB account. When using the default GlobalDocumentDB as 
+         * kind for a CosmosDB account this value is empty. Refer to https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/azure/cosmosdb/#Account-connectionStrings
+         */
+        getPrimaryConnectionString(args: GetCosmosDBPrimaryConnectionStringArgs): string;
     }
 }
 
@@ -219,4 +232,8 @@ export class CosmosDBFunction extends appservice.Function<CosmosChangeFeedContex
 
         super(name, trigger, args, appSettings);
     }
+}
+
+Account.prototype.getPrimaryConnectionString = function(this: Account, args){
+    return pulumi.all([args.account.endpoint, args.account.primaryMasterKey]).apply(([accountEndpoint, key]) => `AccountEndpoint=${accountEndpoint};AccountKey=${key};`)
 }


### PR DESCRIPTION
Provider is currently missing a way to get the primary connection string from a SQL CosmosDB account.
This is my first try at the NodeJS implementation.
My laptop didn't want to run `make` so I hope this is an acceptable first attempt :)