### PR TITLE
Allow capturing secrets in CallbackFunction callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Allow capturing secrets in CallbackFunctions
 
 ---
 

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -4,6 +4,7 @@
 package examples
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"testing"
 
@@ -281,6 +282,21 @@ func TestAccHttpMulti(t *testing.T) {
 		With(integration.ProgramTestOptions{
 			Dir:           filepath.Join(getCwd(t), "http-multi"),
 			RunUpdateTest: true,
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
+func TestAccSecretCapture(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir:           filepath.Join(getCwd(t), "http"),
+			RunUpdateTest: true,
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				byts, err := json.Marshal(info.Deployment)
+				assert.NoError(t, err)
+				assert.NotContains(t, "s3cr3t", string(byts))
+			},
 		})
 
 	integration.ProgramTest(t, &test)

--- a/examples/secretcapture/Pulumi.yaml
+++ b/examples/secretcapture/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: secretcapture
+runtime: nodejs
+description: Test capturing secrets in callback functions.

--- a/examples/secretcapture/index.ts
+++ b/examples/secretcapture/index.ts
@@ -1,0 +1,19 @@
+import * as pulumi from '@pulumi/pulumi';
+import * as azure from '@pulumi/azure';
+
+const resourceGroup = new azure.core.ResourceGroup('example');
+
+const secret = pulumi.secret("s3cr3t");
+
+const greeting = new azure.appservice.HttpEventSubscription('greeting', {
+  resourceGroup,
+  callback: async (context, args) => {
+    console.log(secret.get());
+    return {
+      status: 200,
+      body: `Hello World!`
+    };
+  }
+});
+
+export const url = greeting.url;

--- a/examples/secretcapture/package.json
+++ b/examples/secretcapture/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "secretcapture",
+    "version": "0.1.0",
+    "main": "bin/index.js",
+    "typings": "bin/index.d.ts",
+    "scripts": {
+        "build": "tsc"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/azure": "latest"
+    },
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    },
+    "license": "Apache 2.0"
+}

--- a/examples/secretcapture/tsconfig.json
+++ b/examples/secretcapture/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/provider/resource.go
+++ b/provider/resource.go
@@ -1920,7 +1920,7 @@ func Provider() tfbridge.ProviderInfo {
 				"@types/node": "^8.0.0", // so we can access strongly typed node definitions.
 			},
 			Dependencies: map[string]string{
-				"@pulumi/pulumi":                "2.17.0-alpha.1609369338",
+				"@pulumi/pulumi":                "^2.17.0",
 				"azure-eventgrid":               "^1.6.0",
 				"@azure/functions":              "^1.0.3",
 				"@azure/ms-rest-azure-js":       "^2.0.1",

--- a/provider/resource.go
+++ b/provider/resource.go
@@ -1920,7 +1920,7 @@ func Provider() tfbridge.ProviderInfo {
 				"@types/node": "^8.0.0", // so we can access strongly typed node definitions.
 			},
 			Dependencies: map[string]string{
-				"@pulumi/pulumi":                "^2.15.0",
+				"@pulumi/pulumi":                "dev",
 				"azure-eventgrid":               "^1.6.0",
 				"@azure/functions":              "^1.0.3",
 				"@azure/ms-rest-azure-js":       "^2.0.1",

--- a/provider/resource.go
+++ b/provider/resource.go
@@ -1920,7 +1920,7 @@ func Provider() tfbridge.ProviderInfo {
 				"@types/node": "^8.0.0", // so we can access strongly typed node definitions.
 			},
 			Dependencies: map[string]string{
-				"@pulumi/pulumi":                "dev",
+				"@pulumi/pulumi":                "2.17.0-alpha.1609369338",
 				"azure-eventgrid":               "^1.6.0",
 				"@azure/functions":              "^1.0.3",
 				"@azure/ms-rest-azure-js":       "^2.0.1",

--- a/sdk/nodejs/appservice/zMixins.ts
+++ b/sdk/nodejs/appservice/zMixins.ts
@@ -412,7 +412,7 @@ async function produceDeploymentArchiveAsync(args: MultiCallbackFunctionAppArgs)
         })));
 
         const body = await serializeFunctionCallback(func.callback);
-        containsSecrets ||= body.containsSecrets;
+        containsSecrets = containsSecrets || body.containsSecrets;
 
         map[`${func.name}/index.js`] = new pulumi.asset.StringAsset(`module.exports = require("./handler").handler`);
         map[`${func.name}/handler.js`] = new pulumi.asset.StringAsset(body.text);

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -16,7 +16,7 @@
         "@azure/functions": "^1.0.3",
         "@azure/ms-rest-azure-js": "^2.0.1",
         "@azure/ms-rest-nodeauth": "^3.0.0",
-        "@pulumi/pulumi": "^2.15.0",
+        "@pulumi/pulumi": "2.17.0-alpha.1609369338",
         "azure-eventgrid": "^1.6.0",
         "azure-functions-ts-essentials": "^1.3.2",
         "moment": "2.24.0"

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -16,7 +16,7 @@
         "@azure/functions": "^1.0.3",
         "@azure/ms-rest-azure-js": "^2.0.1",
         "@azure/ms-rest-nodeauth": "^3.0.0",
-        "@pulumi/pulumi": "2.17.0-alpha.1609369338",
+        "@pulumi/pulumi": "^2.17.0",
         "azure-eventgrid": "^1.6.0",
         "azure-functions-ts-essentials": "^1.3.2",
         "moment": "2.24.0"


### PR DESCRIPTION
Opts-in to the secret capture support added in pulumi/pulumi#6013.

Part of pulumi/pulumi#2718.

Fixes https://github.com/pulumi/pulumi-cloud/issues/780.