### PR TITLE
Remove default values for Backup VM Policies in upstream provider

### DIFF
--- a/patches/0001-Client-options.patch
+++ b/patches/0001-Client-options.patch
@@ -1,7 +1,7 @@
-From 86dffa760caf22f51898d62cea9e1d2438866da4 Mon Sep 17 00:00:00 2001
+From 1d5a9056aeae1cc1e65a17fc130245b4abcfc80c Mon Sep 17 00:00:00 2001
 From: aq17 <aqiu@pulumi.com>
 Date: Thu, 25 May 2023 10:33:38 -0700
-Subject: [PATCH 1/8] Client-options
+Subject: [PATCH 1/9] Client-options
 
 ---
  internal/common/client_options.go | 15 +++++----------
@@ -50,5 +50,5 @@ index 6eba6eeaed..56ccbd5f87 100644
  
  	if partnerID != "" {
 -- 
-2.41.0
+2.39.2 (Apple Git-143)
 

--- a/patches/0002-Shared-features.patch
+++ b/patches/0002-Shared-features.patch
@@ -1,7 +1,7 @@
-From 0745908fec984437e0cf7852d4d1de665f67e173 Mon Sep 17 00:00:00 2001
+From ca25bd6b791fb66f6bcc75a44e7d3bd91003e8e1 Mon Sep 17 00:00:00 2001
 From: aq17 <aqiu@pulumi.com>
 Date: Thu, 25 May 2023 10:33:38 -0700
-Subject: [PATCH 2/8] Shared-features
+Subject: [PATCH 2/9] Shared-features
 
 ---
  internal/features/four_point_oh.go | 6 ++++++
@@ -36,5 +36,5 @@ index bdb0cbfe3a..c4122bf0bc 100644
  		MinItems: 1,
  		Elem: &pluginsdk.Resource{
 -- 
-2.41.0
+2.39.2 (Apple Git-143)
 

--- a/patches/0003-Add-new-resources.patch
+++ b/patches/0003-Add-new-resources.patch
@@ -1,7 +1,7 @@
-From 69441c2f48c60a0c92ff03e91415f04a1753f0ae Mon Sep 17 00:00:00 2001
+From c6dedc0f310770a8b60ae63497b17f9da7a7497b Mon Sep 17 00:00:00 2001
 From: aq17 <aqiu@pulumi.com>
 Date: Thu, 25 May 2023 10:33:38 -0700
-Subject: [PATCH 3/8] Add-new-resources
+Subject: [PATCH 3/9] Add-new-resources
 
 ---
  .../parse/proximity_placement_group.go        |  69 ++++++++++
@@ -4842,5 +4842,5 @@ index 0000000000..ad87350b81
 +	}
 +}
 -- 
-2.41.0
+2.39.2 (Apple Git-143)
 

--- a/patches/0004-fixup-Shared-features.patch
+++ b/patches/0004-fixup-Shared-features.patch
@@ -1,7 +1,7 @@
-From f5f613cf921bc36573302a63fd723ac22be690de Mon Sep 17 00:00:00 2001
+From e1400ccb19dcdf1156fc0cbc31905c08190855b5 Mon Sep 17 00:00:00 2001
 From: aq17 <aqiu@pulumi.com>
 Date: Thu, 25 May 2023 10:33:38 -0700
-Subject: [PATCH 4/8] fixup-Shared-features
+Subject: [PATCH 4/9] fixup-Shared-features
 
 ---
  internal/tf/suppress/deprecated_soon.go | 6 ++++++
@@ -22,5 +22,5 @@ index 926f57f880..815f6e3006 100644
 +	return strings.EqualFold(old, new)
 +}
 -- 
-2.41.0
+2.39.2 (Apple Git-143)
 

--- a/patches/0005-Modify-resources.patch
+++ b/patches/0005-Modify-resources.patch
@@ -1,7 +1,7 @@
-From 3ad036935d30dcf7e4110c33da435d5d1e0ea2df Mon Sep 17 00:00:00 2001
+From 39afe3d83b8f7d7bb6e6833dd8c04ef40305aec1 Mon Sep 17 00:00:00 2001
 From: aq17 <aqiu@pulumi.com>
 Date: Thu, 25 May 2023 10:33:38 -0700
-Subject: [PATCH 5/8] Modify-resources
+Subject: [PATCH 5/9] Modify-resources
 
 ---
  .../advisor_recommendations_data_source.go    |  6 ++-
@@ -2941,5 +2941,5 @@ index da8c25a5b0..fa2bfff38e 100644
  	}
  
 -- 
-2.41.0
+2.39.2 (Apple Git-143)
 

--- a/patches/0006-Add-privatedns-parse.patch
+++ b/patches/0006-Add-privatedns-parse.patch
@@ -1,7 +1,7 @@
-From 248ca568a264a6fff255539431250592bf682b46 Mon Sep 17 00:00:00 2001
+From ed9f28c2b8604fb66a10f472206ff538296da3d9 Mon Sep 17 00:00:00 2001
 From: aq17 <aqiu@pulumi.com>
 Date: Thu, 25 May 2023 10:33:39 -0700
