### PR TITLE
Avoid baking config from environment into checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ CHANGELOG
   **PLEASE NOTE:** `azure.mariaDb.getMariaDbServer` 'administratorLoginPassword' has been removed. This was
   a property that was never available from the Azure API so was never accessible.
 * Use FunctionAppIdentity for packagedfunctionapp args
-* Set `FUNCTIONS_WORKER_RUNTIME` as part of `appservice.CallbackFunctionApp` and `appservice.MultiCallbackFunctionApp` -  [ #548 ]
+* Set `FUNCTIONS_WORKER_RUNTIME` as part of `appservice.CallbackFunctionApp` and `appservice.MultiCallbackFunctionApp`
+  [#548](https://github.com/pulumi/pulumi-azure/pull/548)
+* Avoid storing config from the environment into the state
+  [#577](https://github.com/pulumi/pulumi-azure/pull/577)
 
 ---
 

--- a/provider/resource.go
+++ b/provider/resource.go
@@ -234,76 +234,16 @@ func Provider() tfbridge.ProviderInfo {
 					EnvVars: []string{"ARM_SUBSCRIPTION_ID"},
 				},
 			},
-			"client_id": {
-				Default: &tfbridge.DefaultInfo{
-					Value:   "",
-					EnvVars: []string{"AZURE_CLIENT_ID", "ARM_CLIENT_ID"},
-				},
-			},
-			"tenant_id": {
-				Default: &tfbridge.DefaultInfo{
-					Value:   cloudShell.tenantID,
-					EnvVars: []string{"AZURE_TENANT_ID", "ARM_TENANT_ID"},
-				},
-			},
 			"environment": {
 				Default: &tfbridge.DefaultInfo{
 					Value:   "public",
 					EnvVars: []string{"AZURE_ENVIRONMENT", "ARM_ENVIRONMENT"},
 				},
 			},
-			"client_certificate_password": {
-				Default: &tfbridge.DefaultInfo{
-					Value:   "",
-					EnvVars: []string{"AZURE_CLIENT_CERTIFICATE_PASSWORD", "ARM_CLIENT_CERTIFICATE_PASSWORD"},
-				},
-			},
-			"client_certificate_path": {
-				Default: &tfbridge.DefaultInfo{
-					Value:   "",
-					EnvVars: []string{"AZURE_CLIENT_CERTIFICATE_PATH", "ARM_CLIENT_CERTIFICATE_PATH"},
-				},
-			},
-			"client_secret": {
-				Default: &tfbridge.DefaultInfo{
-					Value:   "",
-					EnvVars: []string{"AZURE_CLIENT_SECRET", "ARM_CLIENT_SECRET"},
-				},
-			},
-			"partner_id": {
-				Default: &tfbridge.DefaultInfo{
-					Value:   "",
-					EnvVars: []string{"ARM_PARTNER_ID"},
-				},
-			},
-			"skip_credentials_validation": {
-				Default: &tfbridge.DefaultInfo{
-					Value:   false,
-					EnvVars: []string{"ARM_SKIP_CREDENTIALS_VALIDATION"},
-				},
-			},
 			"skip_provider_registration": {
 				Default: &tfbridge.DefaultInfo{
 					Value:   false,
 					EnvVars: []string{"ARM_SKIP_PROVIDER_REGISTRATION"},
-				},
-			},
-			"use_msi": {
-				Default: &tfbridge.DefaultInfo{
-					Value:   cloudShell.useMSI,
-					EnvVars: []string{"ARM_USE_MSI"},
-				},
-			},
-			"msi_endpoint": {
-				Default: &tfbridge.DefaultInfo{
-					Value:   cloudShell.msiEndpoint,
-					EnvVars: []string{"ARM_MSI_ENDPOINT"},
-				},
-			},
-			"disable_terraform_partner_id": {
-				Default: &tfbridge.DefaultInfo{
-					Value:   true,
-					EnvVars: []string{"ARM_DISABLE_TERRAFORM_PARTNER_ID"},
 				},
 			},
 			"storage_use_azuread": {

--- a/sdk/dotnet/Config/Config.cs
+++ b/sdk/dotnet/Config/Config.cs
@@ -14,23 +14,23 @@ namespace Pulumi.Azure
         /// The password associated with the Client Certificate. For use when authenticating as a Service Principal using a Client
         /// Certificate
         /// </summary>
-        public static string? ClientCertificatePassword { get; set; } = __config.Get("clientCertificatePassword") ?? Utilities.GetEnv("AZURE_CLIENT_CERTIFICATE_PASSWORD", "ARM_CLIENT_CERTIFICATE_PASSWORD") ?? "";
+        public static string? ClientCertificatePassword { get; set; } = __config.Get("clientCertificatePassword");
 
         /// <summary>
         /// The path to the Client Certificate associated with the Service Principal for use when authenticating as a Service
         /// Principal using a Client Certificate.
         /// </summary>
-        public static string? ClientCertificatePath { get; set; } = __config.Get("clientCertificatePath") ?? Utilities.GetEnv("AZURE_CLIENT_CERTIFICATE_PATH", "ARM_CLIENT_CERTIFICATE_PATH") ?? "";
+        public static string? ClientCertificatePath { get; set; } = __config.Get("clientCertificatePath");
 
         /// <summary>
         /// The Client ID which should be used.
         /// </summary>
-        public static string? ClientId { get; set; } = __config.Get("clientId") ?? Utilities.GetEnv("AZURE_CLIENT_ID", "ARM_CLIENT_ID") ?? "";
+        public static string? ClientId { get; set; } = __config.Get("clientId");
 
         /// <summary>
         /// The Client Secret which should be used. For use When authenticating as a Service Principal using a Client Secret.
         /// </summary>
-        public static string? ClientSecret { get; set; } = __config.Get("clientSecret") ?? Utilities.GetEnv("AZURE_CLIENT_SECRET", "ARM_CLIENT_SECRET") ?? "";
+        public static string? ClientSecret { get; set; } = __config.Get("clientSecret");
 
         /// <summary>
         /// This will disable the x-ms-correlation-request-id header.
@@ -40,7 +40,7 @@ namespace Pulumi.Azure
         /// <summary>
         /// This will disable the Terraform Partner ID which is used if a custom `partner_id` isn't specified.
         /// </summary>
-        public static bool? DisableTerraformPartnerId { get; set; } = __config.GetBoolean("disableTerraformPartnerId") ?? Utilities.GetEnvBoolean("ARM_DISABLE_TERRAFORM_PARTNER_ID") ?? true;
+        public static bool? DisableTerraformPartnerId { get; set; } = __config.GetBoolean("disableTerraformPartnerId");
 
         /// <summary>
         /// The Cloud Environment which should be used. Possible values are public, usgovernment, german, and china. Defaults to
@@ -56,17 +56,17 @@ namespace Pulumi.Azure
         /// The path to a custom endpoint for Managed Service Identity - in most circumstances this should be detected
         /// automatically.
         /// </summary>
-        public static string? MsiEndpoint { get; set; } = __config.Get("msiEndpoint") ?? Utilities.GetEnv("ARM_MSI_ENDPOINT") ?? "";
+        public static string? MsiEndpoint { get; set; } = __config.Get("msiEndpoint");
 
         /// <summary>
         /// A GUID/UUID that is registered with Microsoft to facilitate partner resource usage attribution.
         /// </summary>
-        public static string? PartnerId { get; set; } = __config.Get("partnerId") ?? Utilities.GetEnv("ARM_PARTNER_ID") ?? "";
+        public static string? PartnerId { get; set; } = __config.Get("partnerId");
 
         /// <summary>
         /// This will cause the AzureRM Provider to skip verifying the credentials being used are valid.
         /// </summary>
-        public static bool? SkipCredentialsValidation { get; set; } = __config.GetBoolean("skipCredentialsValidation") ?? Utilities.GetEnvBoolean("ARM_SKIP_CREDENTIALS_VALIDATION") ?? false;
+        public static bool? SkipCredentialsValidation { get; set; } = __config.GetBoolean("skipCredentialsValidation");
 
         /// <summary>
         /// Should the AzureRM Provider skip registering all of the Resource Providers that it supports, if they're not already
@@ -87,12 +87,12 @@ namespace Pulumi.Azure
         /// <summary>
         /// The Tenant ID which should be used.
         /// </summary>
-        public static string? TenantId { get; set; } = __config.Get("tenantId") ?? Utilities.GetEnv("AZURE_TENANT_ID", "ARM_TENANT_ID") ?? "";
+        public static string? TenantId { get; set; } = __config.Get("tenantId");
 
         /// <summary>
         /// Allowed Managed Service Identity be used for Authentication.
         /// </summary>
-        public static bool? UseMsi { get; set; } = __config.GetBoolean("useMsi") ?? Utilities.GetEnvBoolean("ARM_USE_MSI") ?? false;
+        public static bool? UseMsi { get; set; } = __config.GetBoolean("useMsi");
 
         public static class Types
         {

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -152,20 +152,10 @@ namespace Pulumi.Azure
 
         public ProviderArgs()
         {
-            ClientCertificatePassword = Utilities.GetEnv("AZURE_CLIENT_CERTIFICATE_PASSWORD", "ARM_CLIENT_CERTIFICATE_PASSWORD") ?? "";
-            ClientCertificatePath = Utilities.GetEnv("AZURE_CLIENT_CERTIFICATE_PATH", "ARM_CLIENT_CERTIFICATE_PATH") ?? "";
-            ClientId = Utilities.GetEnv("AZURE_CLIENT_ID", "ARM_CLIENT_ID") ?? "";
-            ClientSecret = Utilities.GetEnv("AZURE_CLIENT_SECRET", "ARM_CLIENT_SECRET") ?? "";
-            DisableTerraformPartnerId = Utilities.GetEnvBoolean("ARM_DISABLE_TERRAFORM_PARTNER_ID") ?? true;
             Environment = Utilities.GetEnv("AZURE_ENVIRONMENT", "ARM_ENVIRONMENT") ?? "public";
-            MsiEndpoint = Utilities.GetEnv("ARM_MSI_ENDPOINT") ?? "";
-            PartnerId = Utilities.GetEnv("ARM_PARTNER_ID") ?? "";
-            SkipCredentialsValidation = Utilities.GetEnvBoolean("ARM_SKIP_CREDENTIALS_VALIDATION") ?? false;
             SkipProviderRegistration = Utilities.GetEnvBoolean("ARM_SKIP_PROVIDER_REGISTRATION") ?? false;
             StorageUseAzuread = Utilities.GetEnvBoolean("ARM_STORAGE_USE_AZUREAD") ?? false;
             SubscriptionId = Utilities.GetEnv("ARM_SUBSCRIPTION_ID") ?? "";
-            TenantId = Utilities.GetEnv("AZURE_TENANT_ID", "ARM_TENANT_ID") ?? "";
-            UseMsi = Utilities.GetEnvBoolean("ARM_USE_MSI") ?? false;
         }
     }
 }

--- a/sdk/go/azure/config/config.go
+++ b/sdk/go/azure/config/config.go
@@ -15,39 +15,23 @@ func GetAuxiliaryTenantIds(ctx *pulumi.Context) string {
 // The password associated with the Client Certificate. For use when authenticating as a Service Principal using a Client
 // Certificate
 func GetClientCertificatePassword(ctx *pulumi.Context) string {
-	v, err := config.Try(ctx, "azure:clientCertificatePassword")
-	if err == nil {
-		return v
-	}
-	return getEnvOrDefault("", nil, "AZURE_CLIENT_CERTIFICATE_PASSWORD", "ARM_CLIENT_CERTIFICATE_PASSWORD").(string)
+	return config.Get(ctx, "azure:clientCertificatePassword")
 }
 
 // The path to the Client Certificate associated with the Service Principal for use when authenticating as a Service
 // Principal using a Client Certificate.
 func GetClientCertificatePath(ctx *pulumi.Context) string {
-	v, err := config.Try(ctx, "azure:clientCertificatePath")
-	if err == nil {
-		return v
-	}
-	return getEnvOrDefault("", nil, "AZURE_CLIENT_CERTIFICATE_PATH", "ARM_CLIENT_CERTIFICATE_PATH").(string)
+	return config.Get(ctx, "azure:clientCertificatePath")
 }
 
 // The Client ID which should be used.
 func GetClientId(ctx *pulumi.Context) string {
-	v, err := config.Try(ctx, "azure:clientId")
-	if err == nil {
-		return v
-	}
-	return getEnvOrDefault("", nil, "AZURE_CLIENT_ID", "ARM_CLIENT_ID").(string)
+	return config.Get(ctx, "azure:clientId")
 }
 
 // The Client Secret which should be used. For use When authenticating as a Service Principal using a Client Secret.
 func GetClientSecret(ctx *pulumi.Context) string {
-	v, err := config.Try(ctx, "azure:clientSecret")
-	if err == nil {
-		return v
-	}
-	return getEnvOrDefault("", nil, "AZURE_CLIENT_SECRET", "ARM_CLIENT_SECRET").(string)
+	return config.Get(ctx, "azure:clientSecret")
 }
 
 // This will disable the x-ms-correlation-request-id header.
@@ -57,11 +41,7 @@ func GetDisableCorrelationRequestId(ctx *pulumi.Context) bool {
 
 // This will disable the Terraform Partner ID which is used if a custom `partner_id` isn't specified.
 func GetDisableTerraformPartnerId(ctx *pulumi.Context) bool {
-	v, err := config.TryBool(ctx, "azure:disableTerraformPartnerId")
-	if err == nil {
-		return v
-	}
-	return getEnvOrDefault(true, parseEnvBool, "ARM_DISABLE_TERRAFORM_PARTNER_ID").(bool)
+	return config.GetBool(ctx, "azure:disableTerraformPartnerId")
 }
 
 // The Cloud Environment which should be used. Possible values are public, usgovernment, german, and china. Defaults to
@@ -87,29 +67,17 @@ func GetLocation(ctx *pulumi.Context) string {
 // The path to a custom endpoint for Managed Service Identity - in most circumstances this should be detected
 // automatically.
 func GetMsiEndpoint(ctx *pulumi.Context) string {
-	v, err := config.Try(ctx, "azure:msiEndpoint")
-	if err == nil {
-		return v
-	}
-	return getEnvOrDefault("", nil, "ARM_MSI_ENDPOINT").(string)
+	return config.Get(ctx, "azure:msiEndpoint")
 }
 
 // A GUID/UUID that is registered with Microsoft to facilitate partner resource usage attribution.
 func GetPartnerId(ctx *pulumi.Context) string {
-	v, err := config.Try(ctx, "azure:partnerId")
-	if err == nil {
-		return v
-	}
-	return getEnvOrDefault("", nil, "ARM_PARTNER_ID").(string)
+	return config.Get(ctx, "azure:partnerId")
 }
 
 // This will cause the AzureRM Provider to skip verifying the credentials being used are valid.
 func GetSkipCredentialsValidation(ctx *pulumi.Context) bool {
-	v, err := config.TryBool(ctx, "azure:skipCredentialsValidation")
-	if err == nil {
-		return v
-	}
-	return getEnvOrDefault(false, parseEnvBool, "ARM_SKIP_CREDENTIALS_VALIDATION").(bool)
+	return config.GetBool(ctx, "azure:skipCredentialsValidation")
 }
 
 // Should the AzureRM Provider skip registering all of the Resource Providers that it supports, if they're not already
@@ -142,18 +110,10 @@ func GetSubscriptionId(ctx *pulumi.Context) string {
 
 // The Tenant ID which should be used.
 func GetTenantId(ctx *pulumi.Context) string {
-	v, err := config.Try(ctx, "azure:tenantId")
-	if err == nil {
-		return v
-	}
-	return getEnvOrDefault("", nil, "AZURE_TENANT_ID", "ARM_TENANT_ID").(string)
+	return config.Get(ctx, "azure:tenantId")
 }
 
 // Allowed Managed Service Identity be used for Authentication.
 func GetUseMsi(ctx *pulumi.Context) bool {
-	v, err := config.TryBool(ctx, "azure:useMsi")
-	if err == nil {
-		return v
-	}
-	return getEnvOrDefault(false, parseEnvBool, "ARM_USE_MSI").(bool)
+	return config.GetBool(ctx, "azure:useMsi")
 }

--- a/sdk/go/azure/provider.go
+++ b/sdk/go/azure/provider.go
@@ -23,32 +23,8 @@ func NewProvider(ctx *pulumi.Context,
 	if args == nil {
 		args = &ProviderArgs{}
 	}
-	if args.ClientCertificatePassword == nil {
-		args.ClientCertificatePassword = pulumi.StringPtr(getEnvOrDefault("", nil, "AZURE_CLIENT_CERTIFICATE_PASSWORD", "ARM_CLIENT_CERTIFICATE_PASSWORD").(string))
-	}
-	if args.ClientCertificatePath == nil {
-		args.ClientCertificatePath = pulumi.StringPtr(getEnvOrDefault("", nil, "AZURE_CLIENT_CERTIFICATE_PATH", "ARM_CLIENT_CERTIFICATE_PATH").(string))
-	}
-	if args.ClientId == nil {
-		args.ClientId = pulumi.StringPtr(getEnvOrDefault("", nil, "AZURE_CLIENT_ID", "ARM_CLIENT_ID").(string))
-	}
-	if args.ClientSecret == nil {
-		args.ClientSecret = pulumi.StringPtr(getEnvOrDefault("", nil, "AZURE_CLIENT_SECRET", "ARM_CLIENT_SECRET").(string))
-	}
-	if args.DisableTerraformPartnerId == nil {
-		args.DisableTerraformPartnerId = pulumi.BoolPtr(getEnvOrDefault(true, parseEnvBool, "ARM_DISABLE_TERRAFORM_PARTNER_ID").(bool))
-	}
 	if args.Environment == nil {
 		args.Environment = pulumi.StringPtr(getEnvOrDefault("public", nil, "AZURE_ENVIRONMENT", "ARM_ENVIRONMENT").(string))
-	}
-	if args.MsiEndpoint == nil {
-		args.MsiEndpoint = pulumi.StringPtr(getEnvOrDefault("", nil, "ARM_MSI_ENDPOINT").(string))
-	}
-	if args.PartnerId == nil {
-		args.PartnerId = pulumi.StringPtr(getEnvOrDefault("", nil, "ARM_PARTNER_ID").(string))
-	}
-	if args.SkipCredentialsValidation == nil {
-		args.SkipCredentialsValidation = pulumi.BoolPtr(getEnvOrDefault(false, parseEnvBool, "ARM_SKIP_CREDENTIALS_VALIDATION").(bool))
 	}
 	if args.SkipProviderRegistration == nil {
 		args.SkipProviderRegistration = pulumi.BoolPtr(getEnvOrDefault(false, parseEnvBool, "ARM_SKIP_PROVIDER_REGISTRATION").(bool))
@@ -58,12 +34,6 @@ func NewProvider(ctx *pulumi.Context,
 	}
 	if args.SubscriptionId == nil {
 		args.SubscriptionId = pulumi.StringPtr(getEnvOrDefault("", nil, "ARM_SUBSCRIPTION_ID").(string))
-	}
-	if args.TenantId == nil {
-		args.TenantId = pulumi.StringPtr(getEnvOrDefault("", nil, "AZURE_TENANT_ID", "ARM_TENANT_ID").(string))
-	}
-	if args.UseMsi == nil {
-		args.UseMsi = pulumi.BoolPtr(getEnvOrDefault(false, parseEnvBool, "ARM_USE_MSI").(bool))
 	}
 	var resource Provider
 	err := ctx.RegisterResource("pulumi:providers:azure", name, args, &resource, opts...)

--- a/sdk/nodejs/config/vars.ts
+++ b/sdk/nodejs/config/vars.ts
@@ -11,20 +11,20 @@ export let auxiliaryTenantIds: string[] | undefined = __config.getObject<string[
  * The password associated with the Client Certificate. For use when authenticating as a Service Principal using a Client
  * Certificate
  */
-export let clientCertificatePassword: string | undefined = __config.get("clientCertificatePassword") || (utilities.getEnv("AZURE_CLIENT_CERTIFICATE_PASSWORD", "ARM_CLIENT_CERTIFICATE_PASSWORD") || "");
+export let clientCertificatePassword: string | undefined = __config.get("clientCertificatePassword");
 /**
  * The path to the Client Certificate associated with the Service Principal for use when authenticating as a Service
  * Principal using a Client Certificate.
  */
-export let clientCertificatePath: string | undefined = __config.get("clientCertificatePath") || (utilities.getEnv("AZURE_CLIENT_CERTIFICATE_PATH", "ARM_CLIENT_CERTIFICATE_PATH") || "");
+export let clientCertificatePath: string | undefined = __config.get("clientCertificatePath");
 /**
  * The Client ID which should be used.
  */
-export let clientId: string | undefined = __config.get("clientId") || (utilities.getEnv("AZURE_CLIENT_ID", "ARM_CLIENT_ID") || "");
+export let clientId: string | undefined = __config.get("clientId");
 /**
  * The Client Secret which should be used. For use When authenticating as a Service Principal using a Client Secret.
  */
-export let clientSecret: string | undefined = __config.get("clientSecret") || (utilities.getEnv("AZURE_CLIENT_SECRET", "ARM_CLIENT_SECRET") || "");
+export let clientSecret: string | undefined = __config.get("clientSecret");
 /**
  * This will disable the x-ms-correlation-request-id header.
  */
@@ -32,7 +32,7 @@ export let disableCorrelationRequestId: boolean | undefined = __config.getObject
 /**
  * This will disable the Terraform Partner ID which is used if a custom `partner_id` isn't specified.
  */
-export let disableTerraformPartnerId: boolean | undefined = __config.getObject<boolean>("disableTerraformPartnerId") || (utilities.getEnvBoolean("ARM_DISABLE_TERRAFORM_PARTNER_ID") || true);
+export let disableTerraformPartnerId: boolean | undefined = __config.getObject<boolean>("disableTerraformPartnerId");
 /**
  * The Cloud Environment which should be used. Possible values are public, usgovernment, german, and china. Defaults to
  * public.
@@ -43,15 +43,15 @@ export let features: { keyVault?: { purgeSoftDeleteOnDestroy?: boolean, recoverS
  * The path to a custom endpoint for Managed Service Identity - in most circumstances this should be detected
  * automatically.
  */
-export let msiEndpoint: string | undefined = __config.get("msiEndpoint") || (utilities.getEnv("ARM_MSI_ENDPOINT") || "");
+export let msiEndpoint: string | undefined = __config.get("msiEndpoint");
 /**
  * A GUID/UUID that is registered with Microsoft to facilitate partner resource usage attribution.
  */
-export let partnerId: string | undefined = __config.get("partnerId") || (utilities.getEnv("ARM_PARTNER_ID") || "");
+export let partnerId: string | undefined = __config.get("partnerId");
 /**
  * This will cause the AzureRM Provider to skip verifying the credentials being used are valid.
  */
-export let skipCredentialsValidation: boolean | undefined = __config.getObject<boolean>("skipCredentialsValidation") || (utilities.getEnvBoolean("ARM_SKIP_CREDENTIALS_VALIDATION") || false);
+export let skipCredentialsValidation: boolean | undefined = __config.getObject<boolean>("skipCredentialsValidation");
 /**
  * Should the AzureRM Provider skip registering all of the Resource Providers that it supports, if they're not already
  * registered?
@@ -68,9 +68,9 @@ export let subscriptionId: string | undefined = __config.get("subscriptionId") |
 /**
  * The Tenant ID which should be used.
  */
-export let tenantId: string | undefined = __config.get("tenantId") || (utilities.getEnv("AZURE_TENANT_ID", "ARM_TENANT_ID") || "");
+export let tenantId: string | undefined = __config.get("tenantId");
 /**
  * Allowed Managed Service Identity be used for Authentication.
  */
-export let useMsi: boolean | undefined = __config.getObject<boolean>("useMsi") || (utilities.getEnvBoolean("ARM_USE_MSI") || false);
+export let useMsi: boolean | undefined = __config.getObject<boolean>("useMsi");
 export let location: string | undefined = __config.get("location") || utilities.getEnv("ARM_LOCATION");

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -38,22 +38,22 @@ export class Provider extends pulumi.ProviderResource {
         let inputs: pulumi.Inputs = {};
         {
             inputs["auxiliaryTenantIds"] = pulumi.output(args ? args.auxiliaryTenantIds : undefined).apply(JSON.stringify);
-            inputs["clientCertificatePassword"] = (args ? args.clientCertificatePassword : undefined) || (utilities.getEnv("AZURE_CLIENT_CERTIFICATE_PASSWORD", "ARM_CLIENT_CERTIFICATE_PASSWORD") || "");
-            inputs["clientCertificatePath"] = (args ? args.clientCertificatePath : undefined) || (utilities.getEnv("AZURE_CLIENT_CERTIFICATE_PATH", "ARM_CLIENT_CERTIFICATE_PATH") || "");
-            inputs["clientId"] = (args ? args.clientId : undefined) || (utilities.getEnv("AZURE_CLIENT_ID", "ARM_CLIENT_ID") || "");
-            inputs["clientSecret"] = (args ? args.clientSecret : undefined) || (utilities.getEnv("AZURE_CLIENT_SECRET", "ARM_CLIENT_SECRET") || "");
+            inputs["clientCertificatePassword"] = args ? args.clientCertificatePassword : undefined;
+            inputs["clientCertificatePath"] = args ? args.clientCertificatePath : undefined;
+            inputs["clientId"] = args ? args.clientId : undefined;
+            inputs["clientSecret"] = args ? args.clientSecret : undefined;
             inputs["disableCorrelationRequestId"] = pulumi.output(args ? args.disableCorrelationRequestId : undefined).apply(JSON.stringify);
-            inputs["disableTerraformPartnerId"] = pulumi.output((args ? args.disableTerraformPartnerId : undefined) || (utilities.getEnvBoolean("ARM_DISABLE_TERRAFORM_PARTNER_ID") || true)).apply(JSON.stringify);
+            inputs["disableTerraformPartnerId"] = pulumi.output(args ? args.disableTerraformPartnerId : undefined).apply(JSON.stringify);
             inputs["environment"] = (args ? args.environment : undefined) || (utilities.getEnv("AZURE_ENVIRONMENT", "ARM_ENVIRONMENT") || "public");
             inputs["features"] = pulumi.output(args ? args.features : undefined).apply(JSON.stringify);
-            inputs["msiEndpoint"] = (args ? args.msiEndpoint : undefined) || (utilities.getEnv("ARM_MSI_ENDPOINT") || "");
-            inputs["partnerId"] = (args ? args.partnerId : undefined) || (utilities.getEnv("ARM_PARTNER_ID") || "");
-            inputs["skipCredentialsValidation"] = pulumi.output((args ? args.skipCredentialsValidation : undefined) || (utilities.getEnvBoolean("ARM_SKIP_CREDENTIALS_VALIDATION") || false)).apply(JSON.stringify);
+            inputs["msiEndpoint"] = args ? args.msiEndpoint : undefined;
+            inputs["partnerId"] = args ? args.partnerId : undefined;
+            inputs["skipCredentialsValidation"] = pulumi.output(args ? args.skipCredentialsValidation : undefined).apply(JSON.stringify);
             inputs["skipProviderRegistration"] = pulumi.output((args ? args.skipProviderRegistration : undefined) || (utilities.getEnvBoolean("ARM_SKIP_PROVIDER_REGISTRATION") || false)).apply(JSON.stringify);
             inputs["storageUseAzuread"] = pulumi.output((args ? args.storageUseAzuread : undefined) || (utilities.getEnvBoolean("ARM_STORAGE_USE_AZUREAD") || false)).apply(JSON.stringify);
             inputs["subscriptionId"] = (args ? args.subscriptionId : undefined) || (utilities.getEnv("ARM_SUBSCRIPTION_ID") || "");
-            inputs["tenantId"] = (args ? args.tenantId : undefined) || (utilities.getEnv("AZURE_TENANT_ID", "ARM_TENANT_ID") || "");
-            inputs["useMsi"] = pulumi.output((args ? args.useMsi : undefined) || (utilities.getEnvBoolean("ARM_USE_MSI") || false)).apply(JSON.stringify);
+            inputs["tenantId"] = args ? args.tenantId : undefined;
+            inputs["useMsi"] = pulumi.output(args ? args.useMsi : undefined).apply(JSON.stringify);
         }
         if (!opts) {
             opts = {}

--- a/sdk/python/pulumi_azure/config/vars.py
+++ b/sdk/python/pulumi_azure/config/vars.py
@@ -13,24 +13,24 @@ __config__ = pulumi.Config('azure')
 
 auxiliary_tenant_ids = __config__.get('auxiliaryTenantIds')
 
-client_certificate_password = __config__.get('clientCertificatePassword') or (utilities.get_env('AZURE_CLIENT_CERTIFICATE_PASSWORD', 'ARM_CLIENT_CERTIFICATE_PASSWORD') or '')
+client_certificate_password = __config__.get('clientCertificatePassword')
 """
 The password associated with the Client Certificate. For use when authenticating as a Service Principal using a Client
 Certificate
 """
 
-client_certificate_path = __config__.get('clientCertificatePath') or (utilities.get_env('AZURE_CLIENT_CERTIFICATE_PATH', 'ARM_CLIENT_CERTIFICATE_PATH') or '')
+client_certificate_path = __config__.get('clientCertificatePath')
 """
 The path to the Client Certificate associated with the Service Principal for use when authenticating as a Service
 Principal using a Client Certificate.
 """
 
-client_id = __config__.get('clientId') or (utilities.get_env('AZURE_CLIENT_ID', 'ARM_CLIENT_ID') or '')
+client_id = __config__.get('clientId')
 """
 The Client ID which should be used.
 """
 
-client_secret = __config__.get('clientSecret') or (utilities.get_env('AZURE_CLIENT_SECRET', 'ARM_CLIENT_SECRET') or '')
+client_secret = __config__.get('clientSecret')
 """
 The Client Secret which should be used. For use When authenticating as a Service Principal using a Client Secret.
 """
@@ -40,7 +40,7 @@ disable_correlation_request_id = __config__.get('disableCorrelationRequestId')
 This will disable the x-ms-correlation-request-id header.
 """
 
-disable_terraform_partner_id = __config__.get('disableTerraformPartnerId') or (utilities.get_env_bool('ARM_DISABLE_TERRAFORM_PARTNER_ID') or True)
+disable_terraform_partner_id = __config__.get('disableTerraformPartnerId')
 """
 This will disable the Terraform Partner ID which is used if a custom `partner_id` isn't specified.
 """
@@ -55,18 +55,18 @@ features = __config__.get('features')
 
 location = __config__.get('location') or utilities.get_env('ARM_LOCATION')
 
-msi_endpoint = __config__.get('msiEndpoint') or (utilities.get_env('ARM_MSI_ENDPOINT') or '')
+msi_endpoint = __config__.get('msiEndpoint')
 """
 The path to a custom endpoint for Managed Service Identity - in most circumstances this should be detected
 automatically.
 """
 
-partner_id = __config__.get('partnerId') or (utilities.get_env('ARM_PARTNER_ID') or '')
+partner_id = __config__.get('partnerId')
 """
 A GUID/UUID that is registered with Microsoft to facilitate partner resource usage attribution.
 """
 
-skip_credentials_validation = __config__.get('skipCredentialsValidation') or (utilities.get_env_bool('ARM_SKIP_CREDENTIALS_VALIDATION') or False)
+skip_credentials_validation = __config__.get('skipCredentialsValidation')
 """
 This will cause the AzureRM Provider to skip verifying the credentials being used are valid.
 """
@@ -87,12 +87,12 @@ subscription_id = __config__.get('subscriptionId') or (utilities.get_env('ARM_SU
 The Subscription ID which should be used.
 """
 
-tenant_id = __config__.get('tenantId') or (utilities.get_env('AZURE_TENANT_ID', 'ARM_TENANT_ID') or '')
+tenant_id = __config__.get('tenantId')
 """
 The Tenant ID which should be used.
 """
 
-use_msi = __config__.get('useMsi') or (utilities.get_env_bool('ARM_USE_MSI') or False)
+use_msi = __config__.get('useMsi')
 """
 Allowed Managed Service Identity be used for Authentication.
 """

--- a/sdk/python/pulumi_azure/provider.py
+++ b/sdk/python/pulumi_azure/provider.py
@@ -70,34 +70,18 @@ class Provider(pulumi.ProviderResource):
             __props__ = dict()
 
             __props__['auxiliary_tenant_ids'] = pulumi.Output.from_input(auxiliary_tenant_ids).apply(json.dumps) if auxiliary_tenant_ids is not None else None
-            if client_certificate_password is None:
-                client_certificate_password = (utilities.get_env('AZURE_CLIENT_CERTIFICATE_PASSWORD', 'ARM_CLIENT_CERTIFICATE_PASSWORD') or '')
             __props__['client_certificate_password'] = client_certificate_password
-            if client_certificate_path is None:
-                client_certificate_path = (utilities.get_env('AZURE_CLIENT_CERTIFICATE_PATH', 'ARM_CLIENT_CERTIFICATE_PATH') or '')
             __props__['client_certificate_path'] = client_certificate_path
-            if client_id is None:
-                client_id = (utilities.get_env('AZURE_CLIENT_ID', 'ARM_CLIENT_ID') or '')
             __props__['client_id'] = client_id
-            if client_secret is None:
-                client_secret = (utilities.get_env('AZURE_CLIENT_SECRET', 'ARM_CLIENT_SECRET') or '')
             __props__['client_secret'] = client_secret
             __props__['disable_correlation_request_id'] = pulumi.Output.from_input(disable_correlation_request_id).apply(json.dumps) if disable_correlation_request_id is not None else None
-            if disable_terraform_partner_id is None:
-                disable_terraform_partner_id = (utilities.get_env_bool('ARM_DISABLE_TERRAFORM_PARTNER_ID') or True)
             __props__['disable_terraform_partner_id'] = pulumi.Output.from_input(disable_terraform_partner_id).apply(json.dumps) if disable_terraform_partner_id is not None else None
             if environment is None:
                 environment = (utilities.get_env('AZURE_ENVIRONMENT', 'ARM_ENVIRONMENT') or 'public')
             __props__['environment'] = environment
             __props__['features'] = pulumi.Output.from_input(features).apply(json.dumps) if features is not None else None
-            if msi_endpoint is None:
-                msi_endpoint = (utilities.get_env('ARM_MSI_ENDPOINT') or '')
             __props__['msi_endpoint'] = msi_endpoint
-            if partner_id is None:
-                partner_id = (utilities.get_env('ARM_PARTNER_ID') or '')
             __props__['partner_id'] = partner_id
-            if skip_credentials_validation is None:
-                skip_credentials_validation = (utilities.get_env_bool('ARM_SKIP_CREDENTIALS_VALIDATION') or False)
             __props__['skip_credentials_validation'] = pulumi.Output.from_input(skip_credentials_validation).apply(json.dumps) if skip_credentials_validation is not None else None
             if skip_provider_registration is None:
                 skip_provider_registration = (utilities.get_env_bool('ARM_SKIP_PROVIDER_REGISTRATION') or False)
@@ -108,11 +92,7 @@ class Provider(pulumi.ProviderResource):
             if subscription_id is None:
                 subscription_id = (utilities.get_env('ARM_SUBSCRIPTION_ID') or '')
             __props__['subscription_id'] = subscription_id
-            if tenant_id is None:
-                tenant_id = (utilities.get_env('AZURE_TENANT_ID', 'ARM_TENANT_ID') or '')
             __props__['tenant_id'] = tenant_id
-            if use_msi is None:
-                use_msi = (utilities.get_env_bool('ARM_USE_MSI') or False)
             __props__['use_msi'] = pulumi.Output.from_input(use_msi).apply(json.dumps) if use_msi is not None else None
         super(Provider, __self__).__init__(
             'azure',


### PR DESCRIPTION
Like in https://github.com/pulumi/pulumi-aws/pull/894, we will avoid baking any provider configuration from environment variables into the checkpoint file for any potentially transient configuration (like credentials) that is not part of the "identity" of the provider.

This notion is still a little loosely defined, and will be more precisely defined for each provider as part of https://github.com/pulumi/pulumi-terraform-bridge/issues/14.  For now though, there is no reason to include these, and indeed they can lead to (a) leaking of sensitive data from the environment into the state file and (b) storing invalid (expired) data in the checkpoint which unintentionally gets used for future destroy/refresh operations.

Fixes #576.