### PR TITLE
Set `FUNCTIONS_WORKER_RUNTIME` as part of appservice Callbackfunctions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
   **PLEASE NOTE:** `azure.mariaDb.getMariaDbServer` 'administratorLoginPassword' has been removed. This was
   a property that was never available from the Azure API so was never accessible.
 * Use FunctionAppIdentity for packagedfunctionapp args
+* Set `FUNCTIONS_WORKER_RUNTIME` as part of `appservice.CallbackFunctionApp` and `appservice.MultiCallbackFunctionApp` -  [ #548 ]
 
 ---
 

--- a/sdk/nodejs/appservice/zMixins.ts
+++ b/sdk/nodejs/appservice/zMixins.ts
@@ -411,7 +411,7 @@ async function produceDeploymentArchiveAsync(args: MultiCallbackFunctionAppArgs)
 function combineFunctionAppSettings(args: MultiCallbackFunctionAppArgs): pulumi.Output<{ [key: string]: string }> {
     const applicationSetting = args.appSettings || {};
     const perFunctionSettings = args.functions !== undefined ? args.functions.map(c => c.appSettings || {}) : [];
-    return combineAppSettings([applicationSetting, ...perFunctionSettings]);
+    return combineAppSettings([{FUNCTIONS_WORKER_RUNTIME: "node"}, applicationSetting, ...perFunctionSettings]);
 }
 
 function redirectConsoleOutput<C extends Context<R>, E, R extends Result>(callback: Callback<C, E, R>) {


### PR DESCRIPTION
Fixes: #548