### PR TITLE
Patch frontdoor permadiff

### DIFF
--- a/patches/0011-set-frontdoor-backend-pool-settings-to-computed.patch
+++ b/patches/0011-set-frontdoor-backend-pool-settings-to-computed.patch
@@ -1,0 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Venelin <venelin@pulumi.com>
+Date: Wed, 8 May 2024 18:25:30 +0100
+Subject: [PATCH] set frontdoor backend pool settings to computed
+
+
+diff --git a/internal/services/frontdoor/frontdoor_resource.go b/internal/services/frontdoor/frontdoor_resource.go
+index 8beaebb89e..23519eaa45 100644
+--- a/internal/services/frontdoor/frontdoor_resource.go
++++ b/internal/services/frontdoor/frontdoor_resource.go
+@@ -2072,6 +2072,7 @@ func resourceFrontDoorSchema() map[string]*pluginsdk.Schema {
+ 		"backend_pool_settings": {
+ 			Type:     pluginsdk.TypeList,
+ 			Optional: true,
++			Computed: true,
+ 			Elem: &pluginsdk.Resource{
+ 				Schema: map[string]*pluginsdk.Schema{
+ 					"enforce_backend_pools_certificate_name_check": {

--- a/sdk/java/src/main/java/com/pulumi/azure/frontdoor/Frontdoor.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/frontdoor/Frontdoor.java
@@ -189,14 +189,14 @@ public class Frontdoor extends com.pulumi.resources.CustomResource {
      * 
      */
     @Export(name="backendPoolSettings", refs={List.class,FrontdoorBackendPoolSetting.class}, tree="[0,1]")
-    private Output</* @Nullable */ List<FrontdoorBackendPoolSetting>> backendPoolSettings;
+    private Output<List<FrontdoorBackendPoolSetting>> backendPoolSettings;
 
     /**
      * @return A `backend_pool_settings` block as defined below.
      * 
      */
-    public Output<Optional<List<FrontdoorBackendPoolSetting>>> backendPoolSettings() {
-        return Codegen.optional(this.backendPoolSettings);
+    public Output<List<FrontdoorBackendPoolSetting>> backendPoolSettings() {
+        return this.backendPoolSettings;
     }
     /**
      * A `backend_pool` block as defined below.

--- a/sdk/nodejs/frontdoor/frontdoor.ts
+++ b/sdk/nodejs/frontdoor/frontdoor.ts
@@ -124,7 +124,7 @@ export class Frontdoor extends pulumi.CustomResource {
     /**
      * A `backendPoolSettings` block as defined below.
      */
-    public readonly backendPoolSettings!: pulumi.Output<outputs.frontdoor.FrontdoorBackendPoolSetting[] | undefined>;
+    public readonly backendPoolSettings!: pulumi.Output<outputs.frontdoor.FrontdoorBackendPoolSetting[]>;
     /**
      * A `backendPool` block as defined below.
      *

--- a/sdk/python/pulumi_azure/frontdoor/frontdoor.py
+++ b/sdk/python/pulumi_azure/frontdoor/frontdoor.py
@@ -866,7 +866,7 @@ class Frontdoor(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="backendPoolSettings")
-    def backend_pool_settings(self) -> pulumi.Output[Optional[Sequence['outputs.FrontdoorBackendPoolSetting']]]:
+    def backend_pool_settings(self) -> pulumi.Output[Sequence['outputs.FrontdoorBackendPoolSetting']]:
         """
         A `backend_pool_settings` block as defined below.
         """


### PR DESCRIPTION
fixes https://github.com/pulumi/pulumi-azure/issues/1421 by patching the upstream resource to be computed as the provider sets a value for it. This is needed for https://github.com/pulumi/pulumi-terraform-bridge/pull/1936

works around https://github.com/hashicorp/terraform-provider-azurerm/issues/25911

issue for patch: https://github.com/pulumi/pulumi-azure/issues/2015

upstream PR: https://github.com/hashicorp/terraform-provider-azurerm/pull/25912