### PR TITLE
Add preConfigureCallback using Azure auth builder helper library

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/Azure/go-autorest/autorest/azure/cli v0.4.5
-	github.com/hashicorp/go-azure-helpers v0.39.1
+	github.com/hashicorp/go-azure-helpers v0.40.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.19.0
 	github.com/hashicorp/terraform-provider-azurerm v1.44.1-0.20210812080924-c853ec4222d8
 	github.com/hashicorp/terraform-provider-azurerm/shim v0.0.0
@@ -96,7 +96,6 @@ require (
 	github.com/gorilla/mux v1.7.4 // indirect
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-azure-helpers v0.40.0 // indirect
 	github.com/hashicorp/go-azure-sdk v0.20220824.1090858 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/Azure/go-autorest/autorest/azure/cli v0.4.5
+	github.com/hashicorp/go-azure-helpers v0.39.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.19.0
 	github.com/hashicorp/terraform-provider-azurerm v1.44.1-0.20210812080924-c853ec4222d8
 	github.com/hashicorp/terraform-provider-azurerm/shim v0.0.0

--- a/provider/resource.go
+++ b/provider/resource.go
@@ -285,9 +285,10 @@ func preConfigureCallback(vars resource.PropertyMap, c tfshim.ResourceConfig) er
 	_, err := builder.Build()
 
 	if err != nil {
-		return fmt.Errorf("failed to load application credentials.\n" +
-			"\tPlease sign in via 'az login' or configure another authentication method.\n" +
-			"\tSee https://www.pulumi.com/registry/packages/azure/installation-configuration/ for details.")
+		return fmt.Errorf("failed to load application credentials:\n"+
+			"Details: %v\n\n"+
+			"\tPlease make sure you have signed in via 'az login' or configured another authentication method.\n"+
+			"\tSee https://www.pulumi.com/registry/packages/azure/installation-configuration/ for more information.", err)
 	}
 	return nil
 }

--- a/provider/resource.go
+++ b/provider/resource.go
@@ -286,7 +286,7 @@ func preConfigureCallback(vars resource.PropertyMap, c tfshim.ResourceConfig) er
 
 	if err != nil {
 		return fmt.Errorf("failed to load application credentials.\n" +
-			"\tPlease sign in via 'az login' or confugure another authentication method.\n" +
+			"\tPlease sign in via 'az login' or configure another authentication method.\n" +
 			"\tSee https://www.pulumi.com/registry/packages/azure/installation-configuration/ for details.")
 	}
 	return nil

