### PR TITLE
Fix creation of azure.compute.*VirtualMachine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Ensure `azure.compute.LinuxVirtualMachine` and `azure.compute.WindowsVirtualMachine` resources don't error with validation
+  errors regarding `platformFaultDomain` and `virtualMachineScaleSet`
 
 ---
 

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -301,3 +301,13 @@ func TestAccSecretCapture(t *testing.T) {
 
 	integration.ProgramTest(t, &test)
 }
+
+func TestAccLinuxVirtualMachines(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir:           filepath.Join(getCwd(t), "linux-virtual-machine"),
+			RunUpdateTest: false,
+		})
+
+	integration.ProgramTest(t, &test)
+}

--- a/examples/linux-virtual-machine/Pulumi.yaml
+++ b/examples/linux-virtual-machine/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: azure-linux-virtual-machine
+runtime: nodejs
+description: Create a linux virtual machine resource

--- a/examples/linux-virtual-machine/index.ts
+++ b/examples/linux-virtual-machine/index.ts
@@ -1,0 +1,45 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as azure from "@pulumi/azure";
+
+const exampleResourceGroup = new azure.core.ResourceGroup("exampleResourceGroup");
+
+const exampleVirtualNetwork = new azure.network.VirtualNetwork("exampleVirtualNetwork", {
+    addressSpaces: ["10.0.0.0/16"],
+    location: exampleResourceGroup.location,
+    resourceGroupName: exampleResourceGroup.name,
+});
+const exampleSubnet = new azure.network.Subnet("exampleSubnet", {
+    resourceGroupName: exampleResourceGroup.name,
+    virtualNetworkName: exampleVirtualNetwork.name,
+    addressPrefixes: ["10.0.2.0/24"],
+});
+const exampleNetworkInterface = new azure.network.NetworkInterface("exampleNetworkInterface", {
+    location: exampleResourceGroup.location,
+    resourceGroupName: exampleResourceGroup.name,
+    ipConfigurations: [{
+        name: "internal",
+        subnetId: exampleSubnet.id,
+        privateIpAddressAllocation: "Dynamic",
+    }],
+});
+const exampleLinuxVirtualMachine = new azure.compute.LinuxVirtualMachine("exampleLinuxVirtualMachine", {
+    resourceGroupName: exampleResourceGroup.name,
+    location: exampleResourceGroup.location,
+    size: "Standard_F2",
+    adminUsername: "adminuser",
+    networkInterfaceIds: [exampleNetworkInterface.id],
+    adminSshKeys: [{
+        username: "adminuser",
+        publicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDcn5KndQimiRsJc1FE5Oq9qbtxFqkO1UvbLa1gkhBrOVANwlm1w+6eMa9+fHjFnuRgr+DudC93u7pNytH4qeRYiGtw9/Lbp7sKTIPe7dJfZvbAGW/3nVMQK0lE+gKEMQ6GVeHq0wecoOMac5ZUHrc4jyrtwrcOQSPVEgJB9d7rlY2mHuNS5ODlGxAEKdovM0Kb0/FHDQOiqVz9tI/hRAow2bygaid2nwhgAiT4ar7gWgQXfxrGp7xurfGZz7mQP8wyHMle4qykZKqKMYbsEbDvpOK7351uwGqgviDS6F1qrJ7zEyK/XYLOeXiNWD7shvSbM8N9ExZXPzc+53OEFS2VISYCTELFch9gfib/6VGducFlZAxu5qKCdS0KxVQUrqgUTdbW6PmRiEoyszN822iuAZ/9yCYqU5XM4zKs6BKXUMQmouYeHQEMBw6AsQTS0s/bmCml9FOePim6lwcgZ6jZDIFY9amMzD6PJ/c2jiVfqHgTMe9gm0C0DpZH4rD5kfJF/s36acvFTxR9A/XfKk4EOC4VXWLd3C2C6MO2bHL90WqkNT0IabwDhecCDTrE6ZCrgG6b0fvBHKxwV0j7jWATgQlytXCcGqdZBtTY4MXYlT+TbTTxxD1VeJ8CJa34Hcike5Fgbgh96iSIxSO3ekmH1jYpGcVSGOS5gES8l3BfIQ==\n",
+    }],
+    osDisk: {
+        caching: "ReadWrite",
+        storageAccountType: "Standard_LRS",
+    },
+    sourceImageReference: {
+        publisher: "Canonical",
+        offer: "UbuntuServer",
+        sku: "16.04-LTS",
+        version: "latest",
+    },
+});

