### PR TITLE
Downgrade bridge to v3.38.1 from v3.39.0

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/hashicorp/terraform-provider-azurerm v1.44.1-0.20220923005104-eaa801c358ff
 	github.com/hashicorp/terraform-provider-azurerm/shim v0.0.0
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.39.0
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.38.1
 	github.com/pulumi/pulumi/sdk/v3 v3.53.1
 )
 

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1537,8 +1537,8 @@ github.com/prometheus/prometheus v0.37.0/go.mod h1:egARUgz+K93zwqsVIAneFlLZefyGO
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/pulumi/pulumi-java/pkg v0.7.1 h1:3tl36+I5BRYVXbq10mqDeh3X5kdJBaNDYiATOfEfgSY=
 github.com/pulumi/pulumi-java/pkg v0.7.1/go.mod h1:XdN2jYNlcQewr0MFecZfBnY3gnGcvV+WoPTzQqH48k4=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.39.0 h1:wjK7vofB5RpY4zo67lERQl+Uur5od/oBUoZr1H0T2Og=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.39.0/go.mod h1:EJf9ZhjOuZ7jxef1zy6tL4akyclmXzk0DDkhRQ+k2a0=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.38.1 h1:LhpJzV5b+7SpEVpYhS6IVYCKk+jO0WPY6yEfm7vJUYE=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.38.1/go.mod h1:RC9XOYwRU6c+1TtZKwwzpojz6POHz8Mbtx9qZcU+lPA=
 github.com/pulumi/pulumi-yaml v1.0.4 h1:p+989rW3AqkkxbzxtxccHKAN4xCJi3K2cRpvA2K84tw=
 github.com/pulumi/pulumi-yaml v1.0.4/go.mod h1:Szj8ud4Vqyq3oO1n3kzIUfaP3AiCjYZM4FYjOVWwJn8=
 github.com/pulumi/pulumi/pkg/v3 v3.53.1 h1:NSgzjci0ykEoKC2BHmp/brP7/V8ARafl8ovr76B9Jak=


### PR DESCRIPTION
Having various issues with unpredictable schema generations. This might fix the issue, but might not. This at least reduces the number of things changing at one time.