### PR TITLE
fix: depend on node-fetch as it is used in the zMixins file and breaks when manually installing v3

### DIFF
--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -19,7 +19,8 @@
         "@pulumi/pulumi": "^3.0.0",
         "azure-eventgrid": "^1.6.0",
         "azure-functions-ts-essentials": "^1.3.2",
-        "moment": "2.24.0"
+        "moment": "2.24.0",
+        "node-fetch": "^2.3.0"
     },
     "devDependencies": {
         "@types/node": "^10.0.0",


### PR DESCRIPTION
See #945 