### PR TITLE
make ci-mgmt - install required dotnet

### DIFF
--- a/.github/workflows/build_provider.yml
+++ b/.github/workflows/build_provider.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           tool-cache: false
           swap-storage: false
+          dotnet: false
       - name: Checkout Repo
         uses: actions/checkout@v4
       - name: Setup tools

--- a/.github/workflows/build_sdk.yml
+++ b/.github/workflows/build_sdk.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           allowed-changes: |
             sdk/**/pulumi-plugin.json
-            sdk/dotnet/Pulumi.*.csproj
+            sdk/dotnet/*.csproj
             sdk/go/**/pulumiUtilities.go
             sdk/nodejs/package.json
             sdk/python/pyproject.toml

--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
-    - uses: peter-evans/slash-command-dispatch@v2
+    - uses: peter-evans/slash-command-dispatch@v4
       with:
         commands: |
           run-acceptance-tests

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -115,6 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check if this commit needs release
+      if: ${{ env.RELEASE_BOT_ENDPOINT != '' }}
       uses: pulumi/action-release-by-pr-label@main
       with:
         command: "release-if-needed"
@@ -144,6 +145,7 @@ jobs:
       with:
         tool-cache: false
         swap-storage: false
+        dotnet: false
     - name: Checkout Repo
       uses: actions/checkout@v4
     - name: Setup tools

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -66,6 +66,7 @@ jobs:
       with:
         tool-cache: false
         swap-storage: false
+        dotnet: false
     - name: Checkout Repo
       uses: actions/checkout@v4
     - name: Setup tools

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -89,6 +89,7 @@ jobs:
       with:
         tool-cache: false
         swap-storage: false
+        dotnet: false
     - name: Checkout Repo
       uses: actions/checkout@v4
     - name: Setup tools

--- a/.github/workflows/prerequisites.yml
+++ b/.github/workflows/prerequisites.yml
@@ -55,6 +55,7 @@ jobs:
       with:
         tool-cache: false
         swap-storage: false
+        dotnet: false
     - name: Checkout Repo
       uses: actions/checkout@v4
     - uses: pulumi/provider-version-action@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,7 +89,7 @@ jobs:
         {
           echo 'summary<<EOF'
           if [[ "$LAST_VERSION" != "No stable release" ]]; then
-            schema-tools compare --provider="azure" --old-commit="$LAST_VERSION" --new-commit="--local-path=provider/cmd/pulumi-resource-azure/schema.json"
+            schema-tools compare --provider="azure" --old-commit="$LAST_VERSION" --repository="github://api.github.com/pulumi" --new-commit="--local-path=provider/cmd/pulumi-resource-azure/schema.json"
           fi
           echo 'EOF'
         } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,7 @@ jobs:
       with:
         tool-cache: false
         swap-storage: false
+        dotnet: false
     - name: Checkout Repo
       uses: actions/checkout@v4
     - name: Setup tools

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -122,6 +122,7 @@ jobs:
       with:
         tool-cache: false
         swap-storage: false
+        dotnet: false
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/upgrade-bridge.yml
+++ b/.github/workflows/upgrade-bridge.yml
@@ -63,6 +63,7 @@ jobs:
       with:
         tool-cache: false
         swap-storage: false
+        dotnet: false
     - name: Checkout Repo
       uses: actions/checkout@v4
     - name: Setup tools

--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -9,21 +9,26 @@ jobs:
     name: upgrade-provider
     runs-on: ubuntu-latest
     steps:
-    # Run as first step so we don't delete things that have just been installed
-    - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
-      with:
-        tool-cache: false
-        swap-storage: false
-    - name: Call upgrade provider action
-      uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
-      with:
-        kind: all
-        email: bot@pulumi.com
-        username: pulumi-bot
+      # Run as first step so we don't delete things that have just been installed
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        with:
+          tool-cache: false
+          swap-storage: false
+          dotnet: false
+      - name: Setup tools
+        uses: ./.github/actions/setup-tools
+        with:
+          tools: pulumictl, pulumicli, go, nodejs, dotnet, python, java
+      - name: Call upgrade provider action
+        uses: pulumi/pulumi-upgrade-provider-action@v0.0.12
+        with:
+          kind: all
+          email: bot@pulumi.com
+          username: pulumi-bot
 name: Upgrade provider
 on:
   issues:
     types:
-    - opened
+      - opened
   workflow_dispatch: {}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,3 @@ linters-settings:
       - prefix(github.com/pulumi/) # Custom section: groups all imports with the github.com/pulumi/ prefix.
       - prefix(github.com/pulumi/pulumi-azure) # Custom section: local imports
     custom-order: true
-  misspell:
-    ignore-words:
-      - hdinsight

--- a/Makefile
+++ b/Makefile
@@ -248,3 +248,6 @@ provider_dist-darwin-arm64: bin/$(PROVIDER)-v$(VERSION_GENERIC)-darwin-arm64.tar
 provider_dist-windows-amd64: bin/$(PROVIDER)-v$(VERSION_GENERIC)-windows-amd64.tar.gz
 provider_dist: provider_dist-linux-amd64 provider_dist-linux-arm64 provider_dist-darwin-amd64 provider_dist-darwin-arm64 provider_dist-windows-amd64
 .PHONY: provider_dist-linux-amd64 provider_dist-linux-arm64 provider_dist-darwin-amd64 provider_dist-darwin-arm64 provider_dist-windows-amd64 provider_dist
+
+# Permit providers to extend the Makefile with provider-specific Make includes.
+include $(wildcard .mk/*.mk)

--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -95,6 +95,7 @@ func Test_containerservice_k8scluster(t *testing.T) {
 		optproviderupgrade.NewSourcePath(filepath.Join("test-programs", "containerservice_k8scluster", "v6")))
 }
 
+//nolint:misspell
 func Test_hdinsight(t *testing.T) {
 	test(t, filepath.Join("test-programs", "hdinsight"),
 		optproviderupgrade.NewSourcePath(filepath.Join("test-programs", "hdinsight", "v6")))


### PR DESCRIPTION
This unblocks the upgrade-provider workflow which [failed](https://github.com/pulumi/pulumi-azure/actions/runs/11189927179/job/31110979162) due to a missing dotnet installation.