-Subject: [PATCH 6/8] Add-privatedns-parse
+Subject: [PATCH 6/9] Add-privatedns-parse
 
 ---
  .../services/privatedns/parse/a_record.go     |  75 ++++++++++
@@ -1956,5 +1956,5 @@ index 0000000000..1f45b56b1b
 +	}
 +}
 -- 
-2.41.0
+2.39.2 (Apple Git-143)
 

--- a/patches/0007-Update-documentation.patch
+++ b/patches/0007-Update-documentation.patch
@@ -1,7 +1,7 @@
-From 4c09b9fcf5e7acf770e58897910810f52840417c Mon Sep 17 00:00:00 2001
+From 9ad2b91fc170a884fe548d6f1b525089d36ee3e3 Mon Sep 17 00:00:00 2001
 From: aq17 <aqiu@pulumi.com>
 Date: Thu, 25 May 2023 10:33:39 -0700
-Subject: [PATCH 7/8] Update-documentation
+Subject: [PATCH 7/9] Update-documentation
 
 ---
  .../d/function_app_host_keys.html.markdown    |   2 -
@@ -3264,5 +3264,5 @@ index e94d26bbb6..3b17a31535 100644
  
  A `gallery_application` block supports the following:
 -- 
-2.41.0
+2.39.2 (Apple Git-143)
 

--- a/patches/0008-expose-provider.patch
+++ b/patches/0008-expose-provider.patch
@@ -1,7 +1,7 @@
-From 8dd5cfbd098292e7a1aa5517faa23523de8a4633 Mon Sep 17 00:00:00 2001
+From c52f982ed427a25fcba5f763f452abf99a8250ac Mon Sep 17 00:00:00 2001
 From: aq17 <aqiu@pulumi.com>
 Date: Thu, 25 May 2023 10:33:39 -0700
-Subject: [PATCH 8/8] expose-provider
+Subject: [PATCH 8/9] expose-provider
 
 ---
  shim/shim.go | 10 ++++++++++
@@ -25,5 +25,5 @@ index 0000000000..cd6b26156c
 +	return provider.AzureProvider()
 +}
 -- 
-2.41.0
+2.39.2 (Apple Git-143)
 

--- a/patches/0009-remove-defaults-backup-retention-policies.patch
+++ b/patches/0009-remove-defaults-backup-retention-policies.patch
@@ -1,0 +1,43 @@
+From 9d7ecb05ba1c2329f8a215b54d943159d28a2624 Mon Sep 17 00:00:00 2001
+From: Ramon Quitales <ramon@pulumi.com>
+Date: Wed, 9 Aug 2023 13:05:13 -1000
+Subject: [PATCH 9/9] remove defaults backup retention policies
+
+Fixes #1318
+---
+ .../services/recoveryservices/backup_policy_vm_resource.go  | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/internal/services/recoveryservices/backup_policy_vm_resource.go b/internal/services/recoveryservices/backup_policy_vm_resource.go
+index 097e3ab2f0..313190d12c 100644
+--- a/internal/services/recoveryservices/backup_policy_vm_resource.go
++++ b/internal/services/recoveryservices/backup_policy_vm_resource.go
+@@ -1072,10 +1072,11 @@ func resourceBackupProtectionPolicyVMSchema() map[string]*pluginsdk.Schema {
+ 						},
+ 					},
+ 
++					// FORK: Removed default value due to pulumi-azure#1318
++					// These modifications can be removed once pulumi-terraform-bridge#577 is fixed.
+ 					"include_last_days": {
+ 						Type:     pluginsdk.TypeBool,
+ 						Optional: true,
+-						Default:  false,
+ 						ConflictsWith: []string{
+ 							"retention_monthly.0.weeks",
+ 							"retention_monthly.0.weekdays",
+@@ -1186,10 +1187,11 @@ func resourceBackupProtectionPolicyVMSchema() map[string]*pluginsdk.Schema {
+ 						},
+ 					},
+ 
++					// FORK: Removed default value due to pulumi-azure#1318
++					// These modifications can be removed once pulumi-terraform-bridge#577 is fixed.
+ 					"include_last_days": {
+ 						Type:     pluginsdk.TypeBool,
+ 						Optional: true,
+-						Default:  false,
+ 						ConflictsWith: []string{
+ 							"retention_yearly.0.weeks",
+ 							"retention_yearly.0.weekdays",
+-- 
+2.39.2 (Apple Git-143)
+


### PR DESCRIPTION
Fixes: #1318 

This PR adds a new patchset to remove default values in the upstream azurerm provider. The new file added of interest is:
`patches/0009-remove-defaults-backup-retention-policies.patch`