--- a/provider/resource.go
+++ b/provider/resource.go
@@ -271,7 +271,6 @@ func boolValue(vars resource.PropertyMap, prop resource.PropertyKey, envs []stri
 func arrayValue(vars resource.PropertyMap, prop resource.PropertyKey, envs []string) []string {
 	val, ok := vars[prop]
 	var vals []string
-	fmt.Println(vals)
 	if ok && val.IsArray() {
 		for _, v := range val.ArrayValue() {
 			vals = append(vals, v.StringValue())

--- a/provider/resource.go
+++ b/provider/resource.go
@@ -252,6 +252,42 @@ func stringValue(vars resource.PropertyMap, prop resource.PropertyKey, envs []st
 	return ""
 }
 
+// boolValue takes a bool value from a property map, then from environment vars; defaults to false
+func boolValue(vars resource.PropertyMap, prop resource.PropertyKey, envs []string) bool {
+	val, ok := vars[prop]
+	if ok && val.IsBool() {
+		return val.BoolValue()
+	}
+	for _, env := range envs {
+		val, ok := os.LookupEnv(env)
+		if ok && val == "true" {
+			return true
+		}
+	}
+	return false
+}
+
+// arrayValue takes an array value from a property map, then from environment vars; defaults to an empty array
+func arrayValue(vars resource.PropertyMap, prop resource.PropertyKey, envs []string) []string {
+	val, ok := vars[prop]
+	var vals []string
+	fmt.Println(vals)
+	if ok && val.IsArray() {
+		for _, v := range val.ArrayValue() {
+			vals = append(vals, v.StringValue())
+		}
+		return vals
+	}
+
+	for _, env := range envs {
+		val, ok := os.LookupEnv(env)
+		if ok {
+			return strings.Split(val, ";")
+		}
+	}
+	return vals
+}
+
 // preConfigureCallback returns an error when cloud provider setup is misconfigured
 func preConfigureCallback(vars resource.PropertyMap, c tfshim.ResourceConfig) error {
 
@@ -260,26 +296,29 @@ func preConfigureCallback(vars resource.PropertyMap, c tfshim.ResourceConfig) er
 		envName = "public"
 	}
 
+	//check for auxiliary tenants
+	auxTenants := arrayValue(vars, "auxiliaryTenantIDs", []string{"ARM_AUXILIARY_TENANT_IDS"})
+
 	// validate the azure config
 	// make a Builder
 	builder := &authentication.Builder{
-		SubscriptionID:     stringValue(vars, "subscriptionID", []string{"ARM_SUBSCRIPTION_ID"}),
-		ClientID:           stringValue(vars, "clientId", []string{"ARM_CLIENT_ID"}),
-		ClientSecret:       stringValue(vars, "clientSecret", []string{"ARM_CLIENT_SECRET"}),
-		TenantID:           stringValue(vars, "tenantId", []string{"ARM_TENANT_ID"}),
-		Environment:        envName,
-		ClientCertPath:     stringValue(vars, "clientCertificatePath", []string{"ARM_CLIENT_CERTIFICATE_PATH"}),
-		ClientCertPassword: stringValue(vars, "clientCertificatePassword", []string{"ARM_CLIENT_CERTIFICATE_PASSWORD"}),
-		MsiEndpoint:        stringValue(vars, "msiEndpoint", []string{"ARM_MSI_ENDPOINT"}),
-		//AuxiliaryTenantIDs:   auxTenants,
+		SubscriptionID:       stringValue(vars, "subscriptionID", []string{"ARM_SUBSCRIPTION_ID"}),
+		ClientID:             stringValue(vars, "clientId", []string{"ARM_CLIENT_ID"}),
+		ClientSecret:         stringValue(vars, "clientSecret", []string{"ARM_CLIENT_SECRET"}),
+		TenantID:             stringValue(vars, "tenantId", []string{"ARM_TENANT_ID"}),
+		Environment:          envName,
+		ClientCertPath:       stringValue(vars, "clientCertificatePath", []string{"ARM_CLIENT_CERTIFICATE_PATH"}),
+		ClientCertPassword:   stringValue(vars, "clientCertificatePassword", []string{"ARM_CLIENT_CERTIFICATE_PASSWORD"}),
+		MsiEndpoint:          stringValue(vars, "msiEndpoint", []string{"ARM_MSI_ENDPOINT"}),
+		AuxiliaryTenantIDs:   auxTenants,
 		ClientSecretDocsLink: "https://www.pulumi.com/docs/intro/cloud-providers/azure/setup/#service-principal-authentication",
 
 		// Feature Toggles
-		SupportsClientCertAuth:   true,
-		SupportsClientSecretAuth: true,
-		//SupportsManagedServiceIdentity: useMsi,
-		SupportsAzureCliToken: true,
-		//SupportsAuxiliaryTenants:       len(auxTenants) > 0,
+		SupportsClientCertAuth:         true,
+		SupportsClientSecretAuth:       true,
+		SupportsManagedServiceIdentity: boolValue(vars, "msiEndpoint", []string{"ARM_USE_MSI"}),
+		SupportsAzureCliToken:          true,
+		SupportsAuxiliaryTenants:       len(auxTenants) > 0,
 	}
 
 	_, err := builder.Build()
@@ -287,7 +326,7 @@ func preConfigureCallback(vars resource.PropertyMap, c tfshim.ResourceConfig) er
 	if err != nil {
 		return fmt.Errorf("failed to load application credentials:\n"+
 			"Details: %v\n\n"+
-			"\tPlease make sure you have signed in via 'az login' or configured another authentication method.\n"+
+			"\tPlease make sure you have signed in via 'az login' or configured another authentication method.\n\n"+
 			"\tSee https://www.pulumi.com/registry/packages/azure/installation-configuration/ for more information.", err)
 	}
 	return nil

--- a/provider/resource.go
+++ b/provider/resource.go
@@ -237,7 +237,7 @@ func detectCloudShell() cloudShellProfile {
 	return negative
 }
 
-// stringValue gets a string value from a property map if present, else ""
+// stringValue gets a string value from a property map, then from environment vars; if neither are present, returns empty string ""
 func stringValue(vars resource.PropertyMap, prop resource.PropertyKey, envs []string) string {
 	val, ok := vars[prop]
 	if ok && val.IsString() {
@@ -285,7 +285,8 @@ func preConfigureCallback(vars resource.PropertyMap, c tfshim.ResourceConfig) er
 	_, err := builder.Build()
 
 	if err != nil {
-		return fmt.Errorf("failed to load application credentials. Please run 'az login' to set up account.\n" +
+		return fmt.Errorf("failed to load application credentials.\n" +
+			"\tPlease sign in via 'az login' or confugure another authentication method.\n" +
 			"\tSee https://www.pulumi.com/registry/packages/azure/installation-configuration/ for details.")
 	}
 	return nil

--- a/provider/resource.go
+++ b/provider/resource.go
@@ -23,11 +23,13 @@ import (
 	"unicode"
 
 	"github.com/Azure/go-autorest/autorest/azure/cli"
+	"github.com/hashicorp/go-azure-helpers/authentication"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/shim"
 	"github.com/pulumi/pulumi-azure/provider/v5/pkg/version"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	tfshim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -235,6 +237,60 @@ func detectCloudShell() cloudShellProfile {
 	return negative
 }
 
+// stringValue gets a string value from a property map if present, else ""
+func stringValue(vars resource.PropertyMap, prop resource.PropertyKey, envs []string) string {
+	val, ok := vars[prop]
+	if ok && val.IsString() {
+		return val.StringValue()
+	}
+	for _, env := range envs {
+		val, ok := os.LookupEnv(env)
+		if ok {
+			return val
+		}
+	}
+	return ""
+}
+
+// preConfigureCallback returns an error when cloud provider setup is misconfigured
+func preConfigureCallback(vars resource.PropertyMap, c tfshim.ResourceConfig) error {
+
+	envName := stringValue(vars, "environment", []string{"ARM_ENVIRONMENT"})
+	if envName == "" {
+		envName = "public"
+	}
+
+	// validate the azure config
+	// make a Builder
+	builder := &authentication.Builder{
+		SubscriptionID:     stringValue(vars, "subscriptionID", []string{"ARM_SUBSCRIPTION_ID"}),
+		ClientID:           stringValue(vars, "clientId", []string{"ARM_CLIENT_ID"}),
+		ClientSecret:       stringValue(vars, "clientSecret", []string{"ARM_CLIENT_SECRET"}),
+		TenantID:           stringValue(vars, "tenantId", []string{"ARM_TENANT_ID"}),
+		Environment:        envName,
+		ClientCertPath:     stringValue(vars, "clientCertificatePath", []string{"ARM_CLIENT_CERTIFICATE_PATH"}),
+		ClientCertPassword: stringValue(vars, "clientCertificatePassword", []string{"ARM_CLIENT_CERTIFICATE_PASSWORD"}),
+		MsiEndpoint:        stringValue(vars, "msiEndpoint", []string{"ARM_MSI_ENDPOINT"}),
+		//AuxiliaryTenantIDs:   auxTenants,
+		ClientSecretDocsLink: "https://www.pulumi.com/docs/intro/cloud-providers/azure/setup/#service-principal-authentication",
+
+		// Feature Toggles
+		SupportsClientCertAuth:   true,
+		SupportsClientSecretAuth: true,
+		//SupportsManagedServiceIdentity: useMsi,
+		SupportsAzureCliToken: true,
+		//SupportsAuxiliaryTenants:       len(auxTenants) > 0,
+	}
+
+	_, err := builder.Build()
+
+	if err != nil {
+		return fmt.Errorf("failed to load application credentials. Please run 'az login' to set up account.\n" +
+			"\tSee https://www.pulumi.com/registry/packages/azure/installation-configuration/ for details.")
+	}
+	return nil
+}
+
 // Provider returns additional overlaid schema and metadata associated with the azure package.
 //
 // nolint: lll
@@ -299,6 +355,7 @@ func Provider() tfbridge.ProviderInfo {
 				},
 			},
 		},
+		PreConfigureCallback: preConfigureCallback,
 		Resources: map[string]*tfbridge.ResourceInfo{
 			// Azure Active Directory Business to Consumer
 			"azurerm_aadb2c_directory": {


### PR DESCRIPTION
Fixes https://github.com/pulumi/home/issues/2274

**UPDATE** I decided the third party library is useful and azure-focused enough that we should probably just surface its errors. I added that functionality.

Also I rebased off of default, so the tests should clear.

 Here's the output on a pulumi-azure program when not logged in:
```
@guin:azure-classic-go🦉 PATH=/Users/guin/go/src/github.com/pulumi/pulumi-azure/bin:$PATH pulumi up
Please choose a stack, or create a new one: dev
Previewing update (dev)

View Live: https://app.pulumi.com/guinevere/azure-classic-go/dev/previews/929a8af5-2459-420f-825c-cbc3f5efece3

     Type                         Name                  Plan       Info
 +   pulumi:pulumi:Stack          azure-classic-go-dev  create     
     └─ azure:core:ResourceGroup  exampleResourceGroup             1 error
 
Diagnostics:
  azure:core:ResourceGroup (exampleResourceGroup):
    error: failed to load application credentials:
    Details: obtain subscription() from Azure CLI: parsing json result from the Azure CLI: waiting for the Azure CLI: exit status 1: ERROR: Please run 'az login' to setup account.
    
    	Please make sure you have signed in via 'az login' or configured another authentication method.
    	See https://www.pulumi.com/registry/packages/azure/installation-configuration/ for more information.
```
