### PR TITLE
Do not install the Azure provider.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ tfgen::
 
 install_plugins::
 	[ -x "$(shell which pulumi)" ] || curl -fsSL https://get.pulumi.com | sh
-	pulumi plugin install resource $(PACK) 3.9.0
 	pulumi plugin install resource random 2.1.0
 	pulumi plugin install resource azuread 2.1.0
 


### PR DESCRIPTION
This is no longer necessary for example conversion.