--- a/examples/linux-virtual-machine/package.json
+++ b/examples/linux-virtual-machine/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "azure-linux-virtual-machine",
+    "version": "0.1.0",
+    "main": "bin/index.js",
+    "typings": "bin/index.d.ts",
+    "scripts": {
+        "build": "tsc"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0",
+        "mime-types": "^2.1.19"
+    },
+    "devDependencies": {
+        "@types/node": "^10.0.0"
+    },
+    "license": "Apache 2.0"
+}

--- a/examples/linux-virtual-machine/tsconfig.json
+++ b/examples/linux-virtual-machine/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -14,5 +14,5 @@ require (
 replace (
 	github.com/hashicorp/go-getter v1.5.0 => github.com/hashicorp/go-getter v1.4.0
 	github.com/hashicorp/vault => github.com/hashicorp/vault v1.2.0
-	github.com/terraform-providers/terraform-provider-azurerm => github.com/pulumi/terraform-provider-azurerm v1.41.1-0.20210418180637-432435c3cf3a
+	github.com/terraform-providers/terraform-provider-azurerm => github.com/pulumi/terraform-provider-azurerm v1.41.1-0.20210427121202-8cf73dba9bbe
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -769,6 +769,8 @@ github.com/pulumi/terraform-provider-azurerm v1.41.1-0.20210409084350-225aaed053
 github.com/pulumi/terraform-provider-azurerm v1.41.1-0.20210409084350-225aaed0530b/go.mod h1:k6TdLQyQX3KlYcdPzZEPg+AIXAm1PD2LBTxSmsdiAUo=
 github.com/pulumi/terraform-provider-azurerm v1.41.1-0.20210418180637-432435c3cf3a h1:yY0yzk31kmI67H67rFZyZfKz6HDrXgL39/tDTfQphIA=
 github.com/pulumi/terraform-provider-azurerm v1.41.1-0.20210418180637-432435c3cf3a/go.mod h1:k6TdLQyQX3KlYcdPzZEPg+AIXAm1PD2LBTxSmsdiAUo=
+github.com/pulumi/terraform-provider-azurerm v1.41.1-0.20210427121202-8cf73dba9bbe h1:QlqfSI3jLS4BkISN9krPHKAOLcTn8WrhVHr3hToJtbs=
+github.com/pulumi/terraform-provider-azurerm v1.41.1-0.20210427121202-8cf73dba9bbe/go.mod h1:k6TdLQyQX3KlYcdPzZEPg+AIXAm1PD2LBTxSmsdiAUo=
 github.com/rickb777/date v1.12.5-0.20200422084442-6300e543c4d9 h1:czJCcoUR3FMpHnRQow2E84H/0CPrX1fMAGn9HugzyI4=
 github.com/rickb777/date v1.12.5-0.20200422084442-6300e543c4d9/go.mod h1:L8WrssTzvgYw34/Ppa0JpJfI7KKXZ2cVGI6Djt0brUU=
 github.com/rickb777/plural v1.2.0 h1:5tvEc7UBCZ7l8h/2UeybSkt/uu1DQsZFOFdNevmUhlE=


### PR DESCRIPTION
Fixes: #860

A change was merged to the upstream provider that introduced a
RequiredWith check. At the same time, a default value of `-1` was
added to the `platformFaultDomain` value. This means that when a
Linux / Windows Virtual Machine was tried to be provisioned, it was
failing the `RequiredWith` check as `-1` was being passed as a value

The bug fix here was to relax the `RequiredWith` check. Also included
a reproduction that will now succeed that failed previously as follows:

```
  azure:compute:LinuxVirtualMachine (exampleLinuxVirtualMachine):
    error: azure:compute/linuxVirtualMachine:LinuxVirtualMachine resource 'exampleLinuxVirtualMachine' has a problem: "platform_fault_domain": all of `platform_fault_domain,virtual_machine_scale_set_id` must be specified
```