### PR TITLE
Upgrade test validate no replacements

### DIFF
--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -35,6 +35,7 @@ func test(t *testing.T, dir string, opts ...providertest.Option) {
 		providertest.WithBaselineVersion("5.60.0"),
 		providertest.WithResourceProviderServer(providerServer()),
 		providertest.WithSkippedUpgradeTestMode(providertest.UpgradeTestMode_Quick, "Using PreviewOnly mode instead"),
+		providertest.WithDiffValidation(providertest.NoReplacements()),
 	)
 	ptest := providertest.NewProviderTest(dir, opts...)
 	ptest.Run(t)


### PR DESCRIPTION
The upgrade tests here were using the no-diff validation yielding noise in the tests as can be seen here: https://github.com/pulumi/pulumi-azure/actions/runs/9505545675/job/26201251247?pr=2125

The tests there fail because of default properties applied to storage account and storage bucket. The azure provider is especially prone to dirty refreshes because of a policy the upstream provider has AGAINST setting Optional + Computed for properties returned by the API: https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/best-practices.md#setting-properties-to-optional--computed

No diff is too strict for upgrade tests so this PR replaces it with "no replacements".