### PR TITLE
Fix subnet replacement under PRC when upgrading provider

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1891,7 +1891,7 @@ func Provider() tfbridge.ProviderInfo {
 						Transform: strings.ToLower,
 					}),
 				},
-				TransformFromState: func(ctx context.Context, pm resource.PropertyMap) (resource.PropertyMap, error) {
+				TransformFromState: func(_ context.Context, pm resource.PropertyMap) (resource.PropertyMap, error) {
 					// if the defaultOutboundAccessEnabled property is not set, set it to the default value of true
 					// this prevents an unnecessary replacement when upgrading the provider
 					if _, ok := pm["defaultOutboundAccessEnabled"]; !ok {

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1891,6 +1891,14 @@ func Provider() tfbridge.ProviderInfo {
 						Transform: strings.ToLower,
 					}),
 				},
+				TransformFromState: func(ctx context.Context, pm resource.PropertyMap) (resource.PropertyMap, error) {
+					// if the defaultOutboundAccessEnabled property is not set, set it to the default value of true
+					// this prevents an unnecessary replacement when upgrading the provider
+					if _, ok := pm["defaultOutboundAccessEnabled"]; !ok {
+						pm["defaultOutboundAccessEnabled"] = resource.NewBoolProperty(true)
+					}
+					return pm, nil
+				},
 			},
 			"azurerm_subnet_network_security_group_association": {Tok: azureResource(azureNetwork, "SubnetNetworkSecurityGroupAssociation")},
 			"azurerm_subnet_route_table_association":            {Tok: azureResource(azureNetwork, "SubnetRouteTableAssociation")},


### PR DESCRIPTION
This prevents the `Subnet` resource from being replaced under PRC when upgrading the provider.

Note this is an intentional divergence from the TF provider but the TF behaviour here is bad and we are not taking up a patch for this.

Note this is already covered by `Test_network`, see failure in https://github.com/pulumi/pulumi-azure/actions/runs/10178181276/job/28152031872?pr=2306

fixes https://github.com/pulumi/pulumi-azure/issues/2323
stacked on https://github.com/pulumi/pulumi-azure/pull/2306