### PR TITLE
OIDC support

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -494,6 +494,9 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         version: v2.4.0
     - name: Run tests
+      env:
+        # specifying this id will cause the OIDC test(s) to run against this AD application
+        OIDC_ARM_CLIENT_ID: "89380e12-5be6-486a-89ef-eea107af2f47" # AD app 'oidc-test'
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
         matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - if: failure() && github.event_name == 'push'

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -312,6 +312,9 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         version: v2.4.0
     - name: Run tests
+      env:
+        # specifying this id will cause the OIDC test(s) to run against this AD application
+        OIDC_ARM_CLIENT_ID: "89380e12-5be6-486a-89ef-eea107af2f47" # AD app 'oidc-test'
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
         matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - if: failure() && github.event_name == 'push'

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -313,8 +313,9 @@ jobs:
         version: v2.4.0
     - name: Run tests
       env:
-        # specifying this id will cause the OIDC test(s) to run against this AD application
-        OIDC_ARM_CLIENT_ID: "89380e12-5be6-486a-89ef-eea107af2f47" # AD app 'oidc-test'
+        # Specifying this id will cause the OIDC test(s) to run against this AD application ('oidc-test').
+        # The AD application only has credentials for PRs and for the master branch.
+        OIDC_ARM_CLIENT_ID: "${{ (github.event_name == 'pull_request' || github.ref_name == 'master') && '89380e12-5be6-486a-89ef-eea107af2f47' || '' }}"
       run: cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{
         matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
     - if: failure() && github.event_name == 'push'

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -36,7 +36,7 @@ env:
   TRAVIS_OS_NAME: linux
 jobs:
   build_sdk:
-    if: github.event_name == 'repository_dispatch' ||
+    if: github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: build_sdk
     needs: prerequisites
@@ -148,7 +148,7 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         token: ${{ secrets.PULUMI_BOT_TOKEN }}
   prerequisites:
-    if: github.event_name == 'repository_dispatch' ||
+    if: github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: prerequisites
     runs-on: ubuntu-latest
@@ -225,7 +225,7 @@ jobs:
     - name: Is workflow a success
       run: echo yes
   test:
-    if: github.event_name == 'repository_dispatch' ||
+    if: github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: test
     needs: build_sdk
@@ -344,3 +344,4 @@ on:
   repository_dispatch:
     types:
     - run-acceptance-tests-command
+  workflow_dispatch: {}

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -6,6 +6,7 @@ package examples
 
 import (
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -173,6 +174,27 @@ func TestAccNetwork(t *testing.T) {
 			Dir:                  filepath.Join(getCwd(t), "network"),
 			RunUpdateTest:        true,
 			ExpectRefreshChanges: true,
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
+func TestAccNetwork_OIDC(t *testing.T) {
+	oidcClientId := os.Getenv("OIDC_ARM_CLIENT_ID")
+	if oidcClientId == "" {
+		t.Skip("Skipping OIDC test without OIDC_ARM_CLIENT_ID")
+	}
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir:                  filepath.Join(getCwd(t), "network"),
+			RunUpdateTest:        true,
+			ExpectRefreshChanges: true,
+			Env: []string{
+				"ARM_USE_OIDC=true",
+				"ARM_CLIENT_ID=" + oidcClientId,
+				// not strictly necessary but making sure we test the OIDC path
+				"ARM_CLIENT_SECRET=",
+			},
 		})
 
 	integration.ProgramTest(t, &test)

--- a/provider/resource.go
+++ b/provider/resource.go
@@ -319,7 +319,9 @@ func preConfigureCallback(vars resource.PropertyMap, c tfshim.ResourceConfig) er
 	auxTenants := arrayValue(vars, "auxiliaryTenantIDs", []string{"ARM_AUXILIARY_TENANT_IDS"})
 
 	// validate the azure config
+	useOIDC := boolValue(vars, "useOidc", []string{"ARM_USE_OIDC"})
 	authConfig := auth.Credentials{
+		// SubscriptionID:                stringValue(vars, "subscriptionId", []string{"ARM_SUBSCRIPTION_ID"}),
 		ClientID:                      stringValue(vars, "clientId", []string{"ARM_CLIENT_ID"}),
 		ClientSecret:                  stringValue(vars, "clientSecret", []string{"ARM_CLIENT_SECRET"}),
 		TenantID:                      stringValue(vars, "tenantId", []string{"ARM_TENANT_ID"}),
@@ -329,11 +331,18 @@ func preConfigureCallback(vars resource.PropertyMap, c tfshim.ResourceConfig) er
 		CustomManagedIdentityEndpoint: stringValue(vars, "msiEndpoint", []string{"ARM_MSI_ENDPOINT"}),
 		AuxiliaryTenantIDs:            auxTenants,
 
+		// OIDC section. The ACTIONS_ variables are set by GitHub.
+		GitHubOIDCTokenRequestToken: stringValue(vars, "oidcRequestToken", []string{"ARM_OIDC_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN"}),
+		GitHubOIDCTokenRequestURL:   stringValue(vars, "oidcRequestUrl", []string{"ARM_OIDC_REQUEST_URL", "ACTIONS_ID_TOKEN_REQUEST_URL"}),
+		OIDCAssertionToken:          stringValue(vars, "oidcToken", []string{"ARM_OIDC_TOKEN"}),
+
 		// Feature Toggles
 		EnableAuthenticatingUsingClientCertificate: true,
 		EnableAuthenticatingUsingClientSecret:      true,
 		EnableAuthenticatingUsingManagedIdentity:   boolValue(vars, "useMsi", []string{"ARM_USE_MSI"}),
 		EnableAuthenticatingUsingAzureCLI:          true,
+		EnableAuthenticationUsingOIDC:              useOIDC,
+		EnableAuthenticationUsingGitHubOIDC:        useOIDC,
 	}
 
 	_, err = auth.NewAuthorizerFromCredentials(context.Background(), authConfig, env.MicrosoftGraph)


### PR DESCRIPTION
- Add OIDC configuration
- Add OIDC testing in CI

[CI test run with debug logging on to prove we're setting `OIDC_ARM_CLIENT_ID`](https://github.com/pulumi/pulumi-azure/actions/runs/4567390150/jobs/8064673591).

Supersedes #1165