### PR TITLE
Re-ignore EventGrid test due to persistent CI failure

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -265,6 +265,7 @@ func TestAccDurableFunctions(t *testing.T) {
 }
 
 func TestAccEventgrid(t *testing.T) {
+	t.Skip(`Passes locally but fails in CI with 'Waiting for 'eventgrid_extension' key to become available' until timeout. #2222`)
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir:                      filepath.Join(getCwd(t), "eventgrid"),


### PR DESCRIPTION
Resolves #2222

I tried determining the root cause but wasn't able to so far. The test passes when run from my machine. It also passes in CI when I run only that test. Probably some unintended interaction between tests, or a timing issue?