### PR TITLE
Fix TestAccAciVolumeMount unreliability

### DIFF
--- a/examples/aci-volume-mount/index.ts
+++ b/examples/aci-volume-mount/index.ts
@@ -1,6 +1,7 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
-
+import * as pulumi from "@pulumi/pulumi";
 import * as azure from "@pulumi/azure";
+import * as docker from "@pulumi/docker";
 
 const resourceGroup = new azure.core.ResourceGroup("resourcegroup");
 // We ensure the accessTier is consistent between the storage account and the storage share to avoid any potential
@@ -8,40 +9,67 @@ const resourceGroup = new azure.core.ResourceGroup("resourcegroup");
 const accessTier = "Hot";
 
 const storageAccount = new azure.storage.Account("storageaccount", {
-    resourceGroupName: resourceGroup.name,
-    accountTier: "standard",
-    accountReplicationType: "LRS",
-    accessTier,
+  resourceGroupName: resourceGroup.name,
+  accountTier: "standard",
+  accountReplicationType: "LRS",
+  accessTier,
 });
 
 const storageShare = new azure.storage.Share("storageshare", {
-    storageAccountName: storageAccount.name,
-    quota: 50,
-    accessTier,
+  storageAccountName: storageAccount.name,
+  quota: 50,
+  accessTier,
+});
+
+const registry = new azure.containerservice.Registry("registry", {
+  resourceGroupName: resourceGroup.name,
+  sku: "Basic",
+  adminEnabled: true,
+});
+
+var customImage = "node-app";
+
+const image = new docker.Image("image", {
+  imageName: pulumi.interpolate`${registry.loginServer}/${customImage}:v1`,
+  build: { context: `./${customImage}` },
+  registry: {
+    server: registry.loginServer,
+    username: registry.adminUsername,
+    password: registry.adminPassword,
+  },
 });
 
 const containerGroup = new azure.containerservice.Group("containergroup", {
-    resourceGroupName: resourceGroup.name,
-    ipAddressType: "public",
-    osType: "linux",
-    containers: [
-        {
-            name: "webserver",
-            image: "seanmckenna/aci-hellofiles",
-            cpu: 1,
-            memory: 1.5,
-            ports: [{port: 80, protocol: "TCP"}],
-            volumes: [{
-                name: "logs",
-                mountPath: "/aci/logs",
-                readOnly: false,
-                shareName: storageShare.name,
-                storageAccountName: storageAccount.name,
-                storageAccountKey: storageAccount.primaryAccessKey,
-            }],
-        },
-    ],
-    tags: {
-        "environment": "testing",
+  resourceGroupName: resourceGroup.name,
+  ipAddressType: "public",
+  osType: "linux",
+  imageRegistryCredentials: [
+    {
+      server: registry.loginServer,
+      username: registry.adminUsername,
+      password: registry.adminPassword,
     },
+  ],
+  containers: [
+    {
+      name: "webserver",
+      image: image.imageName,
+      cpu: 1,
+      memory: 1.5,
+      ports: [{ port: 80, protocol: "TCP" }],
+      volumes: [
+        {
+          name: "logs",
+          mountPath: "/aci/logs",
+          readOnly: false,
+          shareName: storageShare.name,
+          storageAccountName: storageAccount.name,
+          storageAccountKey: storageAccount.primaryAccessKey,
+        },
+      ],
+    },
+  ],
+  tags: {
+    environment: "testing",
+  },
 });

--- a/examples/aci-volume-mount/node-app/.dockerignore
+++ b/examples/aci-volume-mount/node-app/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/examples/aci-volume-mount/node-app/Dockerfile
+++ b/examples/aci-volume-mount/node-app/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:8.9.3-alpine
+RUN mkdir -p /usr/src/app
+COPY ./app/* /usr/src/app/
+WORKDIR /usr/src/app
+RUN npm install
+CMD node /usr/src/app/index.js

--- a/examples/aci-volume-mount/node-app/app/index.html
+++ b/examples/aci-volume-mount/node-app/app/index.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<h1>Your custom docker image is running in Azure App Service!</h1>
+</body>
+</html>

--- a/examples/aci-volume-mount/node-app/app/index.js
+++ b/examples/aci-volume-mount/node-app/app/index.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const morgan = require('morgan');
+
+const app = express();
+app.use(morgan('combined'));
+
+app.get('/', (req, res) => {
+  res.sendFile(__dirname + '/index.html')
+});
+
+var listener = app.listen(process.env.PORT || 80, function() {
+ console.log('listening on port ' + listener.address().port);
+});

--- a/examples/aci-volume-mount/node-app/app/package.json
+++ b/examples/aci-volume-mount/node-app/app/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "node-helloworld",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "dependencies": {
+    "express": "^4.14.0",
+    "morgan": "^1.8.2"
+  },
+  "devDependencies": {},
+  "author": ""
+}

--- a/examples/aci-volume-mount/package.json
+++ b/examples/aci-volume-mount/package.json
@@ -3,6 +3,7 @@
     "version": "0.0.1",
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/docker": "^4.0.0",
         "@pulumi/azure": "^5.0.0"
     },
     "devDependencies": {

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -20,7 +21,6 @@ func skipIfShort(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 }
-
 
 func getLocation(t *testing.T) string {
 	azureLocation := os.Getenv("ARM_LOCATION")
@@ -43,9 +43,20 @@ func getCwd(t *testing.T) string {
 
 func getBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	azureLocation := getLocation(t)
+	binPath, err := filepath.Abs("../bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Printf("Using binPath %s\n", binPath)
 	return integration.ProgramTestOptions{
 		Config: map[string]string{
 			"azure:location": azureLocation,
+		},
+		LocalProviders: []integration.LocalDependency{
+			{
+				Package: "azure",
+				Path:    binPath,
+			},
 		},
 	}
 }


### PR DESCRIPTION
Deploy our own registry and image into Azure instead of relying on docker hub which gets rate-limited.

Also, set the path to the local binary to prevent pulumi from trying to download the provider binary.