### PR TITLE
Fix useMsi Authorization Config

### DIFF
--- a/provider/resource.go
+++ b/provider/resource.go
@@ -330,7 +330,7 @@ func preConfigureCallback(vars resource.PropertyMap, c tfshim.ResourceConfig) er
 		// Feature Toggles
 		EnableAuthenticatingUsingClientCertificate: true,
 		EnableAuthenticatingUsingClientSecret:      true,
-		EnableAuthenticatingUsingManagedIdentity:   boolValue(vars, "msiEndpoint", []string{"ARM_USE_MSI"}),
+		EnableAuthenticatingUsingManagedIdentity:   boolValue(vars, "useMsi", []string{"ARM_USE_MSI"}),
 		EnableAuthenticatingUsingAzureCLI:          true,
 	}
 


### PR DESCRIPTION
https://www.pulumi.com/registry/packages/azure/installation-configuration/#configuration-options

According to azure classic documentation, `useMsi` should match the environment variable `ARM_USE_MSI`

![image](https://user-images.githubusercontent.com/122757931/225162744-319ff49f-756a-4bbd-973b-482a2894e227.png)
