### PR TITLE
Re-enable skipped tests that were waiting for upstream fixes

### DIFF
--- a/examples/aci-volume-mount/package.json
+++ b/examples/aci-volume-mount/package.json
@@ -3,10 +3,11 @@
     "version": "0.0.1",
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/azure": "^4.0.0"
+        "@pulumi/azure": "^5.0.0"
     },
     "devDependencies": {
-        "@types/node": "^10.0.0"
+        "@types/node": "^18.0.0",
+        "typescript": "^4.6.2"
     },
     "license": "Apache 2.0"
 }

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -234,6 +234,8 @@ func TestAccQueue(t *testing.T) {
 }
 
 func TestAccIot(t *testing.T) {
+	t.Skip(`Fails with error: TypeError: sharedAccessPolicies.find is not a function
+		at /home/runner/work/pulumi-azure/pulumi-azure/sdk/nodejs/iot/zMixins.ts:142:131`)
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir:           filepath.Join(getCwd(t), "iot"),

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -31,10 +31,7 @@ func TestAccMultiCallback(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "multi-callback-all"),
-			// Removed until the next release after 1.4.0,
-			// see https://github.com/pulumi/pulumi-azure/pull/417#issuecomment-558227019
 			// RunUpdateTest: true,
-			// work around https://github.com/terraform-providers/terraform-provider-azurerm/issues/4598
 			AllowEmptyPreviewChanges: true,
 			AllowEmptyUpdateChanges:  true,
 		})
@@ -72,11 +69,8 @@ func TestAccAciVolumeMount(t *testing.T) {
 	skipIfShort(t)
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			Dir: filepath.Join(getCwd(t), "aci-volume-mount"),
-			// TODO: Turn this back on after upstream version v3.6.0.
-			// Upstream added a new property to one of the resources in the test, which causes the test to fail when
-			// RunUpdateTest == true.
-			RunUpdateTest: false,
+			Dir:           filepath.Join(getCwd(t), "aci-volume-mount"),
+			RunUpdateTest: true,
 		})
 
 	integration.ProgramTest(t, &test)
@@ -107,17 +101,15 @@ func TestAccTable(t *testing.T) {
 func TestAccServicebusMigration(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			Dir: filepath.Join(getCwd(t), "servicebus-migration-test"),
-			// Removed until the next release after 1.4.0,
-			// see https://github.com/pulumi/pulumi-azure/pull/417#issuecomment-558227019
-			// RunUpdateTest: true,
-			//EditDirs: []integration.EditDir{
-			//	{
-			//		Dir:             "step2",
-			//		Additive:        true,
-			//		ExpectNoChanges: true,
-			//	},
-			//},
+			Dir:           filepath.Join(getCwd(t), "servicebus-migration-test"),
+			RunUpdateTest: true,
+			EditDirs: []integration.EditDir{
+				{
+					Dir:             "step2",
+					Additive:        true,
+					ExpectNoChanges: true,
+				},
+			},
 		})
 
 	integration.ProgramTest(t, &test)
@@ -201,7 +193,6 @@ func TestAccNetwork_OIDC(t *testing.T) {
 }
 
 func TestAccWebserver(t *testing.T) {
-	t.Skip("Skipping until v2.80.0 release comes out upstream")
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir:                  filepath.Join(getCwd(t), "webserver"),
@@ -216,8 +207,6 @@ func TestAccTopic(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "topic"),
-			// Removed until the next release after 1.4.0,
-			// see https://github.com/pulumi/pulumi-azure/pull/417#issuecomment-558227019
 			// RunUpdateTest: true,
 		})
 
@@ -245,7 +234,6 @@ func TestAccQueue(t *testing.T) {
 }
 
 func TestAccIot(t *testing.T) {
-	t.Skip("Temp Skipping as part of Pulumi May4th Release")
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir:           filepath.Join(getCwd(t), "iot"),
@@ -291,11 +279,8 @@ func TestAccEventgrid(t *testing.T) {
 func TestAccEventhub(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			Dir: filepath.Join(getCwd(t), "eventhub"),
-			// Removed until the next release after 1.4.0,
-			// see https://github.com/pulumi/pulumi-azure/pull/417#issuecomment-558227019
-			// RunUpdateTest: true,
-			// work around https://github.com/terraform-providers/terraform-provider-azurerm/issues/4598
+			Dir:                      filepath.Join(getCwd(t), "eventhub"),
+			RunUpdateTest:            true,
 			AllowEmptyPreviewChanges: true,
 			AllowEmptyUpdateChanges:  true,
 		})

--- a/examples/iot/package.json
+++ b/examples/iot/package.json
@@ -4,10 +4,10 @@
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "mime-types": "^2.1.19",
-        "@pulumi/azure": "^4.0.0"
+        "@pulumi/azure": "^5.0.0"
     },
     "devDependencies": {
-        "@types/node": "^10.0.0"
+        "@types/node": "^18.0.0"
     },
     "license": "Apache 2.0"
 }

--- a/examples/webserver/index.ts
+++ b/examples/webserver/index.ts
@@ -20,7 +20,7 @@ let networkInterface = new azure.network.NetworkInterface(name, {
     ipConfigurations: [{
         name: "webserveripcfg",
         subnetId: network.subnets[0].id,
-        privateIpAddressAllocation: "dynamic",
+        privateIpAddressAllocation: "Dynamic",
     }],
 });
 


### PR DESCRIPTION
At the time of submitting the PR I have verified that the mentioned upstream versions have been released, but haven't run the tests yet. ~~We'll see what CI says.~~ Update: after a few small fixes, all but one test are re-enabled.