### PR TITLE
Improve storage account autonaming

### DIFF
--- a/provider/resource.go
+++ b/provider/resource.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"unicode"
 
@@ -1992,6 +1993,13 @@ func Provider() tfbridge.ProviderInfo {
 			"azurerm_storage_account": {
 				Tok: azureResource(azureStorage, "Account"),
 				Fields: map[string]*tfbridge.SchemaInfo{
+					// https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftstorage
+					azureName: tfbridge.AutoNameWithCustomOptions(azureName, tfbridge.AutoNameOptions{
+						Separator: "",
+						Maxlen:    24,
+						Randlen:   8,
+						Transform: lowercaseLettersAndNumbers,
+					}),
 					"static_website": {
 						Name: "staticWebsite",
 						Elem: &tfbridge.SchemaInfo{
@@ -3467,4 +3475,10 @@ func Provider() tfbridge.ProviderInfo {
 	}
 
 	return prov
+}
+
+// lowercaseLettersAndNumbers applies the "Lowercase letters and numbers" naming convention to the given name.
+// See: https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
+func lowercaseLettersAndNumbers(name string) string {
+	return regexp.MustCompile("[^a-z0-9]").ReplaceAllString(strings.ToLower(name), "")
 }

--- a/provider/resource_test.go
+++ b/provider/resource_test.go
@@ -1,0 +1,22 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLowercaseLettersAndNumbers(t *testing.T) {
+	cases := map[string]string{
+		"abc123":  "abc123",
+		"ABC123":  "abc123",
+		"abc-123": "abc123",
+		"ABC-123": "abc123",
+		"abc_123": "abc123",
+		"ABC_123": "abc123",
+		"abc.123": "abc123",
+	}
+	for s, expected := range cases {
+		assert.Equal(t, lowercaseLettersAndNumbers(s), expected)
+	}
+}


### PR DESCRIPTION
Part of https://github.com/pulumi/pulumi-azure/issues/1242 that applies improved auto-naming for storage account resources per the rules in https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftstorage.