### PR TITLE
Do not assume ExpectRefreshChanges: true for all tests

### DIFF
--- a/examples/examples_dotnet_test.go
+++ b/examples/examples_dotnet_test.go
@@ -31,6 +31,6 @@ func TestAccAppServiceCs(t *testing.T) {
 				assert.Equal(t, body, "Hello Pulumi")
 			}),
 		})
-
+	skipRefresh(&test)
 	integration.ProgramTest(t, &test)
 }

--- a/examples/examples_go_test.go
+++ b/examples/examples_go_test.go
@@ -26,6 +26,9 @@ func TestAccNetworkGo(t *testing.T) {
 	test := getGoBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "network-go"),
+
+			// TODO[pulumi/pulumi-azure#1569] refresh tries to edit subnets
+			SkipRefresh: true,
 		})
 
 	integration.ProgramTest(t, &test)

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -111,7 +111,7 @@ func TestAccServicebusMigration(t *testing.T) {
 				},
 			},
 		})
-
+	skipRefresh(&test)
 	integration.ProgramTest(t, &test)
 }
 
@@ -209,7 +209,7 @@ func TestAccTopic(t *testing.T) {
 			Dir: filepath.Join(getCwd(t), "topic"),
 			// RunUpdateTest: true,
 		})
-
+	skipRefresh(&test)
 	integration.ProgramTest(t, &test)
 }
 
@@ -219,7 +219,7 @@ func TestAccTimer(t *testing.T) {
 			Dir:           filepath.Join(getCwd(t), "timer"),
 			RunUpdateTest: true,
 		})
-
+	skipRefresh(&test)
 	integration.ProgramTest(t, &test)
 }
 
@@ -229,7 +229,7 @@ func TestAccQueue(t *testing.T) {
 			Dir:           filepath.Join(getCwd(t), "queue"),
 			RunUpdateTest: true,
 		})
-
+	skipRefresh(&test)
 	integration.ProgramTest(t, &test)
 }
 
@@ -260,7 +260,7 @@ func TestAccDurableFunctions(t *testing.T) {
 			Dir:           filepath.Join(getCwd(t), "durable-functions"),
 			RunUpdateTest: false,
 		})
-
+	skipRefresh(&test)
 	integration.ProgramTest(t, &test)
 }
 
@@ -286,7 +286,7 @@ func TestAccEventhub(t *testing.T) {
 			AllowEmptyPreviewChanges: true,
 			AllowEmptyUpdateChanges:  true,
 		})
-
+	skipRefresh(&test)
 	integration.ProgramTest(t, &test)
 }
 
@@ -296,7 +296,7 @@ func TestAccHttpExternal(t *testing.T) {
 			Dir:           filepath.Join(getCwd(t), "http-external"),
 			RunUpdateTest: true,
 		})
-
+	skipRefresh(&test)
 	integration.ProgramTest(t, &test)
 }
 
@@ -306,7 +306,7 @@ func TestAccHttpMulti(t *testing.T) {
 			Dir:           filepath.Join(getCwd(t), "http-multi"),
 			RunUpdateTest: true,
 		})
-
+	skipRefresh(&test)
 	integration.ProgramTest(t, &test)
 }
 
@@ -321,7 +321,7 @@ func TestAccSecretCapture(t *testing.T) {
 				assert.NotContains(t, "s3cr3t", string(byts))
 			},
 		})
-
+	skipRefresh(&test)
 	integration.ProgramTest(t, &test)
 }
 
@@ -331,7 +331,7 @@ func TestAccLinuxVirtualMachines(t *testing.T) {
 			Dir:           filepath.Join(getCwd(t), "linux-virtual-machine"),
 			RunUpdateTest: true,
 		})
-
+	skipRefresh(&test)
 	integration.ProgramTest(t, &test)
 }
 

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -94,7 +94,7 @@ func TestAccTable(t *testing.T) {
 			Dir:           filepath.Join(getCwd(t), "table"),
 			RunUpdateTest: true,
 		})
-
+	skipRefresh(&test)
 	integration.ProgramTest(t, &test)
 }
 

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -43,11 +43,10 @@ func TestAccLoadbalancer(t *testing.T) {
 	skipIfShort(t)
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			Dir:                      filepath.Join(getCwd(t), "loadbalancer"),
-			RunUpdateTest:            false, // the subresources now longer have a resource group in them
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges:  true,
-			// TO-DO: (@stack72) there is a strangeness with lb.Loadbalancer and the FrontendIpConfiguration
+			Dir: filepath.Join(getCwd(t), "loadbalancer"),
+
+			// TODO[pulumi/pulumi-azure#1571] various issues with non-empty refresh.
+			SkipRefresh: true,
 		})
 
 	integration.ProgramTest(t, &test)

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -82,3 +82,12 @@ func validateAPITest(isValid func(body string)) func(t *testing.T, stack integra
 		isValid(string(body))
 	}
 }
+
+// A lot of tests currently generate non-empty diffs upon refresh. While the work of root-causing
+// each individual test has not been done yet, a few common known causes are listed here:
+//
+// TODO[pulumi/pulumi-terraform-bridge#1595]
+// TODO[pulumi/pulumi-azure#1568]
+func skipRefresh(opts *integration.ProgramTestOptions) {
+	opts.SkipRefresh = true
+}

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -53,7 +53,6 @@ func getBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	environ := getEnviron(t)
 	azureLocation := getLocation(t)
 	return integration.ProgramTestOptions{
-		ExpectRefreshChanges: true,
 		Config: map[string]string{
 			"azure:environment": environ,
 			"azure:location":    azureLocation,

--- a/examples/loadbalancer/index.ts
+++ b/examples/loadbalancer/index.ts
@@ -48,7 +48,7 @@ const backendPool = new azure.lb.BackendAddressPool("backendPool", {
 const tcp = new azure.lb.NatRule("tcp", {
     resourceGroupName: resourceGroup.name,
     loadbalancerId: lb.id,
-    protocol: "tcp",
+    protocol: "Tcp",
     frontendPort: 5000,
     backendPort: 3389,
     frontendIpConfigurationName: "LoadBalancerFrontEnd",
@@ -56,7 +56,7 @@ const tcp = new azure.lb.NatRule("tcp", {
 
 const lbprobe = new azure.lb.Probe("lbprobe", {
     loadbalancerId: lb.id,
-    protocol: "tcp",
+    protocol: "Tcp",
     port: 80,
     intervalInSeconds: 5,
     numberOfProbes: 2,
@@ -64,7 +64,7 @@ const lbprobe = new azure.lb.Probe("lbprobe", {
 
 const lbrule = new azure.lb.Rule("lbrule", {
     loadbalancerId: lb.id,
-    protocol: "tcp",
+    protocol: "Tcp",
     frontendPort: 80,
     backendPort: 80,
     frontendIpConfigurationName: "LoadBalancerFrontEnd",


### PR DESCRIPTION
Before this change unexpected refresh change were ignored for all example-based integration tests via `ExpectRefreshChanges: true`, so accidentally regressing on this would have gone unnoticed. After the PR such settings are only set on examples that currently need them and they are cross-linked with issues causing the problem. 