### PR TITLE
Fix verification tests

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -53,6 +53,7 @@ actions:
 pulumiConvert: 1
 releaseVerification:
   nodejs: examples/topic
-  python: examples/eventhub-py
+  # Disable python until https://github.com/pulumi/verify-provider-release/issues/39 is addressed
+  # python: examples/eventhub-py
   dotnet: examples/appservice-cs
   go: examples/network-go

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -78,13 +78,6 @@ jobs:
           directory: examples/topic
           provider: azure
           providerVersion: ${{ inputs.providerVersion }}
-      - name: Verify python release
-        uses: pulumi/verify-provider-release@v1
-        with:
-          runtime: python
-          directory: examples/eventhub-py
-          provider: azure
-          providerVersion: ${{ inputs.providerVersion }}
       - name: Verify dotnet release
         uses: pulumi/verify-provider-release@v1
         with:

--- a/examples/appservice-cs/Program.cs
+++ b/examples/appservice-cs/Program.cs
@@ -14,7 +14,10 @@ class Program
     static Task<int> Main(string[] args)
     {
         return Deployment.RunAsync(() => {
-            var resourceGroup = new ResourceGroup("appservice-rg");
+            var resourceGroup = new ResourceGroup("appservice-rg", new ResourceGroupArgs
+            {
+                Location = "WestUS",
+            });
 
             var storageAccount = new Account("sa", new AccountArgs
             {

--- a/examples/eventhub-py/__main__.py
+++ b/examples/eventhub-py/__main__.py
@@ -2,7 +2,7 @@
 
 import pulumi
 from pulumi_azure import core, eventhub
-resource_group = core.ResourceGroup('eventhub-py-example')
+resource_group = core.ResourceGroup('eventhub-py-example', location='WestUS')
 
 namespace = eventhub.EventHubNamespace('eventhub-py-eg',
     resource_group_name=resource_group.name,

--- a/examples/network-go/main.go
+++ b/examples/network-go/main.go
@@ -10,7 +10,9 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		rg, err := core.NewResourceGroup(ctx, "server-rg", nil)
+		rg, err := core.NewResourceGroup(ctx, "server-rg", &core.ResourceGroupArgs{
+			Location: pulumi.String("WestUS"),
+		})
 		if err != nil {
 			return err
 		}

--- a/examples/topic/index.ts
+++ b/examples/topic/index.ts
@@ -3,7 +3,9 @@
 import * as azure from "@pulumi/azure";
 import * as eventhub from "@pulumi/azure/eventhub";
 
-const resourceGroup = new azure.core.ResourceGroup("test");
+const resourceGroup = new azure.core.ResourceGroup("test", {
+    location: "WestUS",
+});
 
 const namespace = new eventhub.Namespace("test", {
     resourceGroupName: resourceGroup.name,


### PR DESCRIPTION
- Set location explicitly in the programs instead of assuming program test will set it for us.
- Disable python as it currently breaks for pre-releases (see https://github.com/pulumi/verify-provider-release/issues/39)

Manual test run: https://github.com/pulumi/pulumi-azure/actions/runs/10845914340/job/30097763444 - go fails because it's a prerelease being tested, but we can't skip it yet when invoking directly (see https://github.com/pulumi/ci-mgmt/pull/1080)

