### PR TITLE
Cleanup invalid mappings from `resources.go`

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1847,18 +1847,11 @@ func Provider() tfbridge.ProviderInfo {
 					}),
 				},
 			},
-			"azurerm_public_ip_prefix": {
-				Tok: azureResource(azureNetwork, "PublicIpPrefix"),
-				Fields: map[string]*tfbridge.SchemaInfo{
-					// Ensure "sku" is a singleton
-					// Per the Azure API, this is not able to be multiple versions so is wrong in the upstream provider
-					"sku": {Name: "sku", MaxItemsOne: ref(true)},
-				},
-			},
-			"azurerm_route":        {Tok: azureResource(azureNetwork, "Route")},
-			"azurerm_route_filter": {Tok: azureResource(azureNetwork, "RouteFilter")},
-			"azurerm_route_table":  {Tok: azureResource(azureNetwork, "RouteTable")},
-			"azurerm_route_map":    {Tok: azureResource(azureNetwork, "RouteMap")},
+			"azurerm_public_ip_prefix": {Tok: azureResource(azureNetwork, "PublicIpPrefix")},
+			"azurerm_route":            {Tok: azureResource(azureNetwork, "Route")},
+			"azurerm_route_filter":     {Tok: azureResource(azureNetwork, "RouteFilter")},
+			"azurerm_route_table":      {Tok: azureResource(azureNetwork, "RouteTable")},
+			"azurerm_route_map":        {Tok: azureResource(azureNetwork, "RouteMap")},
 			"azurerm_subnet": {
 				Tok: azureResource(azureNetwork, "Subnet"),
 				Fields: map[string]*tfbridge.SchemaInfo{

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1731,9 +1731,6 @@ func Provider() tfbridge.ProviderInfo {
 					"bgp_settings": {
 						Elem: &tfbridge.SchemaInfo{
 							Fields: map[string]*tfbridge.SchemaInfo{
-								"peering_address": {
-									Name: "peeringAddress",
-								},
 								"peering_addresses": {
 									Name: "peeringAddresses",
 								},


### PR DESCRIPTION
This is part of releasing https://github.com/pulumi/pulumi-terraform-bridge/pull/1758.