### PR TITLE
Fix storage container replacement during upgrade under PRC

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -2061,6 +2061,12 @@ func Provider() tfbridge.ProviderInfo {
 						Transform: strings.ToLower,
 					}),
 				},
+				TransformFromState: func(_ context.Context, pm resource.PropertyMap) (resource.PropertyMap, error) {
+					if _, ok := pm["encryptionScopeOverrideEnabled"]; !ok {
+						pm["encryptionScopeOverrideEnabled"] = resource.NewBoolProperty(true)
+					}
+					return pm, nil
+				},
 			},
 			"azurerm_storage_share":           {Tok: azureResource(azureStorage, "Share")},
 			"azurerm_storage_share_directory": {Tok: azureResource(azureStorage, "ShareDirectory")},

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -2062,6 +2062,8 @@ func Provider() tfbridge.ProviderInfo {
 					}),
 				},
 				TransformFromState: func(_ context.Context, pm resource.PropertyMap) (resource.PropertyMap, error) {
+					// This prevents unnecessary replacement when upgrading from a version of the Azure provider
+					// prior to this parameter being added.
 					if _, ok := pm["encryptionScopeOverrideEnabled"]; !ok {
 						pm["encryptionScopeOverrideEnabled"] = resource.NewBoolProperty(true)
 					}


### PR DESCRIPTION
This prevents the storage Container resource from being replaced under PRC when upgrading the provider.

Note this is an intentional divergence from the TF provider but the TF behaviour here is bad and we are not taking up a patch for this.

Note this is already covered by Test_storage, see failure in https://github.com/pulumi/pulumi-azure/actions/runs/10178181276/job/28152031872?pr=2306

Similar to https://github.com/pulumi/pulumi-azure/pull/2325

fixes https://github.com/pulumi/pulumi-azure/issues/2330
stacked on https://github.com/pulumi/pulumi-azure/pull/2306