### PR TITLE
Disable autonaming for 'mysql.Configuration', 'mariadb.Configuration' and 'postgres.Configuration'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Disable autonaming for `mysql.Configuration`, `mariadb.Configuration` and `postgres.Configuration` as the resource
+  names need to relate to validate database configuration names.
 
 ---
 

--- a/provider/resource.go
+++ b/provider/resource.go
@@ -902,7 +902,12 @@ func Provider() tfbridge.ProviderInfo {
 			},
 
 			// MariaDB
-			"azurerm_mariadb_configuration":        {Tok: azureResource(azureMariaDB, "Configuration")},
+			"azurerm_mariadb_configuration": {
+				Tok: azureResource(azureMariaDB, "Configuration"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"name": {Name: "name"},
+				},
+			},
 			"azurerm_mariadb_database":             {Tok: azureResource(azureMariaDB, "Database")},
 			"azurerm_mariadb_firewall_rule":        {Tok: azureResource(azureMariaDB, "FirewallRule")},
 			"azurerm_mariadb_server":               {Tok: azureResource(azureMariaDB, "Server")},
@@ -1014,7 +1019,12 @@ func Provider() tfbridge.ProviderInfo {
 			"azurerm_mssql_server_extended_auditing_policy":   {Tok: azureResource(azureMSSQL, "ServerExtendedAuditingPolicy")},
 
 			// MySQL
-			"azurerm_mysql_configuration":        {Tok: azureResource(azureMySQL, "Configuration")},
+			"azurerm_mysql_configuration": {
+				Tok: azureResource(azureMySQL, "Configuration"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"name": {Name: "name"},
+				},
+			},
 			"azurerm_mysql_database":             {Tok: azureResource(azureMySQL, "Database")},
 			"azurerm_mysql_firewall_rule":        {Tok: azureResource(azureMySQL, "FirewallRule")},
 			"azurerm_mysql_server":               {Tok: azureResource(azureMySQL, "Server")},
@@ -1025,7 +1035,12 @@ func Provider() tfbridge.ProviderInfo {
 			},
 
 			// Postgress SQL
-			"azurerm_postgresql_configuration":        {Tok: azureResource(azurePostgresql, "Configuration")},
+			"azurerm_postgresql_configuration": {
+				Tok: azureResource(azurePostgresql, "Configuration"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"name": {Name: "name"},
+				},
+			},
 			"azurerm_postgresql_database":             {Tok: azureResource(azurePostgresql, "Database")},
 			"azurerm_postgresql_firewall_rule":        {Tok: azureResource(azurePostgresql, "FirewallRule")},
 			"azurerm_postgresql_server":               {Tok: azureResource(azurePostgresql, "Server")},

--- a/sdk/dotnet/MariaDB/Configuration.cs
+++ b/sdk/dotnet/MariaDB/Configuration.cs
@@ -44,6 +44,7 @@ namespace Pulumi.Azure.MariaDB
     ///         });
     ///         var exampleConfiguration = new Azure.MariaDB.Configuration("exampleConfiguration", new Azure.MariaDB.ConfigurationArgs
     ///         {
+    ///             Name = "interactive_timeout",
     ///             ResourceGroupName = exampleResourceGroup.Name,
     ///             ServerName = exampleServer.Name,
     ///             Value = "600",
@@ -128,8 +129,8 @@ namespace Pulumi.Azure.MariaDB
         /// <summary>
         /// Specifies the name of the MariaDB Configuration, which needs [to be a valid MariaDB configuration name](https://mariadb.com/kb/en/library/server-system-variables/). Changing this forces a new resource to be created.
         /// </summary>
-        [Input("name")]
-        public Input<string>? Name { get; set; }
+        [Input("name", required: true)]
+        public Input<string> Name { get; set; } = null!;
 
         /// <summary>
         /// The name of the resource group in which the MariaDB Server exists. Changing this forces a new resource to be created.

--- a/sdk/dotnet/MySql/Configuration.cs
+++ b/sdk/dotnet/MySql/Configuration.cs
@@ -49,6 +49,7 @@ namespace Pulumi.Azure.MySql
     ///         });
     ///         var exampleConfiguration = new Azure.MySql.Configuration("exampleConfiguration", new Azure.MySql.ConfigurationArgs
     ///         {
+    ///             Name = "interactive_timeout",
     ///             ResourceGroupName = exampleResourceGroup.Name,
     ///             ServerName = exampleServer.Name,
     ///             Value = "600",
@@ -133,8 +134,8 @@ namespace Pulumi.Azure.MySql
         /// <summary>
         /// Specifies the name of the MySQL Configuration, which needs [to be a valid MySQL configuration name](https://dev.mysql.com/doc/refman/5.7/en/server-configuration.html). Changing this forces a new resource to be created.
         /// </summary>
-        [Input("name")]
-        public Input<string>? Name { get; set; }
+        [Input("name", required: true)]
+        public Input<string> Name { get; set; } = null!;
 
         /// <summary>
         /// The name of the resource group in which the MySQL Server exists. Changing this forces a new resource to be created.

--- a/sdk/dotnet/PostgreSql/Configuration.cs
+++ b/sdk/dotnet/PostgreSql/Configuration.cs
@@ -46,6 +46,7 @@ namespace Pulumi.Azure.PostgreSql
     ///         });
     ///         var exampleConfiguration = new Azure.PostgreSql.Configuration("exampleConfiguration", new Azure.PostgreSql.ConfigurationArgs
     ///         {
+    ///             Name = "backslash_quote",
     ///             ResourceGroupName = exampleResourceGroup.Name,
     ///             ServerName = exampleServer.Name,
     ///             Value = "on",
@@ -130,8 +131,8 @@ namespace Pulumi.Azure.PostgreSql
         /// <summary>
         /// Specifies the name of the PostgreSQL Configuration, which needs [to be a valid PostgreSQL configuration name](https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIER). Changing this forces a new resource to be created.
         /// </summary>
-        [Input("name")]
-        public Input<string>? Name { get; set; }
+        [Input("name", required: true)]
+        public Input<string> Name { get; set; } = null!;
 
         /// <summary>
         /// The name of the resource group in which the PostgreSQL Server exists. Changing this forces a new resource to be created.

--- a/sdk/go/azure/mariadb/configuration.go
+++ b/sdk/go/azure/mariadb/configuration.go
@@ -49,6 +49,7 @@ import (
 // 			return err
 // 		}
 // 		_, err = mariadb.NewConfiguration(ctx, "exampleConfiguration", &mariadb.ConfigurationArgs{
+// 			Name:              pulumi.String("interactive_timeout"),
 // 			ResourceGroupName: exampleResourceGroup.Name,
 // 			ServerName:        exampleServer.Name,
 // 			Value:             pulumi.String("600"),
@@ -76,6 +77,9 @@ type Configuration struct {
 // NewConfiguration registers a new resource with the given unique name, arguments, and options.
 func NewConfiguration(ctx *pulumi.Context,
 	name string, args *ConfigurationArgs, opts ...pulumi.ResourceOption) (*Configuration, error) {
+	if args == nil || args.Name == nil {
+		return nil, errors.New("missing required argument 'Name'")
+	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}
@@ -137,7 +141,7 @@ func (ConfigurationState) ElementType() reflect.Type {
 
 type configurationArgs struct {
 	// Specifies the name of the MariaDB Configuration, which needs [to be a valid MariaDB configuration name](https://mariadb.com/kb/en/library/server-system-variables/). Changing this forces a new resource to be created.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// The name of the resource group in which the MariaDB Server exists. Changing this forces a new resource to be created.
 	ResourceGroupName string `pulumi:"resourceGroupName"`
 	// Specifies the name of the MariaDB Server. Changing this forces a new resource to be created.
@@ -149,7 +153,7 @@ type configurationArgs struct {
 // The set of arguments for constructing a Configuration resource.
 type ConfigurationArgs struct {
 	// Specifies the name of the MariaDB Configuration, which needs [to be a valid MariaDB configuration name](https://mariadb.com/kb/en/library/server-system-variables/). Changing this forces a new resource to be created.
-	Name pulumi.StringPtrInput
+	Name pulumi.StringInput
 	// The name of the resource group in which the MariaDB Server exists. Changing this forces a new resource to be created.
 	ResourceGroupName pulumi.StringInput
 	// Specifies the name of the MariaDB Server. Changing this forces a new resource to be created.

--- a/sdk/go/azure/mysql/configuration.go
+++ b/sdk/go/azure/mysql/configuration.go
@@ -55,6 +55,7 @@ import (
 // 			return err
 // 		}
 // 		_, err = mysql.NewConfiguration(ctx, "exampleConfiguration", &mysql.ConfigurationArgs{
+// 			Name:              pulumi.String("interactive_timeout"),
 // 			ResourceGroupName: exampleResourceGroup.Name,
 // 			ServerName:        exampleServer.Name,
 // 			Value:             pulumi.String("600"),
@@ -82,6 +83,9 @@ type Configuration struct {
 // NewConfiguration registers a new resource with the given unique name, arguments, and options.
 func NewConfiguration(ctx *pulumi.Context,
 	name string, args *ConfigurationArgs, opts ...pulumi.ResourceOption) (*Configuration, error) {
+	if args == nil || args.Name == nil {
+		return nil, errors.New("missing required argument 'Name'")
+	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}
@@ -143,7 +147,7 @@ func (ConfigurationState) ElementType() reflect.Type {
 
 type configurationArgs struct {
 	// Specifies the name of the MySQL Configuration, which needs [to be a valid MySQL configuration name](https://dev.mysql.com/doc/refman/5.7/en/server-configuration.html). Changing this forces a new resource to be created.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// The name of the resource group in which the MySQL Server exists. Changing this forces a new resource to be created.
 	ResourceGroupName string `pulumi:"resourceGroupName"`
 	// Specifies the name of the MySQL Server. Changing this forces a new resource to be created.
@@ -155,7 +159,7 @@ type configurationArgs struct {
 // The set of arguments for constructing a Configuration resource.
 type ConfigurationArgs struct {
 	// Specifies the name of the MySQL Configuration, which needs [to be a valid MySQL configuration name](https://dev.mysql.com/doc/refman/5.7/en/server-configuration.html). Changing this forces a new resource to be created.
-	Name pulumi.StringPtrInput
+	Name pulumi.StringInput
 	// The name of the resource group in which the MySQL Server exists. Changing this forces a new resource to be created.
 	ResourceGroupName pulumi.StringInput
 	// Specifies the name of the MySQL Server. Changing this forces a new resource to be created.

--- a/sdk/go/azure/postgresql/configuration.go
+++ b/sdk/go/azure/postgresql/configuration.go
@@ -52,6 +52,7 @@ import (
 // 			return err
 // 		}
 // 		_, err = postgresql.NewConfiguration(ctx, "exampleConfiguration", &postgresql.ConfigurationArgs{
+// 			Name:              pulumi.String("backslash_quote"),
 // 			ResourceGroupName: exampleResourceGroup.Name,
 // 			ServerName:        exampleServer.Name,
 // 			Value:             pulumi.String("on"),
@@ -79,6 +80,9 @@ type Configuration struct {
 // NewConfiguration registers a new resource with the given unique name, arguments, and options.
 func NewConfiguration(ctx *pulumi.Context,
 	name string, args *ConfigurationArgs, opts ...pulumi.ResourceOption) (*Configuration, error) {
+	if args == nil || args.Name == nil {
+		return nil, errors.New("missing required argument 'Name'")
+	}
 	if args == nil || args.ResourceGroupName == nil {
 		return nil, errors.New("missing required argument 'ResourceGroupName'")
 	}
@@ -140,7 +144,7 @@ func (ConfigurationState) ElementType() reflect.Type {
 
 type configurationArgs struct {
 	// Specifies the name of the PostgreSQL Configuration, which needs [to be a valid PostgreSQL configuration name](https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIER). Changing this forces a new resource to be created.
-	Name *string `pulumi:"name"`
+	Name string `pulumi:"name"`
 	// The name of the resource group in which the PostgreSQL Server exists. Changing this forces a new resource to be created.
 	ResourceGroupName string `pulumi:"resourceGroupName"`
 	// Specifies the name of the PostgreSQL Server. Changing this forces a new resource to be created.
@@ -152,7 +156,7 @@ type configurationArgs struct {
 // The set of arguments for constructing a Configuration resource.
 type ConfigurationArgs struct {
 	// Specifies the name of the PostgreSQL Configuration, which needs [to be a valid PostgreSQL configuration name](https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIER). Changing this forces a new resource to be created.
-	Name pulumi.StringPtrInput
+	Name pulumi.StringInput
 	// The name of the resource group in which the PostgreSQL Server exists. Changing this forces a new resource to be created.
 	ResourceGroupName pulumi.StringInput
 	// Specifies the name of the PostgreSQL Server. Changing this forces a new resource to be created.

--- a/sdk/nodejs/mariadb/configuration.ts
+++ b/sdk/nodejs/mariadb/configuration.ts
@@ -29,6 +29,7 @@ import * as utilities from "../utilities";
  *     sslEnforcement: "Enabled",
  * });
  * const exampleConfiguration = new azure.mariadb.Configuration("exampleConfiguration", {
+ *     name: "interactive_timeout",
  *     resourceGroupName: exampleResourceGroup.name,
  *     serverName: exampleServer.name,
  *     value: "600",
@@ -98,6 +99,9 @@ export class Configuration extends pulumi.CustomResource {
             inputs["value"] = state ? state.value : undefined;
         } else {
             const args = argsOrState as ConfigurationArgs | undefined;
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
+            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -152,7 +156,7 @@ export interface ConfigurationArgs {
     /**
      * Specifies the name of the MariaDB Configuration, which needs [to be a valid MariaDB configuration name](https://mariadb.com/kb/en/library/server-system-variables/). Changing this forces a new resource to be created.
      */
-    readonly name?: pulumi.Input<string>;
+    readonly name: pulumi.Input<string>;
     /**
      * The name of the resource group in which the MariaDB Server exists. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/mysql/configuration.ts
+++ b/sdk/nodejs/mysql/configuration.ts
@@ -35,6 +35,7 @@ import * as utilities from "../utilities";
  *     sslMinimalTlsVersionEnforced: "TLS1_2",
  * });
  * const exampleConfiguration = new azure.mysql.Configuration("exampleConfiguration", {
+ *     name: "interactive_timeout",
  *     resourceGroupName: exampleResourceGroup.name,
  *     serverName: exampleServer.name,
  *     value: "600",
@@ -104,6 +105,9 @@ export class Configuration extends pulumi.CustomResource {
             inputs["value"] = state ? state.value : undefined;
         } else {
             const args = argsOrState as ConfigurationArgs | undefined;
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
+            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -158,7 +162,7 @@ export interface ConfigurationArgs {
     /**
      * Specifies the name of the MySQL Configuration, which needs [to be a valid MySQL configuration name](https://dev.mysql.com/doc/refman/5.7/en/server-configuration.html). Changing this forces a new resource to be created.
      */
-    readonly name?: pulumi.Input<string>;
+    readonly name: pulumi.Input<string>;
     /**
      * The name of the resource group in which the MySQL Server exists. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/postgresql/configuration.ts
+++ b/sdk/nodejs/postgresql/configuration.ts
@@ -32,6 +32,7 @@ import * as utilities from "../utilities";
  *     sslEnforcementEnabled: true,
  * });
  * const exampleConfiguration = new azure.postgresql.Configuration("exampleConfiguration", {
+ *     name: "backslash_quote",
  *     resourceGroupName: exampleResourceGroup.name,
  *     serverName: exampleServer.name,
  *     value: "on",
@@ -101,6 +102,9 @@ export class Configuration extends pulumi.CustomResource {
             inputs["value"] = state ? state.value : undefined;
         } else {
             const args = argsOrState as ConfigurationArgs | undefined;
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
+            }
             if (!args || args.resourceGroupName === undefined) {
                 throw new Error("Missing required property 'resourceGroupName'");
             }
@@ -155,7 +159,7 @@ export interface ConfigurationArgs {
     /**
      * Specifies the name of the PostgreSQL Configuration, which needs [to be a valid PostgreSQL configuration name](https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIER). Changing this forces a new resource to be created.
      */
-    readonly name?: pulumi.Input<string>;
+    readonly name: pulumi.Input<string>;
     /**
      * The name of the resource group in which the PostgreSQL Server exists. Changing this forces a new resource to be created.
      */

--- a/sdk/python/pulumi_azure/mariadb/configuration.py
+++ b/sdk/python/pulumi_azure/mariadb/configuration.py
@@ -46,6 +46,7 @@ class Configuration(pulumi.CustomResource):
             version="10.2",
             ssl_enforcement="Enabled")
         example_configuration = azure.mariadb.Configuration("exampleConfiguration",
+            name="interactive_timeout",
             resource_group_name=example_resource_group.name,
             server_name=example_server.name,
             value="600")
@@ -75,6 +76,8 @@ class Configuration(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = dict()
 
+            if name is None:
+                raise TypeError("Missing required property 'name'")
             __props__['name'] = name
             if resource_group_name is None:
                 raise TypeError("Missing required property 'resource_group_name'")

--- a/sdk/python/pulumi_azure/mysql/configuration.py
+++ b/sdk/python/pulumi_azure/mysql/configuration.py
@@ -52,6 +52,7 @@ class Configuration(pulumi.CustomResource):
             ssl_enforcement_enabled=True,
             ssl_minimal_tls_version_enforced="TLS1_2")
         example_configuration = azure.mysql.Configuration("exampleConfiguration",
+            name="interactive_timeout",
             resource_group_name=example_resource_group.name,
             server_name=example_server.name,
             value="600")
@@ -81,6 +82,8 @@ class Configuration(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = dict()
 
+            if name is None:
+                raise TypeError("Missing required property 'name'")
             __props__['name'] = name
             if resource_group_name is None:
                 raise TypeError("Missing required property 'resource_group_name'")

--- a/sdk/python/pulumi_azure/postgresql/configuration.py
+++ b/sdk/python/pulumi_azure/postgresql/configuration.py
@@ -49,6 +49,7 @@ class Configuration(pulumi.CustomResource):
             version="9.5",
             ssl_enforcement_enabled=True)
         example_configuration = azure.postgresql.Configuration("exampleConfiguration",
+            name="backslash_quote",
             resource_group_name=example_resource_group.name,
             server_name=example_server.name,
             value="on")
@@ -78,6 +79,8 @@ class Configuration(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = dict()
 
+            if name is None:
+                raise TypeError("Missing required property 'name'")
             __props__['name'] = name
             if resource_group_name is None:
                 raise TypeError("Missing required property 'resource_group_name'")


### PR DESCRIPTION
Fixes: #721