### PR TITLE
Dont skip tests by default

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -23,11 +23,6 @@ func skipIfShort(t *testing.T) {
 
 func getEnviron(t *testing.T) string {
 	env := os.Getenv("ARM_ENVIRONMENT")
-	if env == "" {
-		t.Error("Please set ARM_ENVIRONMENT environment variable.")
-		t.FailNow()
-	}
-
 	return env
 }
 
@@ -51,13 +46,16 @@ func getCwd(t *testing.T) string {
 }
 
 func getBaseOptions(t *testing.T) integration.ProgramTestOptions {
+	config := map[string]string{
+	}
 	environ := getEnviron(t)
+	if environ != "" {
+		config["azure:environment"] = environ
+	}
 	azureLocation := getLocation(t)
+	config["azure:location"] = azureLocation
 	return integration.ProgramTestOptions{
-		Config: map[string]string{
-			"azure:environment": environ,
-			"azure:location":    azureLocation,
-		},
+		Config: config,
 	}
 }
 

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -46,8 +46,7 @@ func getCwd(t *testing.T) string {
 }
 
 func getBaseOptions(t *testing.T) integration.ProgramTestOptions {
-	config := map[string]string{
-	}
+	config := map[string]string{}
 	environ := getEnviron(t)
 	if environ != "" {
 		config["azure:environment"] = environ

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -21,10 +21,6 @@ func skipIfShort(t *testing.T) {
 	}
 }
 
-func getEnviron(t *testing.T) string {
-	env := os.Getenv("ARM_ENVIRONMENT")
-	return env
-}
 
 func getLocation(t *testing.T) string {
 	azureLocation := os.Getenv("ARM_LOCATION")
@@ -46,15 +42,11 @@ func getCwd(t *testing.T) string {
 }
 
 func getBaseOptions(t *testing.T) integration.ProgramTestOptions {
-	config := map[string]string{}
-	environ := getEnviron(t)
-	if environ != "" {
-		config["azure:environment"] = environ
-	}
 	azureLocation := getLocation(t)
-	config["azure:location"] = azureLocation
 	return integration.ProgramTestOptions{
-		Config: config,
+		Config: map[string]string{
+			"azure:location": azureLocation,
+		},
 	}
 }
 

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -24,7 +24,8 @@ func skipIfShort(t *testing.T) {
 func getEnviron(t *testing.T) string {
 	env := os.Getenv("ARM_ENVIRONMENT")
 	if env == "" {
-		t.Skipf("Skipping test due to missing ARM_ENVIRONMENT environment variable")
+		t.Error("Please set ARM_ENVIRONMENT environment variable.")
+		t.FailNow()
 	}
 
 	return env


### PR DESCRIPTION
Highly unexpected behaviour, I think it's much more natural to fail when the required env vars are not set.

EDIT: Even that was unnecessary, azure sets that config by default: https://www.pulumi.com/registry/packages/azure-native/installation-configuration/#configuration-options