### PR TITLE
Relax naming conventions for APIManagement API name to allow 256 character names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Relax naming restrictions on `apimanagement.Api` name to allow 256 character names
+  as per https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftapimanagement
 
 ---
 

--- a/provider/resource.go
+++ b/provider/resource.go
@@ -299,7 +299,18 @@ func Provider() tfbridge.ProviderInfo {
 					}),
 				},
 			},
-			"azurerm_api_management_api":                         {Tok: azureResource(azureAPIManagement, "Api")},
+			"azurerm_api_management_api": {
+				Tok: azureResource(azureAPIManagement, "Api"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					// Max length of an API Management API name is 256.
+					// Source: https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftapimanagement
+					azureName: tfbridge.AutoNameWithCustomOptions(azureName, tfbridge.AutoNameOptions{
+						Separator: "",
+						Maxlen:    256,
+						Randlen:   8,
+					}),
+				},
+			},
 			"azurerm_api_management_api_operation":               {Tok: azureResource(azureAPIManagement, "ApiOperation")},
 			"azurerm_api_management_api_operation_policy":        {Tok: azureResource(azureAPIManagement, "ApiOperationPolicy")},
 			"azurerm_api_management_api_policy":                  {Tok: azureResource(azureAPIManagement, "ApiPolicy")},


### PR DESCRIPTION
Fixes: #644