### PR TITLE
Mark sensitive config settings

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -548,6 +548,7 @@ func Provider() tfbridge.ProviderInfo {
 	// Adjust the defaults if running in Azure Cloud Shell.
 	// Environment variables still take preference, e.g. USE_MSI=false disables the MSI endpoint.
 	cloudShell := detectCloudShell()
+	yes := true
 
 	prov := tfbridge.ProviderInfo{
 		P:                p,
@@ -567,6 +568,7 @@ func Provider() tfbridge.ProviderInfo {
 					Value:   cloudShell.subscriptionID,
 					EnvVars: []string{"ARM_SUBSCRIPTION_ID"},
 				},
+				Secret: &yes,
 			},
 			"environment": {
 				Default: &tfbridge.DefaultInfo{
@@ -591,6 +593,18 @@ func Provider() tfbridge.ProviderInfo {
 					EnvVars: []string{"ARM_METADATA_HOSTNAME"},
 				},
 			},
+			"auxillary_tenant_ids":        {Secret: &yes},
+			"client_certificate":          {Secret: &yes},
+			"client_certificate_password": {Secret: &yes},
+			"client_certificate_path":     {Secret: &yes},
+			"client_id":                   {Secret: &yes},
+			"client_id_file_path":         {Secret: &yes},
+			"client_secret":               {Secret: &yes},
+			"client_secret_file_path":     {Secret: &yes},
+			"oidc_request_token":          {Secret: &yes},
+			"oidc_token":                  {Secret: &yes},
+			"oidc_token_file_path":        {Secret: &yes},
+			"tenant_id":                   {Secret: &yes},
 		},
 		ExtraConfig: map[string]*tfbridge.ConfigInfo{
 			azureLocation: {

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -144,6 +144,21 @@ namespace Pulumi.Azure
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                AdditionalSecretOutputs =
+                {
+                    "clientCertificate",
+                    "clientCertificatePassword",
+                    "clientCertificatePath",
+                    "clientId",
+                    "clientIdFilePath",
+                    "clientSecret",
+                    "clientSecretFilePath",
+                    "oidcRequestToken",
+                    "oidcToken",
+                    "oidcTokenFilePath",
+                    "subscriptionId",
+                    "tenantId",
+                },
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.
@@ -162,50 +177,120 @@ namespace Pulumi.Azure
             set => _auxiliaryTenantIds = value;
         }
 
+        [Input("clientCertificate")]
+        private Input<string>? _clientCertificate;
+
         /// <summary>
         /// Base64 encoded PKCS#12 certificate bundle to use when authenticating as a Service Principal using a Client Certificate
         /// </summary>
-        [Input("clientCertificate")]
-        public Input<string>? ClientCertificate { get; set; }
+        public Input<string>? ClientCertificate
+        {
+            get => _clientCertificate;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _clientCertificate = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        [Input("clientCertificatePassword")]
+        private Input<string>? _clientCertificatePassword;
 
         /// <summary>
         /// The password associated with the Client Certificate. For use when authenticating as a Service Principal using a Client
         /// Certificate
         /// </summary>
-        [Input("clientCertificatePassword")]
-        public Input<string>? ClientCertificatePassword { get; set; }
+        public Input<string>? ClientCertificatePassword
+        {
+            get => _clientCertificatePassword;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _clientCertificatePassword = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        [Input("clientCertificatePath")]
+        private Input<string>? _clientCertificatePath;
 
         /// <summary>
         /// The path to the Client Certificate associated with the Service Principal for use when authenticating as a Service
         /// Principal using a Client Certificate.
         /// </summary>
-        [Input("clientCertificatePath")]
-        public Input<string>? ClientCertificatePath { get; set; }
+        public Input<string>? ClientCertificatePath
+        {
+            get => _clientCertificatePath;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _clientCertificatePath = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        [Input("clientId")]
+        private Input<string>? _clientId;
 
         /// <summary>
         /// The Client ID which should be used.
         /// </summary>
-        [Input("clientId")]
-        public Input<string>? ClientId { get; set; }
+        public Input<string>? ClientId
+        {
+            get => _clientId;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _clientId = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        [Input("clientIdFilePath")]
+        private Input<string>? _clientIdFilePath;
 
         /// <summary>
         /// The path to a file containing the Client ID which should be used.
         /// </summary>
-        [Input("clientIdFilePath")]
-        public Input<string>? ClientIdFilePath { get; set; }
+        public Input<string>? ClientIdFilePath
+        {
+            get => _clientIdFilePath;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _clientIdFilePath = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        [Input("clientSecret")]
+        private Input<string>? _clientSecret;
 
         /// <summary>
         /// The Client Secret which should be used. For use When authenticating as a Service Principal using a Client Secret.
         /// </summary>
-        [Input("clientSecret")]
-        public Input<string>? ClientSecret { get; set; }
+        public Input<string>? ClientSecret
+        {
+            get => _clientSecret;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _clientSecret = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        [Input("clientSecretFilePath")]
+        private Input<string>? _clientSecretFilePath;
 
         /// <summary>
         /// The path to a file containing the Client Secret which should be used. For use When authenticating as a Service Principal
         /// using a Client Secret.
         /// </summary>
-        [Input("clientSecretFilePath")]
-        public Input<string>? ClientSecretFilePath { get; set; }
+        public Input<string>? ClientSecretFilePath
+        {
+            get => _clientSecretFilePath;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _clientSecretFilePath = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
 
         /// <summary>
         /// This will disable the x-ms-correlation-request-id header.
@@ -241,12 +326,22 @@ namespace Pulumi.Azure
         [Input("msiEndpoint")]
         public Input<string>? MsiEndpoint { get; set; }
 
+        [Input("oidcRequestToken")]
+        private Input<string>? _oidcRequestToken;
+
         /// <summary>
         /// The bearer token for the request to the OIDC provider. For use when authenticating as a Service Principal using OpenID
         /// Connect.
         /// </summary>
-        [Input("oidcRequestToken")]
-        public Input<string>? OidcRequestToken { get; set; }
+        public Input<string>? OidcRequestToken
+        {
+            get => _oidcRequestToken;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _oidcRequestToken = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
 
         /// <summary>
         /// The URL for the OIDC provider from which to request an ID token. For use when authenticating as a Service Principal
@@ -255,17 +350,37 @@ namespace Pulumi.Azure
         [Input("oidcRequestUrl")]
         public Input<string>? OidcRequestUrl { get; set; }
 
+        [Input("oidcToken")]
+        private Input<string>? _oidcToken;
+
         /// <summary>
         /// The OIDC ID token for use when authenticating as a Service Principal using OpenID Connect.
         /// </summary>
-        [Input("oidcToken")]
-        public Input<string>? OidcToken { get; set; }
+        public Input<string>? OidcToken
+        {
+            get => _oidcToken;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _oidcToken = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        [Input("oidcTokenFilePath")]
+        private Input<string>? _oidcTokenFilePath;
 
         /// <summary>
         /// The path to a file containing an OIDC ID token for use when authenticating as a Service Principal using OpenID Connect.
         /// </summary>
-        [Input("oidcTokenFilePath")]
-        public Input<string>? OidcTokenFilePath { get; set; }
+        public Input<string>? OidcTokenFilePath
+        {
+            get => _oidcTokenFilePath;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _oidcTokenFilePath = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
 
         /// <summary>
         /// A GUID/UUID that is registered with Microsoft to facilitate partner resource usage attribution.
@@ -286,17 +401,37 @@ namespace Pulumi.Azure
         [Input("storageUseAzuread", json: true)]
         public Input<bool>? StorageUseAzuread { get; set; }
 
+        [Input("subscriptionId")]
+        private Input<string>? _subscriptionId;
+
         /// <summary>
         /// The Subscription ID which should be used.
         /// </summary>
-        [Input("subscriptionId")]
-        public Input<string>? SubscriptionId { get; set; }
+        public Input<string>? SubscriptionId
+        {
+            get => _subscriptionId;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _subscriptionId = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        [Input("tenantId")]
+        private Input<string>? _tenantId;
 
         /// <summary>
         /// The Tenant ID which should be used.
         /// </summary>
-        [Input("tenantId")]
-        public Input<string>? TenantId { get; set; }
+        public Input<string>? TenantId
+        {
+            get => _tenantId;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _tenantId = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
 
         /// <summary>
         /// Allow Azure AKS Workload Identity to be used for Authentication.

--- a/sdk/go/azure/provider.go
+++ b/sdk/go/azure/provider.go
@@ -92,6 +92,57 @@ func NewProvider(ctx *pulumi.Context,
 			args.SubscriptionId = pulumi.StringPtr(d.(string))
 		}
 	}
+	if args.ClientCertificate != nil {
+		args.ClientCertificate = pulumi.ToSecret(args.ClientCertificate).(pulumi.StringPtrInput)
+	}
+	if args.ClientCertificatePassword != nil {
+		args.ClientCertificatePassword = pulumi.ToSecret(args.ClientCertificatePassword).(pulumi.StringPtrInput)
+	}
+	if args.ClientCertificatePath != nil {
+		args.ClientCertificatePath = pulumi.ToSecret(args.ClientCertificatePath).(pulumi.StringPtrInput)
+	}
+	if args.ClientId != nil {
+		args.ClientId = pulumi.ToSecret(args.ClientId).(pulumi.StringPtrInput)
+	}
+	if args.ClientIdFilePath != nil {
+		args.ClientIdFilePath = pulumi.ToSecret(args.ClientIdFilePath).(pulumi.StringPtrInput)
+	}
+	if args.ClientSecret != nil {
+		args.ClientSecret = pulumi.ToSecret(args.ClientSecret).(pulumi.StringPtrInput)
+	}
+	if args.ClientSecretFilePath != nil {
+		args.ClientSecretFilePath = pulumi.ToSecret(args.ClientSecretFilePath).(pulumi.StringPtrInput)
+	}
+	if args.OidcRequestToken != nil {
+		args.OidcRequestToken = pulumi.ToSecret(args.OidcRequestToken).(pulumi.StringPtrInput)
+	}
+	if args.OidcToken != nil {
+		args.OidcToken = pulumi.ToSecret(args.OidcToken).(pulumi.StringPtrInput)
+	}
+	if args.OidcTokenFilePath != nil {
+		args.OidcTokenFilePath = pulumi.ToSecret(args.OidcTokenFilePath).(pulumi.StringPtrInput)
+	}
+	if args.SubscriptionId != nil {
+		args.SubscriptionId = pulumi.ToSecret(args.SubscriptionId).(pulumi.StringPtrInput)
+	}
+	if args.TenantId != nil {
+		args.TenantId = pulumi.ToSecret(args.TenantId).(pulumi.StringPtrInput)
+	}
+	secrets := pulumi.AdditionalSecretOutputs([]string{
+		"clientCertificate",
+		"clientCertificatePassword",
+		"clientCertificatePath",
+		"clientId",
+		"clientIdFilePath",
+		"clientSecret",
+		"clientSecretFilePath",
+		"oidcRequestToken",
+		"oidcToken",
+		"oidcTokenFilePath",
+		"subscriptionId",
+		"tenantId",
+	})
+	opts = append(opts, secrets)
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource Provider
 	err := ctx.RegisterResource("pulumi:providers:azure", name, args, &resource, opts...)

--- a/sdk/java/src/main/java/com/pulumi/azure/Provider.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/Provider.java
@@ -10,6 +10,7 @@ import com.pulumi.core.annotations.Export;
 import com.pulumi.core.annotations.ResourceType;
 import com.pulumi.core.internal.Codegen;
 import java.lang.String;
+import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -301,6 +302,20 @@ public class Provider extends com.pulumi.resources.ProviderResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .additionalSecretOutputs(List.of(
+                "clientCertificate",
+                "clientCertificatePassword",
+                "clientCertificatePath",
+                "clientId",
+                "clientIdFilePath",
+                "clientSecret",
+                "clientSecretFilePath",
+                "oidcRequestToken",
+                "oidcToken",
+                "oidcTokenFilePath",
+                "subscriptionId",
+                "tenantId"
+            ))
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/java/src/main/java/com/pulumi/azure/ProviderArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/ProviderArgs.java
@@ -1038,7 +1038,7 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
             $.metadataHost = Codegen.stringProp("metadataHost").output().arg($.metadataHost).env("ARM_METADATA_HOSTNAME").getNullable();
             $.skipProviderRegistration = Codegen.booleanProp("skipProviderRegistration").output().arg($.skipProviderRegistration).env("ARM_SKIP_PROVIDER_REGISTRATION").def(false).getNullable();
             $.storageUseAzuread = Codegen.booleanProp("storageUseAzuread").output().arg($.storageUseAzuread).env("ARM_STORAGE_USE_AZUREAD").def(false).getNullable();
-            $.subscriptionId = Codegen.stringProp("subscriptionId").output().arg($.subscriptionId).env("ARM_SUBSCRIPTION_ID").def("").getNullable();
+            $.subscriptionId = Codegen.stringProp("subscriptionId").secret().arg($.subscriptionId).env("ARM_SUBSCRIPTION_ID").def("").getNullable();
             return $;
         }
     }

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -114,34 +114,36 @@ export class Provider extends pulumi.ProviderResource {
         opts = opts || {};
         {
             resourceInputs["auxiliaryTenantIds"] = pulumi.output(args ? args.auxiliaryTenantIds : undefined).apply(JSON.stringify);
-            resourceInputs["clientCertificate"] = args ? args.clientCertificate : undefined;
-            resourceInputs["clientCertificatePassword"] = args ? args.clientCertificatePassword : undefined;
-            resourceInputs["clientCertificatePath"] = args ? args.clientCertificatePath : undefined;
-            resourceInputs["clientId"] = args ? args.clientId : undefined;
-            resourceInputs["clientIdFilePath"] = args ? args.clientIdFilePath : undefined;
-            resourceInputs["clientSecret"] = args ? args.clientSecret : undefined;
-            resourceInputs["clientSecretFilePath"] = args ? args.clientSecretFilePath : undefined;
+            resourceInputs["clientCertificate"] = args?.clientCertificate ? pulumi.secret(args.clientCertificate) : undefined;
+            resourceInputs["clientCertificatePassword"] = args?.clientCertificatePassword ? pulumi.secret(args.clientCertificatePassword) : undefined;
+            resourceInputs["clientCertificatePath"] = args?.clientCertificatePath ? pulumi.secret(args.clientCertificatePath) : undefined;
+            resourceInputs["clientId"] = args?.clientId ? pulumi.secret(args.clientId) : undefined;
+            resourceInputs["clientIdFilePath"] = args?.clientIdFilePath ? pulumi.secret(args.clientIdFilePath) : undefined;
+            resourceInputs["clientSecret"] = args?.clientSecret ? pulumi.secret(args.clientSecret) : undefined;
+            resourceInputs["clientSecretFilePath"] = args?.clientSecretFilePath ? pulumi.secret(args.clientSecretFilePath) : undefined;
             resourceInputs["disableCorrelationRequestId"] = pulumi.output(args ? args.disableCorrelationRequestId : undefined).apply(JSON.stringify);
             resourceInputs["disableTerraformPartnerId"] = pulumi.output(args ? args.disableTerraformPartnerId : undefined).apply(JSON.stringify);
             resourceInputs["environment"] = (args ? args.environment : undefined) ?? (utilities.getEnv("AZURE_ENVIRONMENT", "ARM_ENVIRONMENT") || "public");
             resourceInputs["features"] = pulumi.output(args ? args.features : undefined).apply(JSON.stringify);
             resourceInputs["metadataHost"] = (args ? args.metadataHost : undefined) ?? utilities.getEnv("ARM_METADATA_HOSTNAME");
             resourceInputs["msiEndpoint"] = args ? args.msiEndpoint : undefined;
-            resourceInputs["oidcRequestToken"] = args ? args.oidcRequestToken : undefined;
+            resourceInputs["oidcRequestToken"] = args?.oidcRequestToken ? pulumi.secret(args.oidcRequestToken) : undefined;
             resourceInputs["oidcRequestUrl"] = args ? args.oidcRequestUrl : undefined;
-            resourceInputs["oidcToken"] = args ? args.oidcToken : undefined;
-            resourceInputs["oidcTokenFilePath"] = args ? args.oidcTokenFilePath : undefined;
+            resourceInputs["oidcToken"] = args?.oidcToken ? pulumi.secret(args.oidcToken) : undefined;
+            resourceInputs["oidcTokenFilePath"] = args?.oidcTokenFilePath ? pulumi.secret(args.oidcTokenFilePath) : undefined;
             resourceInputs["partnerId"] = args ? args.partnerId : undefined;
             resourceInputs["skipProviderRegistration"] = pulumi.output((args ? args.skipProviderRegistration : undefined) ?? (utilities.getEnvBoolean("ARM_SKIP_PROVIDER_REGISTRATION") || false)).apply(JSON.stringify);
             resourceInputs["storageUseAzuread"] = pulumi.output((args ? args.storageUseAzuread : undefined) ?? (utilities.getEnvBoolean("ARM_STORAGE_USE_AZUREAD") || false)).apply(JSON.stringify);
-            resourceInputs["subscriptionId"] = (args ? args.subscriptionId : undefined) ?? (utilities.getEnv("ARM_SUBSCRIPTION_ID") || "");
-            resourceInputs["tenantId"] = args ? args.tenantId : undefined;
+            resourceInputs["subscriptionId"] = (args?.subscriptionId ? pulumi.secret(args.subscriptionId) : undefined) ?? (utilities.getEnv("ARM_SUBSCRIPTION_ID") || "");
+            resourceInputs["tenantId"] = args?.tenantId ? pulumi.secret(args.tenantId) : undefined;
             resourceInputs["useAksWorkloadIdentity"] = pulumi.output(args ? args.useAksWorkloadIdentity : undefined).apply(JSON.stringify);
             resourceInputs["useCli"] = pulumi.output(args ? args.useCli : undefined).apply(JSON.stringify);
             resourceInputs["useMsi"] = pulumi.output(args ? args.useMsi : undefined).apply(JSON.stringify);
             resourceInputs["useOidc"] = pulumi.output(args ? args.useOidc : undefined).apply(JSON.stringify);
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
+        const secretOpts = { additionalSecretOutputs: ["clientCertificate", "clientCertificatePassword", "clientCertificatePath", "clientId", "clientIdFilePath", "clientSecret", "clientSecretFilePath", "oidcRequestToken", "oidcToken", "oidcTokenFilePath", "subscriptionId", "tenantId"] };
+        opts = pulumi.mergeOptions(opts, secretOpts);
         super(Provider.__pulumiType, name, resourceInputs, opts);
     }
 }

--- a/sdk/python/pulumi_azure/provider.py
+++ b/sdk/python/pulumi_azure/provider.py
@@ -606,13 +606,13 @@ class Provider(pulumi.ProviderResource):
             __props__ = ProviderArgs.__new__(ProviderArgs)
 
             __props__.__dict__["auxiliary_tenant_ids"] = pulumi.Output.from_input(auxiliary_tenant_ids).apply(pulumi.runtime.to_json) if auxiliary_tenant_ids is not None else None
-            __props__.__dict__["client_certificate"] = client_certificate
-            __props__.__dict__["client_certificate_password"] = client_certificate_password
-            __props__.__dict__["client_certificate_path"] = client_certificate_path
-            __props__.__dict__["client_id"] = client_id
-            __props__.__dict__["client_id_file_path"] = client_id_file_path
-            __props__.__dict__["client_secret"] = client_secret
-            __props__.__dict__["client_secret_file_path"] = client_secret_file_path
+            __props__.__dict__["client_certificate"] = None if client_certificate is None else pulumi.Output.secret(client_certificate)
+            __props__.__dict__["client_certificate_password"] = None if client_certificate_password is None else pulumi.Output.secret(client_certificate_password)
+            __props__.__dict__["client_certificate_path"] = None if client_certificate_path is None else pulumi.Output.secret(client_certificate_path)
+            __props__.__dict__["client_id"] = None if client_id is None else pulumi.Output.secret(client_id)
+            __props__.__dict__["client_id_file_path"] = None if client_id_file_path is None else pulumi.Output.secret(client_id_file_path)
+            __props__.__dict__["client_secret"] = None if client_secret is None else pulumi.Output.secret(client_secret)
+            __props__.__dict__["client_secret_file_path"] = None if client_secret_file_path is None else pulumi.Output.secret(client_secret_file_path)
             __props__.__dict__["disable_correlation_request_id"] = pulumi.Output.from_input(disable_correlation_request_id).apply(pulumi.runtime.to_json) if disable_correlation_request_id is not None else None
             __props__.__dict__["disable_terraform_partner_id"] = pulumi.Output.from_input(disable_terraform_partner_id).apply(pulumi.runtime.to_json) if disable_terraform_partner_id is not None else None
             if environment is None:
@@ -623,10 +623,10 @@ class Provider(pulumi.ProviderResource):
                 metadata_host = _utilities.get_env('ARM_METADATA_HOSTNAME')
             __props__.__dict__["metadata_host"] = metadata_host
             __props__.__dict__["msi_endpoint"] = msi_endpoint
-            __props__.__dict__["oidc_request_token"] = oidc_request_token
+            __props__.__dict__["oidc_request_token"] = None if oidc_request_token is None else pulumi.Output.secret(oidc_request_token)
             __props__.__dict__["oidc_request_url"] = oidc_request_url
-            __props__.__dict__["oidc_token"] = oidc_token
-            __props__.__dict__["oidc_token_file_path"] = oidc_token_file_path
+            __props__.__dict__["oidc_token"] = None if oidc_token is None else pulumi.Output.secret(oidc_token)
+            __props__.__dict__["oidc_token_file_path"] = None if oidc_token_file_path is None else pulumi.Output.secret(oidc_token_file_path)
             __props__.__dict__["partner_id"] = partner_id
             if skip_provider_registration is None:
                 skip_provider_registration = (_utilities.get_env_bool('ARM_SKIP_PROVIDER_REGISTRATION') or False)
@@ -636,12 +636,14 @@ class Provider(pulumi.ProviderResource):
             __props__.__dict__["storage_use_azuread"] = pulumi.Output.from_input(storage_use_azuread).apply(pulumi.runtime.to_json) if storage_use_azuread is not None else None
             if subscription_id is None:
                 subscription_id = (_utilities.get_env('ARM_SUBSCRIPTION_ID') or '')
-            __props__.__dict__["subscription_id"] = subscription_id
-            __props__.__dict__["tenant_id"] = tenant_id
+            __props__.__dict__["subscription_id"] = None if subscription_id is None else pulumi.Output.secret(subscription_id)
+            __props__.__dict__["tenant_id"] = None if tenant_id is None else pulumi.Output.secret(tenant_id)
             __props__.__dict__["use_aks_workload_identity"] = pulumi.Output.from_input(use_aks_workload_identity).apply(pulumi.runtime.to_json) if use_aks_workload_identity is not None else None
             __props__.__dict__["use_cli"] = pulumi.Output.from_input(use_cli).apply(pulumi.runtime.to_json) if use_cli is not None else None
             __props__.__dict__["use_msi"] = pulumi.Output.from_input(use_msi).apply(pulumi.runtime.to_json) if use_msi is not None else None
             __props__.__dict__["use_oidc"] = pulumi.Output.from_input(use_oidc).apply(pulumi.runtime.to_json) if use_oidc is not None else None
+        secret_opts = pulumi.ResourceOptions(additional_secret_outputs=["clientCertificate", "clientCertificatePassword", "clientCertificatePath", "clientId", "clientIdFilePath", "clientSecret", "clientSecretFilePath", "oidcRequestToken", "oidcToken", "oidcTokenFilePath", "subscriptionId", "tenantId"])
+        opts = pulumi.ResourceOptions.merge(opts, secret_opts)
         super(Provider, __self__).__init__(
             'azure',
             resource_name,


### PR DESCRIPTION
As https://github.com/pulumi/pulumi-azure/issues/1679 demonstrates the provider has some authentication-related configuration settings that are not marked as sensitive in the upstream schema, and therefore are not treated as secret by Pulumi, but instead plaintexted in the state file. This change reconfigures the bridged provider to treat the properties as secret. 

Fixes #1679 

The suggested list of properties includes:

- auxillary_tenant_ids
- client_certificate
- client_certificate_password
- client_certificate_path
- client_id
- client_id_file_path
- client_secret
- client_secret_file_path
- oidc_request_token
- oidc_token
- oidc_token_file_path
- subscription_id
- tenant_id
