### PR TITLE
Ensure no regression to compute.OrchestratedVirtualMachineScaleSet zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 * Upgrade to v2.86.0 of the AzureRM Terraform Provider
+  * Please note `singlePlacementGroup` has been removed from `azure.compute.OrchestratedVirtualMachineScaleSet` as per the upstream provider
 
 ---
 

--- a/provider/resource.go
+++ b/provider/resource.go
@@ -732,6 +732,12 @@ func Provider() tfbridge.ProviderInfo {
 			"azurerm_windows_virtual_machine_scale_set":   {Tok: azureResource(azureCompute, "WindowsVirtualMachineScaleSet")},
 			"azurerm_orchestrated_virtual_machine_scale_set": {
 				Tok: azureResource(azureCompute, "OrchestratedVirtualMachineScaleSet"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"zones": {
+						MaxItemsOne: tfbridge.True(),
+						Name:        "zones",
+					},
+				},
 			},
 			"azurerm_disk_access":        {Tok: azureResource(azureCompute, "DiskAccess")},
 			"azurerm_ssh_public_key":     {Tok: azureResource(azureCompute, "SshPublicKey")},

--- a/sdk/dotnet/Compute/OrchestratedVirtualMachineScaleSet.cs
+++ b/sdk/dotnet/Compute/OrchestratedVirtualMachineScaleSet.cs
@@ -169,7 +169,7 @@ namespace Pulumi.Azure.Compute
         /// A list of Availability Zones in which the Virtual Machines in this Scale Set should be created in. Changing this forces a new resource to be created.
         /// </summary>
         [Output("zones")]
-        public Output<ImmutableArray<string>> Zones { get; private set; } = null!;
+        public Output<string?> Zones { get; private set; } = null!;
 
 
         /// <summary>
@@ -332,17 +332,11 @@ namespace Pulumi.Azure.Compute
         [Input("zoneBalance")]
         public Input<bool>? ZoneBalance { get; set; }
 
-        [Input("zones")]
-        private InputList<string>? _zones;
-
         /// <summary>
         /// A list of Availability Zones in which the Virtual Machines in this Scale Set should be created in. Changing this forces a new resource to be created.
         /// </summary>
-        public InputList<string> Zones
-        {
-            get => _zones ?? (_zones = new InputList<string>());
-            set => _zones = value;
-        }
+        [Input("zones")]
+        public Input<string>? Zones { get; set; }
 
         public OrchestratedVirtualMachineScaleSetArgs()
         {
@@ -472,17 +466,11 @@ namespace Pulumi.Azure.Compute
         [Input("zoneBalance")]
         public Input<bool>? ZoneBalance { get; set; }
 
-        [Input("zones")]
-        private InputList<string>? _zones;
-
         /// <summary>
         /// A list of Availability Zones in which the Virtual Machines in this Scale Set should be created in. Changing this forces a new resource to be created.
         /// </summary>
-        public InputList<string> Zones
-        {
-            get => _zones ?? (_zones = new InputList<string>());
-            set => _zones = value;
-        }
+        [Input("zones")]
+        public Input<string>? Zones { get; set; }
 
         public OrchestratedVirtualMachineScaleSetState()
         {

--- a/sdk/go/azure/compute/orchestratedVirtualMachineScaleSet.go
+++ b/sdk/go/azure/compute/orchestratedVirtualMachineScaleSet.go
@@ -44,8 +44,8 @@ import (
 // 			Location:                 exampleResourceGroup.Location,
 // 			ResourceGroupName:        exampleResourceGroup.Name,
 // 			PlatformFaultDomainCount: pulumi.Int(1),
-// 			Zones: pulumi.StringArray{
-// 				pulumi.String("1"),
+// 			Zones: pulumi.String{
+// 				"1",
 // 			},
 // 		})
 // 		if err != nil {
@@ -102,7 +102,7 @@ type OrchestratedVirtualMachineScaleSet struct {
 	UniqueId    pulumi.StringOutput  `pulumi:"uniqueId"`
 	ZoneBalance pulumi.BoolPtrOutput `pulumi:"zoneBalance"`
 	// A list of Availability Zones in which the Virtual Machines in this Scale Set should be created in. Changing this forces a new resource to be created.
-	Zones pulumi.StringArrayOutput `pulumi:"zones"`
+	Zones pulumi.StringPtrOutput `pulumi:"zones"`
 }
 
 // NewOrchestratedVirtualMachineScaleSet registers a new resource with the given unique name, arguments, and options.
@@ -176,7 +176,7 @@ type orchestratedVirtualMachineScaleSetState struct {
 	UniqueId    *string `pulumi:"uniqueId"`
 	ZoneBalance *bool   `pulumi:"zoneBalance"`
 	// A list of Availability Zones in which the Virtual Machines in this Scale Set should be created in. Changing this forces a new resource to be created.
-	Zones []string `pulumi:"zones"`
+	Zones *string `pulumi:"zones"`
 }
 
 type OrchestratedVirtualMachineScaleSetState struct {
@@ -216,7 +216,7 @@ type OrchestratedVirtualMachineScaleSetState struct {
 	UniqueId    pulumi.StringPtrInput
 	ZoneBalance pulumi.BoolPtrInput
 	// A list of Availability Zones in which the Virtual Machines in this Scale Set should be created in. Changing this forces a new resource to be created.
-	Zones pulumi.StringArrayInput
+	Zones pulumi.StringPtrInput
 }
 
 func (OrchestratedVirtualMachineScaleSetState) ElementType() reflect.Type {
@@ -258,7 +258,7 @@ type orchestratedVirtualMachineScaleSetArgs struct {
 	TerminationNotification *OrchestratedVirtualMachineScaleSetTerminationNotification `pulumi:"terminationNotification"`
 	ZoneBalance             *bool                                                      `pulumi:"zoneBalance"`
 	// A list of Availability Zones in which the Virtual Machines in this Scale Set should be created in. Changing this forces a new resource to be created.
-	Zones []string `pulumi:"zones"`
+	Zones *string `pulumi:"zones"`
 }
 
 // The set of arguments for constructing a OrchestratedVirtualMachineScaleSet resource.
@@ -297,7 +297,7 @@ type OrchestratedVirtualMachineScaleSetArgs struct {
 	TerminationNotification OrchestratedVirtualMachineScaleSetTerminationNotificationPtrInput
 	ZoneBalance             pulumi.BoolPtrInput
 	// A list of Availability Zones in which the Virtual Machines in this Scale Set should be created in. Changing this forces a new resource to be created.
-	Zones pulumi.StringArrayInput
+	Zones pulumi.StringPtrInput
 }
 
 func (OrchestratedVirtualMachineScaleSetArgs) ElementType() reflect.Type {

--- a/sdk/nodejs/compute/orchestratedVirtualMachineScaleSet.ts
+++ b/sdk/nodejs/compute/orchestratedVirtualMachineScaleSet.ts
@@ -123,7 +123,7 @@ export class OrchestratedVirtualMachineScaleSet extends pulumi.CustomResource {
     /**
      * A list of Availability Zones in which the Virtual Machines in this Scale Set should be created in. Changing this forces a new resource to be created.
      */
-    public readonly zones!: pulumi.Output<string[] | undefined>;
+    public readonly zones!: pulumi.Output<string | undefined>;
 
     /**
      * Create a OrchestratedVirtualMachineScaleSet resource with the given unique name, arguments, and options.
@@ -268,7 +268,7 @@ export interface OrchestratedVirtualMachineScaleSetState {
     /**
      * A list of Availability Zones in which the Virtual Machines in this Scale Set should be created in. Changing this forces a new resource to be created.
      */
-    zones?: pulumi.Input<pulumi.Input<string>[]>;
+    zones?: pulumi.Input<string>;
 }
 
 /**
@@ -327,5 +327,5 @@ export interface OrchestratedVirtualMachineScaleSetArgs {
     /**
      * A list of Availability Zones in which the Virtual Machines in this Scale Set should be created in. Changing this forces a new resource to be created.
      */
-    zones?: pulumi.Input<pulumi.Input<string>[]>;
+    zones?: pulumi.Input<string>;
 }

--- a/sdk/python/pulumi_azure/compute/orchestrated_virtual_machine_scale_set.py
+++ b/sdk/python/pulumi_azure/compute/orchestrated_virtual_machine_scale_set.py
@@ -40,7 +40,7 @@ class OrchestratedVirtualMachineScaleSetArgs:
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  termination_notification: Optional[pulumi.Input['OrchestratedVirtualMachineScaleSetTerminationNotificationArgs']] = None,
                  zone_balance: Optional[pulumi.Input[bool]] = None,
-                 zones: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None):
+                 zones: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a OrchestratedVirtualMachineScaleSet resource.
         :param pulumi.Input[int] platform_fault_domain_count: Specifies the number of fault domains that are used by this Orchestrated Virtual Machine Scale Set. Changing this forces a new resource to be created.
@@ -51,7 +51,7 @@ class OrchestratedVirtualMachineScaleSetArgs:
         :param pulumi.Input[str] proximity_placement_group_id: The ID of the Proximity Placement Group which the Orchestrated Virtual Machine should be assigned to. Changing this forces a new resource to be created.
         :param pulumi.Input['OrchestratedVirtualMachineScaleSetSourceImageReferenceArgs'] source_image_reference: A `source_image_reference` block as defined below.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: A mapping of tags which should be assigned to this Orchestrated Virtual Machine Scale Set.
-        :param pulumi.Input[Sequence[pulumi.Input[str]]] zones: A list of Availability Zones in which the Virtual Machines in this Scale Set should be created in. Changing this forces a new resource to be created.
+        :param pulumi.Input[str] zones: A list of Availability Zones in which the Virtual Machines in this Scale Set should be created in. Changing this forces a new resource to be created.
         """
         pulumi.set(__self__, "platform_fault_domain_count", platform_fault_domain_count)
         pulumi.set(__self__, "resource_group_name", resource_group_name)
@@ -355,14 +355,14 @@ class OrchestratedVirtualMachineScaleSetArgs:
 
     @property
     @pulumi.getter
-    def zones(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
+    def zones(self) -> Optional[pulumi.Input[str]]:
         """
         A list of Availability Zones in which the Virtual Machines in this Scale Set should be created in. Changing this forces a new resource to be created.
         """
         return pulumi.get(self, "zones")
 
     @zones.setter
-    def zones(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
+    def zones(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "zones", value)
 
 
@@ -395,7 +395,7 @@ class _OrchestratedVirtualMachineScaleSetState:
                  termination_notification: Optional[pulumi.Input['OrchestratedVirtualMachineScaleSetTerminationNotificationArgs']] = None,
                  unique_id: Optional[pulumi.Input[str]] = None,
                  zone_balance: Optional[pulumi.Input[bool]] = None,
-                 zones: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None):
+                 zones: Optional[pulumi.Input[str]] = None):
         """
         Input properties used for looking up and filtering OrchestratedVirtualMachineScaleSet resources.
         :param pulumi.Input[int] instances: The number of Virtual Machines in the Orcestrated Virtual Machine Scale Set.
@@ -407,7 +407,7 @@ class _OrchestratedVirtualMachineScaleSetState:
         :param pulumi.Input['OrchestratedVirtualMachineScaleSetSourceImageReferenceArgs'] source_image_reference: A `source_image_reference` block as defined below.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: A mapping of tags which should be assigned to this Orchestrated Virtual Machine Scale Set.
         :param pulumi.Input[str] unique_id: The Unique ID for the Orchestrated Virtual Machine Scale Set.
-        :param pulumi.Input[Sequence[pulumi.Input[str]]] zones: A list of Availability Zones in which the Virtual Machines in this Scale Set should be created in. Changing this forces a new resource to be created.
+        :param pulumi.Input[str] zones: A list of Availability Zones in which the Virtual Machines in this Scale Set should be created in. Changing this forces a new resource to be created.
         """
         if automatic_instance_repair is not None:
             pulumi.set(__self__, "automatic_instance_repair", automatic_instance_repair)
@@ -727,14 +727,14 @@ class _OrchestratedVirtualMachineScaleSetState:
 
     @property
     @pulumi.getter
-    def zones(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
+    def zones(self) -> Optional[pulumi.Input[str]]:
         """
         A list of Availability Zones in which the Virtual Machines in this Scale Set should be created in. Changing this forces a new resource to be created.
         """
         return pulumi.get(self, "zones")
 
     @zones.setter
-    def zones(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
+    def zones(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "zones", value)
 
 
@@ -768,7 +768,7 @@ class OrchestratedVirtualMachineScaleSet(pulumi.CustomResource):
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  termination_notification: Optional[pulumi.Input[pulumi.InputType['OrchestratedVirtualMachineScaleSetTerminationNotificationArgs']]] = None,
                  zone_balance: Optional[pulumi.Input[bool]] = None,
-                 zones: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 zones: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
         Manages an Orchestrated Virtual Machine Scale Set.
@@ -813,7 +813,7 @@ class OrchestratedVirtualMachineScaleSet(pulumi.CustomResource):
         :param pulumi.Input[str] resource_group_name: The name of the Resource Group in which the Orchestrated Virtual Machine Scale Set should exist. Changing this forces a new resource to be created.
         :param pulumi.Input[pulumi.InputType['OrchestratedVirtualMachineScaleSetSourceImageReferenceArgs']] source_image_reference: A `source_image_reference` block as defined below.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: A mapping of tags which should be assigned to this Orchestrated Virtual Machine Scale Set.
-        :param pulumi.Input[Sequence[pulumi.Input[str]]] zones: A list of Availability Zones in which the Virtual Machines in this Scale Set should be created in. Changing this forces a new resource to be created.
+        :param pulumi.Input[str] zones: A list of Availability Zones in which the Virtual Machines in this Scale Set should be created in. Changing this forces a new resource to be created.
         """
         ...
     @overload
@@ -894,7 +894,7 @@ class OrchestratedVirtualMachineScaleSet(pulumi.CustomResource):
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  termination_notification: Optional[pulumi.Input[pulumi.InputType['OrchestratedVirtualMachineScaleSetTerminationNotificationArgs']]] = None,
                  zone_balance: Optional[pulumi.Input[bool]] = None,
-                 zones: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 zones: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         if opts is None:
             opts = pulumi.ResourceOptions()
@@ -974,7 +974,7 @@ class OrchestratedVirtualMachineScaleSet(pulumi.CustomResource):
             termination_notification: Optional[pulumi.Input[pulumi.InputType['OrchestratedVirtualMachineScaleSetTerminationNotificationArgs']]] = None,
             unique_id: Optional[pulumi.Input[str]] = None,
             zone_balance: Optional[pulumi.Input[bool]] = None,
-            zones: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None) -> 'OrchestratedVirtualMachineScaleSet':
+            zones: Optional[pulumi.Input[str]] = None) -> 'OrchestratedVirtualMachineScaleSet':
         """
         Get an existing OrchestratedVirtualMachineScaleSet resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.
@@ -991,7 +991,7 @@ class OrchestratedVirtualMachineScaleSet(pulumi.CustomResource):
         :param pulumi.Input[pulumi.InputType['OrchestratedVirtualMachineScaleSetSourceImageReferenceArgs']] source_image_reference: A `source_image_reference` block as defined below.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: A mapping of tags which should be assigned to this Orchestrated Virtual Machine Scale Set.
         :param pulumi.Input[str] unique_id: The Unique ID for the Orchestrated Virtual Machine Scale Set.
-        :param pulumi.Input[Sequence[pulumi.Input[str]]] zones: A list of Availability Zones in which the Virtual Machines in this Scale Set should be created in. Changing this forces a new resource to be created.
+        :param pulumi.Input[str] zones: A list of Availability Zones in which the Virtual Machines in this Scale Set should be created in. Changing this forces a new resource to be created.
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
@@ -1185,7 +1185,7 @@ class OrchestratedVirtualMachineScaleSet(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def zones(self) -> pulumi.Output[Optional[Sequence[str]]]:
+    def zones(self) -> pulumi.Output[Optional[str]]:
         """
         A list of Availability Zones in which the Virtual Machines in this Scale Set should be created in. Changing this forces a new resource to be created.
         """


### PR DESCRIPTION
PR #980 changed azure.compute.OrchestratedVirtualMachineScaleSet to have no MaxItems on zones parameter

This PR changes that to ensure we don't introduce a breaking change for our users. ﻿
