### PR TITLE
Remove the use of `OverlayInfo.Files`.

### DIFF
--- a/provider/resource.go
+++ b/provider/resource.go
@@ -1503,7 +1503,6 @@ func Provider() tfbridge.ProviderInfo {
 				"moment":                        "2.24.0",
 			},
 			Overlay: &tfbridge.OverlayInfo{
-				Files: []string{},
 				DestFiles: []string{
 					"location.ts",
 					"util.ts",


### PR DESCRIPTION
This property has been removed in the latest bridge. No functional change.

