### PR TITLE
Upgrade terraform-provider-azurerm to v4.13.0

### DIFF
--- a/patches/0013-Update-documentation.patch
+++ b/patches/0013-Update-documentation.patch
@@ -319,7 +319,7 @@ index 820a09f089..d8d31e7ce2 100644
  * `xml_link` - (Optional) A link to a Policy XML Document, which must be publicly available.
  
 diff --git a/website/docs/r/api_management_backend.html.markdown b/website/docs/r/api_management_backend.html.markdown
-index ed8cf79b66..2eee7160e6 100644
+index f0da028865..b2f040916c 100644
 --- a/website/docs/r/api_management_backend.html.markdown
 +++ b/website/docs/r/api_management_backend.html.markdown
 @@ -23,7 +23,7 @@ resource "azurerm_api_management" "example" {
@@ -484,15 +484,15 @@ index ce521efb7a..c43da45129 100644
    sku_name = "Developer_1"
  }
 diff --git a/website/docs/r/api_management_policy.html.markdown b/website/docs/r/api_management_policy.html.markdown
-index a5fb803301..0f3ab6a7e4 100644
+index 2ebf12e3c5..a8250eadef 100644
 --- a/website/docs/r/api_management_policy.html.markdown
 +++ b/website/docs/r/api_management_policy.html.markdown
 @@ -52,7 +52,7 @@ The following arguments are supported:
  
  ---
  
--* `xml_content` - (Optional) The XML Content for this Policy as a string. An XML file can be used here with Terraform's [file function](https://www.terraform.io/docs/configuration/functions/file.html) that is similar to Microsoft's `PolicyFilePath` option.
-+* `xml_content` - (Optional) The XML Content for this Policy as a string.
+-* `xml_content` - (Optional) The XML Content for this Policy as a string. An XML file can be used here with Terraform's [file function](https://www.terraform.io/docs/configuration/functions/file.html) that is similar to Microsoft's `PolicyFilePath` option. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the [`azurerm_api_management_backend`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_backend) configuration.
++* `xml_content` - (Optional) The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
  
  * `xml_link` - (Optional) A link to a Policy XML Document, which must be publicly available.
  

--- a/provider/cmd/pulumi-resource-azure/bridge-metadata.json
+++ b/provider/cmd/pulumi-resource-azure/bridge-metadata.json
@@ -27058,7 +27058,14 @@
                         "maxItemsOne": false
                     },
                     "identity": {
-                        "maxItemsOne": false
+                        "maxItemsOne": false,
+                        "elem": {
+                            "fields": {
+                                "identity_ids": {
+                                    "maxItemsOne": false
+                                }
+                            }
+                        }
                     },
                     "site_config": {
                         "maxItemsOne": true,

--- a/sdk/dotnet/ApiManagement/Backend.cs
+++ b/sdk/dotnet/ApiManagement/Backend.cs
@@ -44,7 +44,7 @@ namespace Pulumi.Azure.ApiManagement
     ///         ResourceGroupName = example.Name,
     ///         ApiManagementName = exampleService.Name,
     ///         Protocol = "http",
-    ///         Url = "https://backend",
+    ///         Url = "https://backend.com/api",
     ///     });
     /// 
     /// });
@@ -128,7 +128,7 @@ namespace Pulumi.Azure.ApiManagement
         public Output<Outputs.BackendTls?> Tls { get; private set; } = null!;
 
         /// <summary>
-        /// The URL of the backend host.
+        /// The backend host URL should be specified in the format `"https://backend.com/api"`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
         /// </summary>
         [Output("url")]
         public Output<string> Url { get; private set; } = null!;
@@ -246,7 +246,7 @@ namespace Pulumi.Azure.ApiManagement
         public Input<Inputs.BackendTlsArgs>? Tls { get; set; }
 
         /// <summary>
-        /// The URL of the backend host.
+        /// The backend host URL should be specified in the format `"https://backend.com/api"`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
         /// </summary>
         [Input("url", required: true)]
         public Input<string> Url { get; set; } = null!;
@@ -326,7 +326,7 @@ namespace Pulumi.Azure.ApiManagement
         public Input<Inputs.BackendTlsGetArgs>? Tls { get; set; }
 
         /// <summary>
-        /// The URL of the backend host.
+        /// The backend host URL should be specified in the format `"https://backend.com/api"`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
         /// </summary>
         [Input("url")]
         public Input<string>? Url { get; set; }

--- a/sdk/dotnet/ApiManagement/Policy.cs
+++ b/sdk/dotnet/ApiManagement/Policy.cs
@@ -80,7 +80,7 @@ namespace Pulumi.Azure.ApiManagement
         public Output<string> ApiManagementId { get; private set; } = null!;
 
         /// <summary>
-        /// The XML Content for this Policy as a string.
+        /// The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
         /// </summary>
         [Output("xmlContent")]
         public Output<string> XmlContent { get; private set; } = null!;
@@ -144,7 +144,7 @@ namespace Pulumi.Azure.ApiManagement
         public Input<string> ApiManagementId { get; set; } = null!;
 
         /// <summary>
-        /// The XML Content for this Policy as a string.
+        /// The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
         /// </summary>
         [Input("xmlContent")]
         public Input<string>? XmlContent { get; set; }
@@ -170,7 +170,7 @@ namespace Pulumi.Azure.ApiManagement
         public Input<string>? ApiManagementId { get; set; }
 
         /// <summary>
-        /// The XML Content for this Policy as a string.
+        /// The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
         /// </summary>
         [Input("xmlContent")]
         public Input<string>? XmlContent { get; set; }

--- a/sdk/dotnet/Cdn/Inputs/EndpointCustomDomainCdnManagedHttpsArgs.cs
+++ b/sdk/dotnet/Cdn/Inputs/EndpointCustomDomainCdnManagedHttpsArgs.cs
@@ -26,6 +26,8 @@ namespace Pulumi.Azure.Cdn.Inputs
 
         /// <summary>
         /// The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+        /// 
+        /// &gt; **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
         /// </summary>
         [Input("tlsVersion")]
         public Input<string>? TlsVersion { get; set; }

--- a/sdk/dotnet/Cdn/Inputs/EndpointCustomDomainCdnManagedHttpsGetArgs.cs
+++ b/sdk/dotnet/Cdn/Inputs/EndpointCustomDomainCdnManagedHttpsGetArgs.cs
@@ -26,6 +26,8 @@ namespace Pulumi.Azure.Cdn.Inputs
 
         /// <summary>
         /// The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+        /// 
+        /// &gt; **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
         /// </summary>
         [Input("tlsVersion")]
         public Input<string>? TlsVersion { get; set; }

--- a/sdk/dotnet/Cdn/Inputs/EndpointCustomDomainUserManagedHttpsArgs.cs
+++ b/sdk/dotnet/Cdn/Inputs/EndpointCustomDomainUserManagedHttpsArgs.cs
@@ -20,6 +20,8 @@ namespace Pulumi.Azure.Cdn.Inputs
 
         /// <summary>
         /// The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+        /// 
+        /// &gt; **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
         /// </summary>
         [Input("tlsVersion")]
         public Input<string>? TlsVersion { get; set; }

--- a/sdk/dotnet/Cdn/Inputs/EndpointCustomDomainUserManagedHttpsGetArgs.cs
+++ b/sdk/dotnet/Cdn/Inputs/EndpointCustomDomainUserManagedHttpsGetArgs.cs
@@ -20,6 +20,8 @@ namespace Pulumi.Azure.Cdn.Inputs
 
         /// <summary>
         /// The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+        /// 
+        /// &gt; **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
         /// </summary>
         [Input("tlsVersion")]
         public Input<string>? TlsVersion { get; set; }

--- a/sdk/dotnet/Cdn/Inputs/FrontdoorOriginGroupHealthProbeArgs.cs
+++ b/sdk/dotnet/Cdn/Inputs/FrontdoorOriginGroupHealthProbeArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Azure.Cdn.Inputs
     public sealed class FrontdoorOriginGroupHealthProbeArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Specifies the number of seconds between health probes. Possible values are between `5` and `31536000` seconds (inclusive).
+        /// Specifies the number of seconds between health probes. Possible values are between `1` and `255` seconds (inclusive).
         /// </summary>
         [Input("intervalInSeconds", required: true)]
         public Input<int> IntervalInSeconds { get; set; } = null!;

--- a/sdk/dotnet/Cdn/Inputs/FrontdoorOriginGroupHealthProbeGetArgs.cs
+++ b/sdk/dotnet/Cdn/Inputs/FrontdoorOriginGroupHealthProbeGetArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Azure.Cdn.Inputs
     public sealed class FrontdoorOriginGroupHealthProbeGetArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Specifies the number of seconds between health probes. Possible values are between `5` and `31536000` seconds (inclusive).
+        /// Specifies the number of seconds between health probes. Possible values are between `1` and `255` seconds (inclusive).
         /// </summary>
         [Input("intervalInSeconds", required: true)]
         public Input<int> IntervalInSeconds { get; set; } = null!;

--- a/sdk/dotnet/Cdn/Outputs/EndpointCustomDomainCdnManagedHttps.cs
+++ b/sdk/dotnet/Cdn/Outputs/EndpointCustomDomainCdnManagedHttps.cs
@@ -23,6 +23,8 @@ namespace Pulumi.Azure.Cdn.Outputs
         public readonly string ProtocolType;
         /// <summary>
         /// The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+        /// 
+        /// &gt; **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
         /// </summary>
         public readonly string? TlsVersion;
 

--- a/sdk/dotnet/Cdn/Outputs/EndpointCustomDomainUserManagedHttps.cs
+++ b/sdk/dotnet/Cdn/Outputs/EndpointCustomDomainUserManagedHttps.cs
@@ -19,6 +19,8 @@ namespace Pulumi.Azure.Cdn.Outputs
         public readonly string KeyVaultSecretId;
         /// <summary>
         /// The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+        /// 
+        /// &gt; **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
         /// </summary>
         public readonly string? TlsVersion;
 

--- a/sdk/dotnet/Cdn/Outputs/FrontdoorOriginGroupHealthProbe.cs
+++ b/sdk/dotnet/Cdn/Outputs/FrontdoorOriginGroupHealthProbe.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Azure.Cdn.Outputs
     public sealed class FrontdoorOriginGroupHealthProbe
     {
         /// <summary>
-        /// Specifies the number of seconds between health probes. Possible values are between `5` and `31536000` seconds (inclusive).
+        /// Specifies the number of seconds between health probes. Possible values are between `1` and `255` seconds (inclusive).
         /// </summary>
         public readonly int IntervalInSeconds;
         /// <summary>

--- a/sdk/dotnet/Cognitive/Deployment.cs
+++ b/sdk/dotnet/Cognitive/Deployment.cs
@@ -74,6 +74,12 @@ namespace Pulumi.Azure.Cognitive
         public Output<string> CognitiveAccountId { get; private set; } = null!;
 
         /// <summary>
+        /// Whether dynamic throttling is enabled.
+        /// </summary>
+        [Output("dynamicThrottlingEnabled")]
+        public Output<bool?> DynamicThrottlingEnabled { get; private set; } = null!;
+
+        /// <summary>
         /// A `model` block as defined below. Changing this forces a new resource to be created.
         /// </summary>
         [Output("model")]
@@ -156,6 +162,12 @@ namespace Pulumi.Azure.Cognitive
         public Input<string> CognitiveAccountId { get; set; } = null!;
 
         /// <summary>
+        /// Whether dynamic throttling is enabled.
+        /// </summary>
+        [Input("dynamicThrottlingEnabled")]
+        public Input<bool>? DynamicThrottlingEnabled { get; set; }
+
+        /// <summary>
         /// A `model` block as defined below. Changing this forces a new resource to be created.
         /// </summary>
         [Input("model", required: true)]
@@ -198,6 +210,12 @@ namespace Pulumi.Azure.Cognitive
         /// </summary>
         [Input("cognitiveAccountId")]
         public Input<string>? CognitiveAccountId { get; set; }
+
+        /// <summary>
+        /// Whether dynamic throttling is enabled.
+        /// </summary>
+        [Input("dynamicThrottlingEnabled")]
+        public Input<bool>? DynamicThrottlingEnabled { get; set; }
 
         /// <summary>
         /// A `model` block as defined below. Changing this forces a new resource to be created.

--- a/sdk/dotnet/DataProtection/BackupInstanceBlogStorage.cs
+++ b/sdk/dotnet/DataProtection/BackupInstanceBlogStorage.cs
@@ -12,6 +12,76 @@ namespace Pulumi.Azure.DataProtection
     /// <summary>
     /// Manages a Backup Instance Blob Storage.
     /// 
+    /// ## Example Usage
+    /// 
+    /// ```csharp
+    /// using System.Collections.Generic;
+    /// using System.Linq;
+    /// using Pulumi;
+    /// using Azure = Pulumi.Azure;
+    /// 
+    /// return await Deployment.RunAsync(() =&gt; 
+    /// {
+    ///     var example = new Azure.Core.ResourceGroup("example", new()
+    ///     {
+    ///         Name = "example-resources",
+    ///         Location = "West Europe",
+    ///     });
+    /// 
+    ///     var exampleAccount = new Azure.Storage.Account("example", new()
+    ///     {
+    ///         Name = "storageaccountname",
+    ///         ResourceGroupName = example.Name,
+    ///         Location = example.Location,
+    ///         AccountTier = "Standard",
+    ///         AccountReplicationType = "LRS",
+    ///     });
+    /// 
+    ///     var exampleBackupVault = new Azure.DataProtection.BackupVault("example", new()
+    ///     {
+    ///         Name = "example-backup-vault",
+    ///         ResourceGroupName = example.Name,
+    ///         Location = example.Location,
+    ///         DatastoreType = "VaultStore",
+    ///         Redundancy = "LocallyRedundant",
+    ///         Identity = new Azure.DataProtection.Inputs.BackupVaultIdentityArgs
+    ///         {
+    ///             Type = "SystemAssigned",
+    ///         },
+    ///     });
+    /// 
+    ///     var exampleAssignment = new Azure.Authorization.Assignment("example", new()
+    ///     {
+    ///         Scope = exampleAccount.Id,
+    ///         RoleDefinitionName = "Storage Account Backup Contributor",
+    ///         PrincipalId = exampleBackupVault.Identity.Apply(identity =&gt; identity?.PrincipalId),
+    ///     });
+    /// 
+    ///     var exampleBackupPolicyBlobStorage = new Azure.DataProtection.BackupPolicyBlobStorage("example", new()
+    ///     {
+    ///         Name = "example-backup-policy",
+    ///         VaultId = exampleBackupVault.Id,
+    ///         OperationalDefaultRetentionDuration = "P30D",
+    ///     });
+    /// 
+    ///     var exampleBackupInstanceBlogStorage = new Azure.DataProtection.BackupInstanceBlogStorage("example", new()
+    ///     {
+    ///         Name = "example-backup-instance",
+    ///         VaultId = exampleBackupVault.Id,
+    ///         Location = example.Location,
+    ///         StorageAccountId = exampleAccount.Id,
+    ///         BackupPolicyId = exampleBackupPolicyBlobStorage.Id,
+    ///     }, new CustomResourceOptions
+    ///     {
+    ///         DependsOn =
+    ///         {
+    ///             exampleAssignment,
+    ///         },
+    ///     });
+    /// 
+    /// });
+    /// ```
+    /// 
     /// ## Import
     /// 
     /// Backup Instance Blob Storages can be imported using the `resource id`, e.g.

--- a/sdk/dotnet/KeyVault/ManagedHardwareSecurityModuleKey.cs
+++ b/sdk/dotnet/KeyVault/ManagedHardwareSecurityModuleKey.cs
@@ -44,13 +44,13 @@ namespace Pulumi.Azure.KeyVault
         public Output<ImmutableArray<string>> KeyOpts { get; private set; } = null!;
 
         /// <summary>
-        /// Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM`. Changing this forces a new resource to be created.
+        /// Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
         /// </summary>
         [Output("keySize")]
         public Output<int?> KeySize { get; private set; } = null!;
 
         /// <summary>
-        /// Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+        /// Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
         /// </summary>
         [Output("keyType")]
         public Output<string> KeyType { get; private set; } = null!;
@@ -158,13 +158,13 @@ namespace Pulumi.Azure.KeyVault
         }
 
         /// <summary>
-        /// Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM`. Changing this forces a new resource to be created.
+        /// Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
         /// </summary>
         [Input("keySize")]
         public Input<int>? KeySize { get; set; }
 
         /// <summary>
-        /// Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+        /// Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
         /// </summary>
         [Input("keyType", required: true)]
         public Input<string> KeyType { get; set; } = null!;
@@ -234,13 +234,13 @@ namespace Pulumi.Azure.KeyVault
         }
 
         /// <summary>
-        /// Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM`. Changing this forces a new resource to be created.
+        /// Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
         /// </summary>
         [Input("keySize")]
         public Input<int>? KeySize { get; set; }
 
         /// <summary>
-        /// Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+        /// Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
         /// </summary>
         [Input("keyType")]
         public Input<string>? KeyType { get; set; }

--- a/sdk/dotnet/LogicApps/Outputs/GetStandardIdentityResult.cs
+++ b/sdk/dotnet/LogicApps/Outputs/GetStandardIdentityResult.cs
@@ -13,6 +13,7 @@ namespace Pulumi.Azure.LogicApps.Outputs
     [OutputType]
     public sealed class GetStandardIdentityResult
     {
+        public readonly ImmutableArray<string> IdentityIds;
         /// <summary>
         /// The Principal ID for the Service Principal associated with the Managed Service Identity of this Logic App Workflow.
         /// </summary>
@@ -28,12 +29,15 @@ namespace Pulumi.Azure.LogicApps.Outputs
 
         [OutputConstructor]
         private GetStandardIdentityResult(
+            ImmutableArray<string> identityIds,
+
             string principalId,
 
             string tenantId,
 
             string type)
         {
+            IdentityIds = identityIds;
             PrincipalId = principalId;
             TenantId = tenantId;
             Type = type;

--- a/sdk/dotnet/Network/NatGateway.cs
+++ b/sdk/dotnet/Network/NatGateway.cs
@@ -30,7 +30,7 @@ namespace Pulumi.Azure.Network
     /// 
     ///     var exampleNatGateway = new Azure.Network.NatGateway("example", new()
     ///     {
-    ///         Name = "nat-Gateway",
+    ///         Name = "nat-gateway",
     ///         Location = example.Location,
     ///         ResourceGroupName = example.Name,
     ///         SkuName = "Standard",

--- a/sdk/dotnet/Search/Service.cs
+++ b/sdk/dotnet/Search/Service.cs
@@ -170,7 +170,7 @@ namespace Pulumi.Azure.Search
         public Output<string> Name { get; private set; } = null!;
 
         /// <summary>
-        /// Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+        /// Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
         /// 
         /// &gt; **NOTE:** when `hosting_mode` is set to `highDensity` the maximum number of partitions allowed is `3`.
         /// </summary>
@@ -349,7 +349,7 @@ namespace Pulumi.Azure.Search
         public Input<string>? Name { get; set; }
 
         /// <summary>
-        /// Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+        /// Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
         /// 
         /// &gt; **NOTE:** when `hosting_mode` is set to `highDensity` the maximum number of partitions allowed is `3`.
         /// </summary>
@@ -479,7 +479,7 @@ namespace Pulumi.Azure.Search
         public Input<string>? Name { get; set; }
 
         /// <summary>
-        /// Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+        /// Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
         /// 
         /// &gt; **NOTE:** when `hosting_mode` is set to `highDensity` the maximum number of partitions allowed is `3`.
         /// </summary>

--- a/sdk/dotnet/ServiceBus/GetSubscription.cs
+++ b/sdk/dotnet/ServiceBus/GetSubscription.cs
@@ -134,7 +134,7 @@ namespace Pulumi.Azure.ServiceBus
     public sealed class GetSubscriptionResult
     {
         /// <summary>
-        /// The idle interval after which the topic is automatically deleted.
+        /// The idle interval after which the Subscription is automatically deleted.
         /// </summary>
         public readonly string AutoDeleteOnIdle;
         /// <summary>

--- a/sdk/go/azure/apimanagement/backend.go
+++ b/sdk/go/azure/apimanagement/backend.go
@@ -52,7 +52,7 @@ import (
 //				ResourceGroupName: example.Name,
 //				ApiManagementName: exampleService.Name,
 //				Protocol:          pulumi.String("http"),
-//				Url:               pulumi.String("https://backend"),
+//				Url:               pulumi.String("https://backend.com/api"),
 //			})
 //			if err != nil {
 //				return err
@@ -95,7 +95,7 @@ type Backend struct {
 	Title pulumi.StringPtrOutput `pulumi:"title"`
 	// A `tls` block as documented below.
 	Tls BackendTlsPtrOutput `pulumi:"tls"`
-	// The URL of the backend host.
+	// The backend host URL should be specified in the format `"https://backend.com/api"`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
 	Url pulumi.StringOutput `pulumi:"url"`
 }
 
@@ -163,7 +163,7 @@ type backendState struct {
 	Title *string `pulumi:"title"`
 	// A `tls` block as documented below.
 	Tls *BackendTls `pulumi:"tls"`
-	// The URL of the backend host.
+	// The backend host URL should be specified in the format `"https://backend.com/api"`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
 	Url *string `pulumi:"url"`
 }
 
@@ -190,7 +190,7 @@ type BackendState struct {
 	Title pulumi.StringPtrInput
 	// A `tls` block as documented below.
 	Tls BackendTlsPtrInput
-	// The URL of the backend host.
+	// The backend host URL should be specified in the format `"https://backend.com/api"`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
 	Url pulumi.StringPtrInput
 }
 
@@ -221,7 +221,7 @@ type backendArgs struct {
 	Title *string `pulumi:"title"`
 	// A `tls` block as documented below.
 	Tls *BackendTls `pulumi:"tls"`
-	// The URL of the backend host.
+	// The backend host URL should be specified in the format `"https://backend.com/api"`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
 	Url string `pulumi:"url"`
 }
 
@@ -249,7 +249,7 @@ type BackendArgs struct {
 	Title pulumi.StringPtrInput
 	// A `tls` block as documented below.
 	Tls BackendTlsPtrInput
-	// The URL of the backend host.
+	// The backend host URL should be specified in the format `"https://backend.com/api"`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
 	Url pulumi.StringInput
 }
 
@@ -395,7 +395,7 @@ func (o BackendOutput) Tls() BackendTlsPtrOutput {
 	return o.ApplyT(func(v *Backend) BackendTlsPtrOutput { return v.Tls }).(BackendTlsPtrOutput)
 }
 
-// The URL of the backend host.
+// The backend host URL should be specified in the format `"https://backend.com/api"`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
 func (o BackendOutput) Url() pulumi.StringOutput {
 	return o.ApplyT(func(v *Backend) pulumi.StringOutput { return v.Url }).(pulumi.StringOutput)
 }

--- a/sdk/go/azure/apimanagement/policy.go
+++ b/sdk/go/azure/apimanagement/policy.go
@@ -91,7 +91,7 @@ type Policy struct {
 
 	// The ID of the API Management service. Changing this forces a new API Management service Policy to be created.
 	ApiManagementId pulumi.StringOutput `pulumi:"apiManagementId"`
-	// The XML Content for this Policy as a string.
+	// The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
 	XmlContent pulumi.StringOutput `pulumi:"xmlContent"`
 	// A link to a Policy XML Document, which must be publicly available.
 	XmlLink pulumi.StringPtrOutput `pulumi:"xmlLink"`
@@ -132,7 +132,7 @@ func GetPolicy(ctx *pulumi.Context,
 type policyState struct {
 	// The ID of the API Management service. Changing this forces a new API Management service Policy to be created.
 	ApiManagementId *string `pulumi:"apiManagementId"`
-	// The XML Content for this Policy as a string.
+	// The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
 	XmlContent *string `pulumi:"xmlContent"`
 	// A link to a Policy XML Document, which must be publicly available.
 	XmlLink *string `pulumi:"xmlLink"`
@@ -141,7 +141,7 @@ type policyState struct {
 type PolicyState struct {
 	// The ID of the API Management service. Changing this forces a new API Management service Policy to be created.
 	ApiManagementId pulumi.StringPtrInput
-	// The XML Content for this Policy as a string.
+	// The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
 	XmlContent pulumi.StringPtrInput
 	// A link to a Policy XML Document, which must be publicly available.
 	XmlLink pulumi.StringPtrInput
@@ -154,7 +154,7 @@ func (PolicyState) ElementType() reflect.Type {
 type policyArgs struct {
 	// The ID of the API Management service. Changing this forces a new API Management service Policy to be created.
 	ApiManagementId string `pulumi:"apiManagementId"`
-	// The XML Content for this Policy as a string.
+	// The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
 	XmlContent *string `pulumi:"xmlContent"`
 	// A link to a Policy XML Document, which must be publicly available.
 	XmlLink *string `pulumi:"xmlLink"`
@@ -164,7 +164,7 @@ type policyArgs struct {
 type PolicyArgs struct {
 	// The ID of the API Management service. Changing this forces a new API Management service Policy to be created.
 	ApiManagementId pulumi.StringInput
-	// The XML Content for this Policy as a string.
+	// The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
 	XmlContent pulumi.StringPtrInput
 	// A link to a Policy XML Document, which must be publicly available.
 	XmlLink pulumi.StringPtrInput
@@ -262,7 +262,7 @@ func (o PolicyOutput) ApiManagementId() pulumi.StringOutput {
 	return o.ApplyT(func(v *Policy) pulumi.StringOutput { return v.ApiManagementId }).(pulumi.StringOutput)
 }
 
-// The XML Content for this Policy as a string.
+// The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
 func (o PolicyOutput) XmlContent() pulumi.StringOutput {
 	return o.ApplyT(func(v *Policy) pulumi.StringOutput { return v.XmlContent }).(pulumi.StringOutput)
 }

--- a/sdk/go/azure/cdn/pulumiTypes.go
+++ b/sdk/go/azure/cdn/pulumiTypes.go
@@ -19,6 +19,8 @@ type EndpointCustomDomainCdnManagedHttps struct {
 	// The type of protocol. Possible values are `ServerNameIndication` and `IPBased`.
 	ProtocolType string `pulumi:"protocolType"`
 	// The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+	//
+	// > **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
 	TlsVersion *string `pulumi:"tlsVersion"`
 }
 
@@ -39,6 +41,8 @@ type EndpointCustomDomainCdnManagedHttpsArgs struct {
 	// The type of protocol. Possible values are `ServerNameIndication` and `IPBased`.
 	ProtocolType pulumi.StringInput `pulumi:"protocolType"`
 	// The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+	//
+	// > **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
 	TlsVersion pulumi.StringPtrInput `pulumi:"tlsVersion"`
 }
 
@@ -130,6 +134,8 @@ func (o EndpointCustomDomainCdnManagedHttpsOutput) ProtocolType() pulumi.StringO
 }
 
 // The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+//
+// > **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
 func (o EndpointCustomDomainCdnManagedHttpsOutput) TlsVersion() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v EndpointCustomDomainCdnManagedHttps) *string { return v.TlsVersion }).(pulumi.StringPtrOutput)
 }
@@ -179,6 +185,8 @@ func (o EndpointCustomDomainCdnManagedHttpsPtrOutput) ProtocolType() pulumi.Stri
 }
 
 // The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+//
+// > **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
 func (o EndpointCustomDomainCdnManagedHttpsPtrOutput) TlsVersion() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *EndpointCustomDomainCdnManagedHttps) *string {
 		if v == nil {
@@ -192,6 +200,8 @@ type EndpointCustomDomainUserManagedHttps struct {
 	// The ID of the Key Vault Secret that contains the HTTPS certificate.
 	KeyVaultSecretId string `pulumi:"keyVaultSecretId"`
 	// The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+	//
+	// > **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
 	TlsVersion *string `pulumi:"tlsVersion"`
 }
 
@@ -210,6 +220,8 @@ type EndpointCustomDomainUserManagedHttpsArgs struct {
 	// The ID of the Key Vault Secret that contains the HTTPS certificate.
 	KeyVaultSecretId pulumi.StringInput `pulumi:"keyVaultSecretId"`
 	// The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+	//
+	// > **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
 	TlsVersion pulumi.StringPtrInput `pulumi:"tlsVersion"`
 }
 
@@ -296,6 +308,8 @@ func (o EndpointCustomDomainUserManagedHttpsOutput) KeyVaultSecretId() pulumi.St
 }
 
 // The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+//
+// > **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
 func (o EndpointCustomDomainUserManagedHttpsOutput) TlsVersion() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v EndpointCustomDomainUserManagedHttps) *string { return v.TlsVersion }).(pulumi.StringPtrOutput)
 }
@@ -335,6 +349,8 @@ func (o EndpointCustomDomainUserManagedHttpsPtrOutput) KeyVaultSecretId() pulumi
 }
 
 // The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+//
+// > **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
 func (o EndpointCustomDomainUserManagedHttpsPtrOutput) TlsVersion() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *EndpointCustomDomainUserManagedHttps) *string {
 		if v == nil {
@@ -6200,7 +6216,7 @@ func (o FrontdoorFirewallPolicyManagedRuleOverrideRuleExclusionArrayOutput) Inde
 }
 
 type FrontdoorOriginGroupHealthProbe struct {
-	// Specifies the number of seconds between health probes. Possible values are between `5` and `31536000` seconds (inclusive).
+	// Specifies the number of seconds between health probes. Possible values are between `1` and `255` seconds (inclusive).
 	IntervalInSeconds int `pulumi:"intervalInSeconds"`
 	// Specifies the path relative to the origin that is used to determine the health of the origin. Defaults to `/`.
 	//
@@ -6224,7 +6240,7 @@ type FrontdoorOriginGroupHealthProbeInput interface {
 }
 
 type FrontdoorOriginGroupHealthProbeArgs struct {
-	// Specifies the number of seconds between health probes. Possible values are between `5` and `31536000` seconds (inclusive).
+	// Specifies the number of seconds between health probes. Possible values are between `1` and `255` seconds (inclusive).
 	IntervalInSeconds pulumi.IntInput `pulumi:"intervalInSeconds"`
 	// Specifies the path relative to the origin that is used to determine the health of the origin. Defaults to `/`.
 	//
@@ -6313,7 +6329,7 @@ func (o FrontdoorOriginGroupHealthProbeOutput) ToFrontdoorOriginGroupHealthProbe
 	}).(FrontdoorOriginGroupHealthProbePtrOutput)
 }
 
-// Specifies the number of seconds between health probes. Possible values are between `5` and `31536000` seconds (inclusive).
+// Specifies the number of seconds between health probes. Possible values are between `1` and `255` seconds (inclusive).
 func (o FrontdoorOriginGroupHealthProbeOutput) IntervalInSeconds() pulumi.IntOutput {
 	return o.ApplyT(func(v FrontdoorOriginGroupHealthProbe) int { return v.IntervalInSeconds }).(pulumi.IntOutput)
 }
@@ -6359,7 +6375,7 @@ func (o FrontdoorOriginGroupHealthProbePtrOutput) Elem() FrontdoorOriginGroupHea
 	}).(FrontdoorOriginGroupHealthProbeOutput)
 }
 
-// Specifies the number of seconds between health probes. Possible values are between `5` and `31536000` seconds (inclusive).
+// Specifies the number of seconds between health probes. Possible values are between `1` and `255` seconds (inclusive).
 func (o FrontdoorOriginGroupHealthProbePtrOutput) IntervalInSeconds() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v *FrontdoorOriginGroupHealthProbe) *int {
 		if v == nil {

--- a/sdk/go/azure/cognitive/deployment.go
+++ b/sdk/go/azure/cognitive/deployment.go
@@ -79,6 +79,8 @@ type Deployment struct {
 
 	// The ID of the Cognitive Services Account. Changing this forces a new resource to be created.
 	CognitiveAccountId pulumi.StringOutput `pulumi:"cognitiveAccountId"`
+	// Whether dynamic throttling is enabled.
+	DynamicThrottlingEnabled pulumi.BoolPtrOutput `pulumi:"dynamicThrottlingEnabled"`
 	// A `model` block as defined below. Changing this forces a new resource to be created.
 	Model DeploymentModelOutput `pulumi:"model"`
 	// The name of the Cognitive Services Account Deployment. Changing this forces a new resource to be created.
@@ -132,6 +134,8 @@ func GetDeployment(ctx *pulumi.Context,
 type deploymentState struct {
 	// The ID of the Cognitive Services Account. Changing this forces a new resource to be created.
 	CognitiveAccountId *string `pulumi:"cognitiveAccountId"`
+	// Whether dynamic throttling is enabled.
+	DynamicThrottlingEnabled *bool `pulumi:"dynamicThrottlingEnabled"`
 	// A `model` block as defined below. Changing this forces a new resource to be created.
 	Model *DeploymentModel `pulumi:"model"`
 	// The name of the Cognitive Services Account Deployment. Changing this forces a new resource to be created.
@@ -147,6 +151,8 @@ type deploymentState struct {
 type DeploymentState struct {
 	// The ID of the Cognitive Services Account. Changing this forces a new resource to be created.
 	CognitiveAccountId pulumi.StringPtrInput
+	// Whether dynamic throttling is enabled.
+	DynamicThrottlingEnabled pulumi.BoolPtrInput
 	// A `model` block as defined below. Changing this forces a new resource to be created.
 	Model DeploymentModelPtrInput
 	// The name of the Cognitive Services Account Deployment. Changing this forces a new resource to be created.
@@ -166,6 +172,8 @@ func (DeploymentState) ElementType() reflect.Type {
 type deploymentArgs struct {
 	// The ID of the Cognitive Services Account. Changing this forces a new resource to be created.
 	CognitiveAccountId string `pulumi:"cognitiveAccountId"`
+	// Whether dynamic throttling is enabled.
+	DynamicThrottlingEnabled *bool `pulumi:"dynamicThrottlingEnabled"`
 	// A `model` block as defined below. Changing this forces a new resource to be created.
 	Model DeploymentModel `pulumi:"model"`
 	// The name of the Cognitive Services Account Deployment. Changing this forces a new resource to be created.
@@ -182,6 +190,8 @@ type deploymentArgs struct {
 type DeploymentArgs struct {
 	// The ID of the Cognitive Services Account. Changing this forces a new resource to be created.
 	CognitiveAccountId pulumi.StringInput
+	// Whether dynamic throttling is enabled.
+	DynamicThrottlingEnabled pulumi.BoolPtrInput
 	// A `model` block as defined below. Changing this forces a new resource to be created.
 	Model DeploymentModelInput
 	// The name of the Cognitive Services Account Deployment. Changing this forces a new resource to be created.
@@ -284,6 +294,11 @@ func (o DeploymentOutput) ToDeploymentOutputWithContext(ctx context.Context) Dep
 // The ID of the Cognitive Services Account. Changing this forces a new resource to be created.
 func (o DeploymentOutput) CognitiveAccountId() pulumi.StringOutput {
 	return o.ApplyT(func(v *Deployment) pulumi.StringOutput { return v.CognitiveAccountId }).(pulumi.StringOutput)
+}
+
+// Whether dynamic throttling is enabled.
+func (o DeploymentOutput) DynamicThrottlingEnabled() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *Deployment) pulumi.BoolPtrOutput { return v.DynamicThrottlingEnabled }).(pulumi.BoolPtrOutput)
 }
 
 // A `model` block as defined below. Changing this forces a new resource to be created.

--- a/sdk/go/azure/dataprotection/backupInstanceBlogStorage.go
+++ b/sdk/go/azure/dataprotection/backupInstanceBlogStorage.go
@@ -14,6 +14,89 @@ import (
 
 // Manages a Backup Instance Blob Storage.
 //
+// ## Example Usage
+//
+// ```go
+// package main
+//
+// import (
+//
+//	"github.com/pulumi/pulumi-azure/sdk/v6/go/azure/authorization"
+//	"github.com/pulumi/pulumi-azure/sdk/v6/go/azure/core"
+//	"github.com/pulumi/pulumi-azure/sdk/v6/go/azure/dataprotection"
+//	"github.com/pulumi/pulumi-azure/sdk/v6/go/azure/storage"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+// )
+//
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			example, err := core.NewResourceGroup(ctx, "example", &core.ResourceGroupArgs{
+//				Name:     pulumi.String("example-resources"),
+//				Location: pulumi.String("West Europe"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			exampleAccount, err := storage.NewAccount(ctx, "example", &storage.AccountArgs{
+//				Name:                   pulumi.String("storageaccountname"),
+//				ResourceGroupName:      example.Name,
+//				Location:               example.Location,
+//				AccountTier:            pulumi.String("Standard"),
+//				AccountReplicationType: pulumi.String("LRS"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			exampleBackupVault, err := dataprotection.NewBackupVault(ctx, "example", &dataprotection.BackupVaultArgs{
+//				Name:              pulumi.String("example-backup-vault"),
+//				ResourceGroupName: example.Name,
+//				Location:          example.Location,
+//				DatastoreType:     pulumi.String("VaultStore"),
+//				Redundancy:        pulumi.String("LocallyRedundant"),
+//				Identity: &dataprotection.BackupVaultIdentityArgs{
+//					Type: pulumi.String("SystemAssigned"),
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			exampleAssignment, err := authorization.NewAssignment(ctx, "example", &authorization.AssignmentArgs{
+//				Scope:              exampleAccount.ID(),
+//				RoleDefinitionName: pulumi.String("Storage Account Backup Contributor"),
+//				PrincipalId: pulumi.String(exampleBackupVault.Identity.ApplyT(func(identity dataprotection.BackupVaultIdentity) (*string, error) {
+//					return &identity.PrincipalId, nil
+//				}).(pulumi.StringPtrOutput)),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			exampleBackupPolicyBlobStorage, err := dataprotection.NewBackupPolicyBlobStorage(ctx, "example", &dataprotection.BackupPolicyBlobStorageArgs{
+//				Name:                                pulumi.String("example-backup-policy"),
+//				VaultId:                             exampleBackupVault.ID(),
+//				OperationalDefaultRetentionDuration: pulumi.String("P30D"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = dataprotection.NewBackupInstanceBlogStorage(ctx, "example", &dataprotection.BackupInstanceBlogStorageArgs{
+//				Name:             pulumi.String("example-backup-instance"),
+//				VaultId:          exampleBackupVault.ID(),
+//				Location:         example.Location,
+//				StorageAccountId: exampleAccount.ID(),
+//				BackupPolicyId:   exampleBackupPolicyBlobStorage.ID(),
+//			}, pulumi.DependsOn([]pulumi.Resource{
+//				exampleAssignment,
+//			}))
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
+// ```
+//
 // ## Import
 //
 // Backup Instance Blob Storages can be imported using the `resource id`, e.g.

--- a/sdk/go/azure/keyvault/managedHardwareSecurityModuleKey.go
+++ b/sdk/go/azure/keyvault/managedHardwareSecurityModuleKey.go
@@ -32,9 +32,9 @@ type ManagedHardwareSecurityModuleKey struct {
 	ExpirationDate pulumi.StringPtrOutput `pulumi:"expirationDate"`
 	// A list of JSON web key operations. Possible values include: `decrypt`, `encrypt`, `sign`, `unwrapKey`, `verify` and `wrapKey`. Please note these values are case-sensitive.
 	KeyOpts pulumi.StringArrayOutput `pulumi:"keyOpts"`
-	// Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `keyType` is `RSA-HSM`. Changing this forces a new resource to be created.
+	// Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `keyType` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
 	KeySize pulumi.IntPtrOutput `pulumi:"keySize"`
-	// Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+	// Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
 	KeyType pulumi.StringOutput `pulumi:"keyType"`
 	// Specifies the ID of the Key Vault Managed Hardware Security Module that they key will be owned by. Changing this forces a new resource to be created.
 	ManagedHsmId pulumi.StringOutput `pulumi:"managedHsmId"`
@@ -95,9 +95,9 @@ type managedHardwareSecurityModuleKeyState struct {
 	ExpirationDate *string `pulumi:"expirationDate"`
 	// A list of JSON web key operations. Possible values include: `decrypt`, `encrypt`, `sign`, `unwrapKey`, `verify` and `wrapKey`. Please note these values are case-sensitive.
 	KeyOpts []string `pulumi:"keyOpts"`
-	// Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `keyType` is `RSA-HSM`. Changing this forces a new resource to be created.
+	// Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `keyType` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
 	KeySize *int `pulumi:"keySize"`
-	// Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+	// Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
 	KeyType *string `pulumi:"keyType"`
 	// Specifies the ID of the Key Vault Managed Hardware Security Module that they key will be owned by. Changing this forces a new resource to be created.
 	ManagedHsmId *string `pulumi:"managedHsmId"`
@@ -120,9 +120,9 @@ type ManagedHardwareSecurityModuleKeyState struct {
 	ExpirationDate pulumi.StringPtrInput
 	// A list of JSON web key operations. Possible values include: `decrypt`, `encrypt`, `sign`, `unwrapKey`, `verify` and `wrapKey`. Please note these values are case-sensitive.
 	KeyOpts pulumi.StringArrayInput
-	// Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `keyType` is `RSA-HSM`. Changing this forces a new resource to be created.
+	// Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `keyType` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
 	KeySize pulumi.IntPtrInput
-	// Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+	// Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
 	KeyType pulumi.StringPtrInput
 	// Specifies the ID of the Key Vault Managed Hardware Security Module that they key will be owned by. Changing this forces a new resource to be created.
 	ManagedHsmId pulumi.StringPtrInput
@@ -149,9 +149,9 @@ type managedHardwareSecurityModuleKeyArgs struct {
 	ExpirationDate *string `pulumi:"expirationDate"`
 	// A list of JSON web key operations. Possible values include: `decrypt`, `encrypt`, `sign`, `unwrapKey`, `verify` and `wrapKey`. Please note these values are case-sensitive.
 	KeyOpts []string `pulumi:"keyOpts"`
-	// Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `keyType` is `RSA-HSM`. Changing this forces a new resource to be created.
+	// Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `keyType` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
 	KeySize *int `pulumi:"keySize"`
-	// Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+	// Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
 	KeyType string `pulumi:"keyType"`
 	// Specifies the ID of the Key Vault Managed Hardware Security Module that they key will be owned by. Changing this forces a new resource to be created.
 	ManagedHsmId string `pulumi:"managedHsmId"`
@@ -173,9 +173,9 @@ type ManagedHardwareSecurityModuleKeyArgs struct {
 	ExpirationDate pulumi.StringPtrInput
 	// A list of JSON web key operations. Possible values include: `decrypt`, `encrypt`, `sign`, `unwrapKey`, `verify` and `wrapKey`. Please note these values are case-sensitive.
 	KeyOpts pulumi.StringArrayInput
-	// Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `keyType` is `RSA-HSM`. Changing this forces a new resource to be created.
+	// Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `keyType` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
 	KeySize pulumi.IntPtrInput
-	// Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+	// Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
 	KeyType pulumi.StringInput
 	// Specifies the ID of the Key Vault Managed Hardware Security Module that they key will be owned by. Changing this forces a new resource to be created.
 	ManagedHsmId pulumi.StringInput
@@ -291,12 +291,12 @@ func (o ManagedHardwareSecurityModuleKeyOutput) KeyOpts() pulumi.StringArrayOutp
 	return o.ApplyT(func(v *ManagedHardwareSecurityModuleKey) pulumi.StringArrayOutput { return v.KeyOpts }).(pulumi.StringArrayOutput)
 }
 
-// Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `keyType` is `RSA-HSM`. Changing this forces a new resource to be created.
+// Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `keyType` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
 func (o ManagedHardwareSecurityModuleKeyOutput) KeySize() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v *ManagedHardwareSecurityModuleKey) pulumi.IntPtrOutput { return v.KeySize }).(pulumi.IntPtrOutput)
 }
 
-// Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+// Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
 func (o ManagedHardwareSecurityModuleKeyOutput) KeyType() pulumi.StringOutput {
 	return o.ApplyT(func(v *ManagedHardwareSecurityModuleKey) pulumi.StringOutput { return v.KeyType }).(pulumi.StringOutput)
 }

--- a/sdk/go/azure/logicapps/pulumiTypes.go
+++ b/sdk/go/azure/logicapps/pulumiTypes.go
@@ -4770,6 +4770,7 @@ func (o GetStandardConnectionStringArrayOutput) Index(i pulumi.IntInput) GetStan
 }
 
 type GetStandardIdentity struct {
+	IdentityIds []string `pulumi:"identityIds"`
 	// The Principal ID for the Service Principal associated with the Managed Service Identity of this Logic App Workflow.
 	PrincipalId string `pulumi:"principalId"`
 	// The Tenant ID for the Service Principal associated with the Managed Service Identity of this Logic App Workflow.
@@ -4790,6 +4791,7 @@ type GetStandardIdentityInput interface {
 }
 
 type GetStandardIdentityArgs struct {
+	IdentityIds pulumi.StringArrayInput `pulumi:"identityIds"`
 	// The Principal ID for the Service Principal associated with the Managed Service Identity of this Logic App Workflow.
 	PrincipalId pulumi.StringInput `pulumi:"principalId"`
 	// The Tenant ID for the Service Principal associated with the Managed Service Identity of this Logic App Workflow.
@@ -4847,6 +4849,10 @@ func (o GetStandardIdentityOutput) ToGetStandardIdentityOutput() GetStandardIden
 
 func (o GetStandardIdentityOutput) ToGetStandardIdentityOutputWithContext(ctx context.Context) GetStandardIdentityOutput {
 	return o
+}
+
+func (o GetStandardIdentityOutput) IdentityIds() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v GetStandardIdentity) []string { return v.IdentityIds }).(pulumi.StringArrayOutput)
 }
 
 // The Principal ID for the Service Principal associated with the Managed Service Identity of this Logic App Workflow.

--- a/sdk/go/azure/network/natGateway.go
+++ b/sdk/go/azure/network/natGateway.go
@@ -37,7 +37,7 @@ import (
 //				return err
 //			}
 //			_, err = network.NewNatGateway(ctx, "example", &network.NatGatewayArgs{
-//				Name:                 pulumi.String("nat-Gateway"),
+//				Name:                 pulumi.String("nat-gateway"),
 //				Location:             example.Location,
 //				ResourceGroupName:    example.Name,
 //				SkuName:              pulumi.String("Standard"),

--- a/sdk/go/azure/search/service.go
+++ b/sdk/go/azure/search/service.go
@@ -164,7 +164,7 @@ type Service struct {
 	Location pulumi.StringOutput `pulumi:"location"`
 	// The Name which should be used for this Search Service. Changing this forces a new Search Service to be created.
 	Name pulumi.StringOutput `pulumi:"name"`
-	// Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+	// Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
 	//
 	// > **NOTE:** when `hostingMode` is set to `highDensity` the maximum number of partitions allowed is `3`.
 	PartitionCount pulumi.IntPtrOutput `pulumi:"partitionCount"`
@@ -259,7 +259,7 @@ type serviceState struct {
 	Location *string `pulumi:"location"`
 	// The Name which should be used for this Search Service. Changing this forces a new Search Service to be created.
 	Name *string `pulumi:"name"`
-	// Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+	// Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
 	//
 	// > **NOTE:** when `hostingMode` is set to `highDensity` the maximum number of partitions allowed is `3`.
 	PartitionCount *int `pulumi:"partitionCount"`
@@ -314,7 +314,7 @@ type ServiceState struct {
 	Location pulumi.StringPtrInput
 	// The Name which should be used for this Search Service. Changing this forces a new Search Service to be created.
 	Name pulumi.StringPtrInput
-	// Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+	// Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
 	//
 	// > **NOTE:** when `hostingMode` is set to `highDensity` the maximum number of partitions allowed is `3`.
 	PartitionCount pulumi.IntPtrInput
@@ -371,7 +371,7 @@ type serviceArgs struct {
 	Location *string `pulumi:"location"`
 	// The Name which should be used for this Search Service. Changing this forces a new Search Service to be created.
 	Name *string `pulumi:"name"`
-	// Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+	// Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
 	//
 	// > **NOTE:** when `hostingMode` is set to `highDensity` the maximum number of partitions allowed is `3`.
 	PartitionCount *int `pulumi:"partitionCount"`
@@ -419,7 +419,7 @@ type ServiceArgs struct {
 	Location pulumi.StringPtrInput
 	// The Name which should be used for this Search Service. Changing this forces a new Search Service to be created.
 	Name pulumi.StringPtrInput
-	// Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+	// Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
 	//
 	// > **NOTE:** when `hostingMode` is set to `highDensity` the maximum number of partitions allowed is `3`.
 	PartitionCount pulumi.IntPtrInput
@@ -581,7 +581,7 @@ func (o ServiceOutput) Name() pulumi.StringOutput {
 	return o.ApplyT(func(v *Service) pulumi.StringOutput { return v.Name }).(pulumi.StringOutput)
 }
 
-// Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+// Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
 //
 // > **NOTE:** when `hostingMode` is set to `highDensity` the maximum number of partitions allowed is `3`.
 func (o ServiceOutput) PartitionCount() pulumi.IntPtrOutput {

--- a/sdk/go/azure/servicebus/getSubscription.go
+++ b/sdk/go/azure/servicebus/getSubscription.go
@@ -66,7 +66,7 @@ type LookupSubscriptionArgs struct {
 
 // A collection of values returned by getSubscription.
 type LookupSubscriptionResult struct {
-	// The idle interval after which the topic is automatically deleted.
+	// The idle interval after which the Subscription is automatically deleted.
 	AutoDeleteOnIdle string `pulumi:"autoDeleteOnIdle"`
 	// Does the ServiceBus Subscription have dead letter support on filter evaluation exceptions?
 	DeadLetteringOnFilterEvaluationError bool `pulumi:"deadLetteringOnFilterEvaluationError"`
@@ -150,7 +150,7 @@ func (o LookupSubscriptionResultOutput) ToLookupSubscriptionResultOutputWithCont
 	return o
 }
 
-// The idle interval after which the topic is automatically deleted.
+// The idle interval after which the Subscription is automatically deleted.
 func (o LookupSubscriptionResultOutput) AutoDeleteOnIdle() pulumi.StringOutput {
 	return o.ApplyT(func(v LookupSubscriptionResult) string { return v.AutoDeleteOnIdle }).(pulumi.StringOutput)
 }

--- a/sdk/java/src/main/java/com/pulumi/azure/apimanagement/Backend.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/apimanagement/Backend.java
@@ -69,7 +69,7 @@ import javax.annotation.Nullable;
  *             .resourceGroupName(example.name())
  *             .apiManagementName(exampleService.name())
  *             .protocol("http")
- *             .url("https://backend")
+ *             .url("https://backend.com/api")
  *             .build());
  * 
  *     }}{@code
@@ -244,14 +244,14 @@ public class Backend extends com.pulumi.resources.CustomResource {
         return Codegen.optional(this.tls);
     }
     /**
-     * The URL of the backend host.
+     * The backend host URL should be specified in the format `&#34;https://backend.com/api&#34;`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
      * 
      */
     @Export(name="url", refs={String.class}, tree="[0]")
     private Output<String> url;
 
     /**
-     * @return The URL of the backend host.
+     * @return The backend host URL should be specified in the format `&#34;https://backend.com/api&#34;`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
      * 
      */
     public Output<String> url() {

--- a/sdk/java/src/main/java/com/pulumi/azure/apimanagement/BackendArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/apimanagement/BackendArgs.java
@@ -186,14 +186,14 @@ public final class BackendArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * The URL of the backend host.
+     * The backend host URL should be specified in the format `&#34;https://backend.com/api&#34;`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
      * 
      */
     @Import(name="url", required=true)
     private Output<String> url;
 
     /**
-     * @return The URL of the backend host.
+     * @return The backend host URL should be specified in the format `&#34;https://backend.com/api&#34;`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
      * 
      */
     public Output<String> url() {
@@ -467,7 +467,7 @@ public final class BackendArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param url The URL of the backend host.
+         * @param url The backend host URL should be specified in the format `&#34;https://backend.com/api&#34;`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
          * 
          * @return builder
          * 
@@ -478,7 +478,7 @@ public final class BackendArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param url The URL of the backend host.
+         * @param url The backend host URL should be specified in the format `&#34;https://backend.com/api&#34;`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/azure/apimanagement/Policy.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/apimanagement/Policy.java
@@ -111,14 +111,14 @@ public class Policy extends com.pulumi.resources.CustomResource {
         return this.apiManagementId;
     }
     /**
-     * The XML Content for this Policy as a string.
+     * The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
      * 
      */
     @Export(name="xmlContent", refs={String.class}, tree="[0]")
     private Output<String> xmlContent;
 
     /**
-     * @return The XML Content for this Policy as a string.
+     * @return The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
      * 
      */
     public Output<String> xmlContent() {

--- a/sdk/java/src/main/java/com/pulumi/azure/apimanagement/PolicyArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/apimanagement/PolicyArgs.java
@@ -32,14 +32,14 @@ public final class PolicyArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * The XML Content for this Policy as a string.
+     * The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
      * 
      */
     @Import(name="xmlContent")
     private @Nullable Output<String> xmlContent;
 
     /**
-     * @return The XML Content for this Policy as a string.
+     * @return The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
      * 
      */
     public Optional<Output<String>> xmlContent() {
@@ -109,7 +109,7 @@ public final class PolicyArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param xmlContent The XML Content for this Policy as a string.
+         * @param xmlContent The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
          * 
          * @return builder
          * 
@@ -120,7 +120,7 @@ public final class PolicyArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param xmlContent The XML Content for this Policy as a string.
+         * @param xmlContent The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/azure/apimanagement/inputs/BackendState.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/apimanagement/inputs/BackendState.java
@@ -185,14 +185,14 @@ public final class BackendState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * The URL of the backend host.
+     * The backend host URL should be specified in the format `&#34;https://backend.com/api&#34;`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
      * 
      */
     @Import(name="url")
     private @Nullable Output<String> url;
 
     /**
-     * @return The URL of the backend host.
+     * @return The backend host URL should be specified in the format `&#34;https://backend.com/api&#34;`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
      * 
      */
     public Optional<Output<String>> url() {
@@ -466,7 +466,7 @@ public final class BackendState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param url The URL of the backend host.
+         * @param url The backend host URL should be specified in the format `&#34;https://backend.com/api&#34;`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
          * 
          * @return builder
          * 
@@ -477,7 +477,7 @@ public final class BackendState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param url The URL of the backend host.
+         * @param url The backend host URL should be specified in the format `&#34;https://backend.com/api&#34;`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/azure/apimanagement/inputs/PolicyState.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/apimanagement/inputs/PolicyState.java
@@ -31,14 +31,14 @@ public final class PolicyState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * The XML Content for this Policy as a string.
+     * The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
      * 
      */
     @Import(name="xmlContent")
     private @Nullable Output<String> xmlContent;
 
     /**
-     * @return The XML Content for this Policy as a string.
+     * @return The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
      * 
      */
     public Optional<Output<String>> xmlContent() {
@@ -108,7 +108,7 @@ public final class PolicyState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param xmlContent The XML Content for this Policy as a string.
+         * @param xmlContent The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
          * 
          * @return builder
          * 
@@ -119,7 +119,7 @@ public final class PolicyState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param xmlContent The XML Content for this Policy as a string.
+         * @param xmlContent The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/azure/cdn/inputs/EndpointCustomDomainCdnManagedHttpsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/cdn/inputs/EndpointCustomDomainCdnManagedHttpsArgs.java
@@ -49,12 +49,16 @@ public final class EndpointCustomDomainCdnManagedHttpsArgs extends com.pulumi.re
     /**
      * The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
      * 
+     * &gt; **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
+     * 
      */
     @Import(name="tlsVersion")
     private @Nullable Output<String> tlsVersion;
 
     /**
      * @return The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+     * 
+     * &gt; **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
      * 
      */
     public Optional<Output<String>> tlsVersion() {
@@ -132,6 +136,8 @@ public final class EndpointCustomDomainCdnManagedHttpsArgs extends com.pulumi.re
         /**
          * @param tlsVersion The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
          * 
+         * &gt; **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
+         * 
          * @return builder
          * 
          */
@@ -142,6 +148,8 @@ public final class EndpointCustomDomainCdnManagedHttpsArgs extends com.pulumi.re
 
         /**
          * @param tlsVersion The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+         * 
+         * &gt; **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/azure/cdn/inputs/EndpointCustomDomainUserManagedHttpsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/cdn/inputs/EndpointCustomDomainUserManagedHttpsArgs.java
@@ -34,12 +34,16 @@ public final class EndpointCustomDomainUserManagedHttpsArgs extends com.pulumi.r
     /**
      * The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
      * 
+     * &gt; **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
+     * 
      */
     @Import(name="tlsVersion")
     private @Nullable Output<String> tlsVersion;
 
     /**
      * @return The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+     * 
+     * &gt; **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
      * 
      */
     public Optional<Output<String>> tlsVersion() {
@@ -95,6 +99,8 @@ public final class EndpointCustomDomainUserManagedHttpsArgs extends com.pulumi.r
         /**
          * @param tlsVersion The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
          * 
+         * &gt; **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
+         * 
          * @return builder
          * 
          */
@@ -105,6 +111,8 @@ public final class EndpointCustomDomainUserManagedHttpsArgs extends com.pulumi.r
 
         /**
          * @param tlsVersion The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+         * 
+         * &gt; **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/azure/cdn/inputs/FrontdoorOriginGroupHealthProbeArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/cdn/inputs/FrontdoorOriginGroupHealthProbeArgs.java
@@ -18,14 +18,14 @@ public final class FrontdoorOriginGroupHealthProbeArgs extends com.pulumi.resour
     public static final FrontdoorOriginGroupHealthProbeArgs Empty = new FrontdoorOriginGroupHealthProbeArgs();
 
     /**
-     * Specifies the number of seconds between health probes. Possible values are between `5` and `31536000` seconds (inclusive).
+     * Specifies the number of seconds between health probes. Possible values are between `1` and `255` seconds (inclusive).
      * 
      */
     @Import(name="intervalInSeconds", required=true)
     private Output<Integer> intervalInSeconds;
 
     /**
-     * @return Specifies the number of seconds between health probes. Possible values are between `5` and `31536000` seconds (inclusive).
+     * @return Specifies the number of seconds between health probes. Possible values are between `1` and `255` seconds (inclusive).
      * 
      */
     public Output<Integer> intervalInSeconds() {
@@ -109,7 +109,7 @@ public final class FrontdoorOriginGroupHealthProbeArgs extends com.pulumi.resour
         }
 
         /**
-         * @param intervalInSeconds Specifies the number of seconds between health probes. Possible values are between `5` and `31536000` seconds (inclusive).
+         * @param intervalInSeconds Specifies the number of seconds between health probes. Possible values are between `1` and `255` seconds (inclusive).
          * 
          * @return builder
          * 
@@ -120,7 +120,7 @@ public final class FrontdoorOriginGroupHealthProbeArgs extends com.pulumi.resour
         }
 
         /**
-         * @param intervalInSeconds Specifies the number of seconds between health probes. Possible values are between `5` and `31536000` seconds (inclusive).
+         * @param intervalInSeconds Specifies the number of seconds between health probes. Possible values are between `1` and `255` seconds (inclusive).
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/azure/cdn/outputs/EndpointCustomDomainCdnManagedHttps.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/cdn/outputs/EndpointCustomDomainCdnManagedHttps.java
@@ -25,6 +25,8 @@ public final class EndpointCustomDomainCdnManagedHttps {
     /**
      * @return The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
      * 
+     * &gt; **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
+     * 
      */
     private @Nullable String tlsVersion;
 
@@ -45,6 +47,8 @@ public final class EndpointCustomDomainCdnManagedHttps {
     }
     /**
      * @return The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+     * 
+     * &gt; **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
      * 
      */
     public Optional<String> tlsVersion() {

--- a/sdk/java/src/main/java/com/pulumi/azure/cdn/outputs/EndpointCustomDomainUserManagedHttps.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/cdn/outputs/EndpointCustomDomainUserManagedHttps.java
@@ -20,6 +20,8 @@ public final class EndpointCustomDomainUserManagedHttps {
     /**
      * @return The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
      * 
+     * &gt; **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
+     * 
      */
     private @Nullable String tlsVersion;
 
@@ -33,6 +35,8 @@ public final class EndpointCustomDomainUserManagedHttps {
     }
     /**
      * @return The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+     * 
+     * &gt; **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
      * 
      */
     public Optional<String> tlsVersion() {

--- a/sdk/java/src/main/java/com/pulumi/azure/cdn/outputs/FrontdoorOriginGroupHealthProbe.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/cdn/outputs/FrontdoorOriginGroupHealthProbe.java
@@ -14,7 +14,7 @@ import javax.annotation.Nullable;
 @CustomType
 public final class FrontdoorOriginGroupHealthProbe {
     /**
-     * @return Specifies the number of seconds between health probes. Possible values are between `5` and `31536000` seconds (inclusive).
+     * @return Specifies the number of seconds between health probes. Possible values are between `1` and `255` seconds (inclusive).
      * 
      */
     private Integer intervalInSeconds;
@@ -38,7 +38,7 @@ public final class FrontdoorOriginGroupHealthProbe {
 
     private FrontdoorOriginGroupHealthProbe() {}
     /**
-     * @return Specifies the number of seconds between health probes. Possible values are between `5` and `31536000` seconds (inclusive).
+     * @return Specifies the number of seconds between health probes. Possible values are between `1` and `255` seconds (inclusive).
      * 
      */
     public Integer intervalInSeconds() {

--- a/sdk/java/src/main/java/com/pulumi/azure/cognitive/Deployment.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/cognitive/Deployment.java
@@ -12,6 +12,7 @@ import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Export;
 import com.pulumi.core.annotations.ResourceType;
 import com.pulumi.core.internal.Codegen;
+import java.lang.Boolean;
 import java.lang.String;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -106,6 +107,20 @@ public class Deployment extends com.pulumi.resources.CustomResource {
      */
     public Output<String> cognitiveAccountId() {
         return this.cognitiveAccountId;
+    }
+    /**
+     * Whether dynamic throttling is enabled.
+     * 
+     */
+    @Export(name="dynamicThrottlingEnabled", refs={Boolean.class}, tree="[0]")
+    private Output</* @Nullable */ Boolean> dynamicThrottlingEnabled;
+
+    /**
+     * @return Whether dynamic throttling is enabled.
+     * 
+     */
+    public Output<Optional<Boolean>> dynamicThrottlingEnabled() {
+        return Codegen.optional(this.dynamicThrottlingEnabled);
     }
     /**
      * A `model` block as defined below. Changing this forces a new resource to be created.

--- a/sdk/java/src/main/java/com/pulumi/azure/cognitive/DeploymentArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/cognitive/DeploymentArgs.java
@@ -8,6 +8,7 @@ import com.pulumi.azure.cognitive.inputs.DeploymentSkuArgs;
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
 import com.pulumi.exceptions.MissingRequiredPropertyException;
+import java.lang.Boolean;
 import java.lang.String;
 import java.util.Objects;
 import java.util.Optional;
@@ -31,6 +32,21 @@ public final class DeploymentArgs extends com.pulumi.resources.ResourceArgs {
      */
     public Output<String> cognitiveAccountId() {
         return this.cognitiveAccountId;
+    }
+
+    /**
+     * Whether dynamic throttling is enabled.
+     * 
+     */
+    @Import(name="dynamicThrottlingEnabled")
+    private @Nullable Output<Boolean> dynamicThrottlingEnabled;
+
+    /**
+     * @return Whether dynamic throttling is enabled.
+     * 
+     */
+    public Optional<Output<Boolean>> dynamicThrottlingEnabled() {
+        return Optional.ofNullable(this.dynamicThrottlingEnabled);
     }
 
     /**
@@ -112,6 +128,7 @@ public final class DeploymentArgs extends com.pulumi.resources.ResourceArgs {
 
     private DeploymentArgs(DeploymentArgs $) {
         this.cognitiveAccountId = $.cognitiveAccountId;
+        this.dynamicThrottlingEnabled = $.dynamicThrottlingEnabled;
         this.model = $.model;
         this.name = $.name;
         this.raiPolicyName = $.raiPolicyName;
@@ -156,6 +173,27 @@ public final class DeploymentArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder cognitiveAccountId(String cognitiveAccountId) {
             return cognitiveAccountId(Output.of(cognitiveAccountId));
+        }
+
+        /**
+         * @param dynamicThrottlingEnabled Whether dynamic throttling is enabled.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder dynamicThrottlingEnabled(@Nullable Output<Boolean> dynamicThrottlingEnabled) {
+            $.dynamicThrottlingEnabled = dynamicThrottlingEnabled;
+            return this;
+        }
+
+        /**
+         * @param dynamicThrottlingEnabled Whether dynamic throttling is enabled.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder dynamicThrottlingEnabled(Boolean dynamicThrottlingEnabled) {
+            return dynamicThrottlingEnabled(Output.of(dynamicThrottlingEnabled));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/azure/cognitive/inputs/DeploymentState.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/cognitive/inputs/DeploymentState.java
@@ -7,6 +7,7 @@ import com.pulumi.azure.cognitive.inputs.DeploymentModelArgs;
 import com.pulumi.azure.cognitive.inputs.DeploymentSkuArgs;
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
+import java.lang.Boolean;
 import java.lang.String;
 import java.util.Objects;
 import java.util.Optional;
@@ -30,6 +31,21 @@ public final class DeploymentState extends com.pulumi.resources.ResourceArgs {
      */
     public Optional<Output<String>> cognitiveAccountId() {
         return Optional.ofNullable(this.cognitiveAccountId);
+    }
+
+    /**
+     * Whether dynamic throttling is enabled.
+     * 
+     */
+    @Import(name="dynamicThrottlingEnabled")
+    private @Nullable Output<Boolean> dynamicThrottlingEnabled;
+
+    /**
+     * @return Whether dynamic throttling is enabled.
+     * 
+     */
+    public Optional<Output<Boolean>> dynamicThrottlingEnabled() {
+        return Optional.ofNullable(this.dynamicThrottlingEnabled);
     }
 
     /**
@@ -111,6 +127,7 @@ public final class DeploymentState extends com.pulumi.resources.ResourceArgs {
 
     private DeploymentState(DeploymentState $) {
         this.cognitiveAccountId = $.cognitiveAccountId;
+        this.dynamicThrottlingEnabled = $.dynamicThrottlingEnabled;
         this.model = $.model;
         this.name = $.name;
         this.raiPolicyName = $.raiPolicyName;
@@ -155,6 +172,27 @@ public final class DeploymentState extends com.pulumi.resources.ResourceArgs {
          */
         public Builder cognitiveAccountId(String cognitiveAccountId) {
             return cognitiveAccountId(Output.of(cognitiveAccountId));
+        }
+
+        /**
+         * @param dynamicThrottlingEnabled Whether dynamic throttling is enabled.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder dynamicThrottlingEnabled(@Nullable Output<Boolean> dynamicThrottlingEnabled) {
+            $.dynamicThrottlingEnabled = dynamicThrottlingEnabled;
+            return this;
+        }
+
+        /**
+         * @param dynamicThrottlingEnabled Whether dynamic throttling is enabled.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder dynamicThrottlingEnabled(Boolean dynamicThrottlingEnabled) {
+            return dynamicThrottlingEnabled(Output.of(dynamicThrottlingEnabled));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/azure/dataprotection/BackupInstanceBlogStorage.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/dataprotection/BackupInstanceBlogStorage.java
@@ -21,6 +21,90 @@ import javax.annotation.Nullable;
  * ## Example Usage
  * 
  * &lt;!--Start PulumiCodeChooser --&gt;
+ * <pre>
+ * {@code
+ * package generated_program;
+ * 
+ * import com.pulumi.Context;
+ * import com.pulumi.Pulumi;
+ * import com.pulumi.core.Output;
+ * import com.pulumi.azure.core.ResourceGroup;
+ * import com.pulumi.azure.core.ResourceGroupArgs;
+ * import com.pulumi.azure.storage.Account;
+ * import com.pulumi.azure.storage.AccountArgs;
+ * import com.pulumi.azure.dataprotection.BackupVault;
+ * import com.pulumi.azure.dataprotection.BackupVaultArgs;
+ * import com.pulumi.azure.dataprotection.inputs.BackupVaultIdentityArgs;
+ * import com.pulumi.azure.authorization.Assignment;
+ * import com.pulumi.azure.authorization.AssignmentArgs;
+ * import com.pulumi.azure.dataprotection.BackupPolicyBlobStorage;
+ * import com.pulumi.azure.dataprotection.BackupPolicyBlobStorageArgs;
+ * import com.pulumi.azure.dataprotection.BackupInstanceBlogStorage;
+ * import com.pulumi.azure.dataprotection.BackupInstanceBlogStorageArgs;
+ * import com.pulumi.resources.CustomResourceOptions;
+ * import java.util.List;
+ * import java.util.ArrayList;
+ * import java.util.Map;
+ * import java.io.File;
+ * import java.nio.file.Files;
+ * import java.nio.file.Paths;
+ * 
+ * public class App {
+ *     public static void main(String[] args) {
+ *         Pulumi.run(App::stack);
+ *     }
+ * 
+ *     public static void stack(Context ctx) {
+ *         var example = new ResourceGroup("example", ResourceGroupArgs.builder()
+ *             .name("example-resources")
+ *             .location("West Europe")
+ *             .build());
+ * 
+ *         var exampleAccount = new Account("exampleAccount", AccountArgs.builder()
+ *             .name("storageaccountname")
+ *             .resourceGroupName(example.name())
+ *             .location(example.location())
+ *             .accountTier("Standard")
+ *             .accountReplicationType("LRS")
+ *             .build());
+ * 
+ *         var exampleBackupVault = new BackupVault("exampleBackupVault", BackupVaultArgs.builder()
+ *             .name("example-backup-vault")
+ *             .resourceGroupName(example.name())
+ *             .location(example.location())
+ *             .datastoreType("VaultStore")
+ *             .redundancy("LocallyRedundant")
+ *             .identity(BackupVaultIdentityArgs.builder()
+ *                 .type("SystemAssigned")
+ *                 .build())
+ *             .build());
+ * 
+ *         var exampleAssignment = new Assignment("exampleAssignment", AssignmentArgs.builder()
+ *             .scope(exampleAccount.id())
+ *             .roleDefinitionName("Storage Account Backup Contributor")
+ *             .principalId(exampleBackupVault.identity().applyValue(identity -> identity.principalId()))
+ *             .build());
+ * 
+ *         var exampleBackupPolicyBlobStorage = new BackupPolicyBlobStorage("exampleBackupPolicyBlobStorage", BackupPolicyBlobStorageArgs.builder()
+ *             .name("example-backup-policy")
+ *             .vaultId(exampleBackupVault.id())
+ *             .operationalDefaultRetentionDuration("P30D")
+ *             .build());
+ * 
+ *         var exampleBackupInstanceBlogStorage = new BackupInstanceBlogStorage("exampleBackupInstanceBlogStorage", BackupInstanceBlogStorageArgs.builder()
+ *             .name("example-backup-instance")
+ *             .vaultId(exampleBackupVault.id())
+ *             .location(example.location())
+ *             .storageAccountId(exampleAccount.id())
+ *             .backupPolicyId(exampleBackupPolicyBlobStorage.id())
+ *             .build(), CustomResourceOptions.builder()
+ *                 .dependsOn(exampleAssignment)
+ *                 .build());
+ * 
+ *     }
+ * }
+ * }
+ * </pre>
  * &lt;!--End PulumiCodeChooser --&gt;
  * 
  * ## Import

--- a/sdk/java/src/main/java/com/pulumi/azure/keyvault/ManagedHardwareSecurityModuleKey.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/keyvault/ManagedHardwareSecurityModuleKey.java
@@ -79,28 +79,28 @@ public class ManagedHardwareSecurityModuleKey extends com.pulumi.resources.Custo
         return this.keyOpts;
     }
     /**
-     * Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM`. Changing this forces a new resource to be created.
+     * Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
      * 
      */
     @Export(name="keySize", refs={Integer.class}, tree="[0]")
     private Output</* @Nullable */ Integer> keySize;
 
     /**
-     * @return Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM`. Changing this forces a new resource to be created.
+     * @return Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
      * 
      */
     public Output<Optional<Integer>> keySize() {
         return Codegen.optional(this.keySize);
     }
     /**
-     * Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+     * Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
      * 
      */
     @Export(name="keyType", refs={String.class}, tree="[0]")
     private Output<String> keyType;
 
     /**
-     * @return Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+     * @return Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
      * 
      */
     public Output<String> keyType() {

--- a/sdk/java/src/main/java/com/pulumi/azure/keyvault/ManagedHardwareSecurityModuleKeyArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/keyvault/ManagedHardwareSecurityModuleKeyArgs.java
@@ -65,14 +65,14 @@ public final class ManagedHardwareSecurityModuleKeyArgs extends com.pulumi.resou
     }
 
     /**
-     * Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM`. Changing this forces a new resource to be created.
+     * Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
      * 
      */
     @Import(name="keySize")
     private @Nullable Output<Integer> keySize;
 
     /**
-     * @return Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM`. Changing this forces a new resource to be created.
+     * @return Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
      * 
      */
     public Optional<Output<Integer>> keySize() {
@@ -80,14 +80,14 @@ public final class ManagedHardwareSecurityModuleKeyArgs extends com.pulumi.resou
     }
 
     /**
-     * Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+     * Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
      * 
      */
     @Import(name="keyType", required=true)
     private Output<String> keyType;
 
     /**
-     * @return Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+     * @return Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
      * 
      */
     public Output<String> keyType() {
@@ -264,7 +264,7 @@ public final class ManagedHardwareSecurityModuleKeyArgs extends com.pulumi.resou
         }
 
         /**
-         * @param keySize Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM`. Changing this forces a new resource to be created.
+         * @param keySize Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
          * 
          * @return builder
          * 
@@ -275,7 +275,7 @@ public final class ManagedHardwareSecurityModuleKeyArgs extends com.pulumi.resou
         }
 
         /**
-         * @param keySize Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM`. Changing this forces a new resource to be created.
+         * @param keySize Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
          * 
          * @return builder
          * 
@@ -285,7 +285,7 @@ public final class ManagedHardwareSecurityModuleKeyArgs extends com.pulumi.resou
         }
 
         /**
-         * @param keyType Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+         * @param keyType Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
          * 
          * @return builder
          * 
@@ -296,7 +296,7 @@ public final class ManagedHardwareSecurityModuleKeyArgs extends com.pulumi.resou
         }
 
         /**
-         * @param keyType Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+         * @param keyType Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/azure/keyvault/inputs/ManagedHardwareSecurityModuleKeyState.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/keyvault/inputs/ManagedHardwareSecurityModuleKeyState.java
@@ -64,14 +64,14 @@ public final class ManagedHardwareSecurityModuleKeyState extends com.pulumi.reso
     }
 
     /**
-     * Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM`. Changing this forces a new resource to be created.
+     * Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
      * 
      */
     @Import(name="keySize")
     private @Nullable Output<Integer> keySize;
 
     /**
-     * @return Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM`. Changing this forces a new resource to be created.
+     * @return Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
      * 
      */
     public Optional<Output<Integer>> keySize() {
@@ -79,14 +79,14 @@ public final class ManagedHardwareSecurityModuleKeyState extends com.pulumi.reso
     }
 
     /**
-     * Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+     * Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
      * 
      */
     @Import(name="keyType")
     private @Nullable Output<String> keyType;
 
     /**
-     * @return Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+     * @return Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
      * 
      */
     public Optional<Output<String>> keyType() {
@@ -279,7 +279,7 @@ public final class ManagedHardwareSecurityModuleKeyState extends com.pulumi.reso
         }
 
         /**
-         * @param keySize Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM`. Changing this forces a new resource to be created.
+         * @param keySize Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
          * 
          * @return builder
          * 
@@ -290,7 +290,7 @@ public final class ManagedHardwareSecurityModuleKeyState extends com.pulumi.reso
         }
 
         /**
-         * @param keySize Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM`. Changing this forces a new resource to be created.
+         * @param keySize Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
          * 
          * @return builder
          * 
@@ -300,7 +300,7 @@ public final class ManagedHardwareSecurityModuleKeyState extends com.pulumi.reso
         }
 
         /**
-         * @param keyType Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+         * @param keyType Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
          * 
          * @return builder
          * 
@@ -311,7 +311,7 @@ public final class ManagedHardwareSecurityModuleKeyState extends com.pulumi.reso
         }
 
         /**
-         * @param keyType Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+         * @param keyType Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/azure/logicapps/outputs/GetStandardIdentity.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/logicapps/outputs/GetStandardIdentity.java
@@ -6,10 +6,12 @@ package com.pulumi.azure.logicapps.outputs;
 import com.pulumi.core.annotations.CustomType;
 import com.pulumi.exceptions.MissingRequiredPropertyException;
 import java.lang.String;
+import java.util.List;
 import java.util.Objects;
 
 @CustomType
 public final class GetStandardIdentity {
+    private List<String> identityIds;
     /**
      * @return The Principal ID for the Service Principal associated with the Managed Service Identity of this Logic App Workflow.
      * 
@@ -27,6 +29,9 @@ public final class GetStandardIdentity {
     private String type;
 
     private GetStandardIdentity() {}
+    public List<String> identityIds() {
+        return this.identityIds;
+    }
     /**
      * @return The Principal ID for the Service Principal associated with the Managed Service Identity of this Logic App Workflow.
      * 
@@ -58,17 +63,30 @@ public final class GetStandardIdentity {
     }
     @CustomType.Builder
     public static final class Builder {
+        private List<String> identityIds;
         private String principalId;
         private String tenantId;
         private String type;
         public Builder() {}
         public Builder(GetStandardIdentity defaults) {
     	      Objects.requireNonNull(defaults);
+    	      this.identityIds = defaults.identityIds;
     	      this.principalId = defaults.principalId;
     	      this.tenantId = defaults.tenantId;
     	      this.type = defaults.type;
         }
 
+        @CustomType.Setter
+        public Builder identityIds(List<String> identityIds) {
+            if (identityIds == null) {
+              throw new MissingRequiredPropertyException("GetStandardIdentity", "identityIds");
+            }
+            this.identityIds = identityIds;
+            return this;
+        }
+        public Builder identityIds(String... identityIds) {
+            return identityIds(List.of(identityIds));
+        }
         @CustomType.Setter
         public Builder principalId(String principalId) {
             if (principalId == null) {
@@ -95,6 +113,7 @@ public final class GetStandardIdentity {
         }
         public GetStandardIdentity build() {
             final var _resultValue = new GetStandardIdentity();
+            _resultValue.identityIds = identityIds;
             _resultValue.principalId = principalId;
             _resultValue.tenantId = tenantId;
             _resultValue.type = type;

--- a/sdk/java/src/main/java/com/pulumi/azure/network/NatGateway.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/network/NatGateway.java
@@ -53,7 +53,7 @@ import javax.annotation.Nullable;
  *             .build());
  * 
  *         var exampleNatGateway = new NatGateway("exampleNatGateway", NatGatewayArgs.builder()
- *             .name("nat-Gateway")
+ *             .name("nat-gateway")
  *             .location(example.location())
  *             .resourceGroupName(example.name())
  *             .skuName("Standard")

--- a/sdk/java/src/main/java/com/pulumi/azure/search/Service.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/search/Service.java
@@ -313,7 +313,7 @@ public class Service extends com.pulumi.resources.CustomResource {
         return this.name;
     }
     /**
-     * Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+     * Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
      * 
      * &gt; **NOTE:** when `hosting_mode` is set to `highDensity` the maximum number of partitions allowed is `3`.
      * 
@@ -322,7 +322,7 @@ public class Service extends com.pulumi.resources.CustomResource {
     private Output</* @Nullable */ Integer> partitionCount;
 
     /**
-     * @return Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+     * @return Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
      * 
      * &gt; **NOTE:** when `hosting_mode` is set to `highDensity` the maximum number of partitions allowed is `3`.
      * 

--- a/sdk/java/src/main/java/com/pulumi/azure/search/ServiceArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/search/ServiceArgs.java
@@ -154,7 +154,7 @@ public final class ServiceArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+     * Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
      * 
      * &gt; **NOTE:** when `hosting_mode` is set to `highDensity` the maximum number of partitions allowed is `3`.
      * 
@@ -163,7 +163,7 @@ public final class ServiceArgs extends com.pulumi.resources.ResourceArgs {
     private @Nullable Output<Integer> partitionCount;
 
     /**
-     * @return Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+     * @return Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
      * 
      * &gt; **NOTE:** when `hosting_mode` is set to `highDensity` the maximum number of partitions allowed is `3`.
      * 
@@ -505,7 +505,7 @@ public final class ServiceArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param partitionCount Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+         * @param partitionCount Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
          * 
          * &gt; **NOTE:** when `hosting_mode` is set to `highDensity` the maximum number of partitions allowed is `3`.
          * 
@@ -518,7 +518,7 @@ public final class ServiceArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param partitionCount Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+         * @param partitionCount Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
          * 
          * &gt; **NOTE:** when `hosting_mode` is set to `highDensity` the maximum number of partitions allowed is `3`.
          * 

--- a/sdk/java/src/main/java/com/pulumi/azure/search/inputs/ServiceState.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/search/inputs/ServiceState.java
@@ -169,7 +169,7 @@ public final class ServiceState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+     * Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
      * 
      * &gt; **NOTE:** when `hosting_mode` is set to `highDensity` the maximum number of partitions allowed is `3`.
      * 
@@ -178,7 +178,7 @@ public final class ServiceState extends com.pulumi.resources.ResourceArgs {
     private @Nullable Output<Integer> partitionCount;
 
     /**
-     * @return Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+     * @return Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
      * 
      * &gt; **NOTE:** when `hosting_mode` is set to `highDensity` the maximum number of partitions allowed is `3`.
      * 
@@ -590,7 +590,7 @@ public final class ServiceState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param partitionCount Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+         * @param partitionCount Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
          * 
          * &gt; **NOTE:** when `hosting_mode` is set to `highDensity` the maximum number of partitions allowed is `3`.
          * 
@@ -603,7 +603,7 @@ public final class ServiceState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param partitionCount Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+         * @param partitionCount Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
          * 
          * &gt; **NOTE:** when `hosting_mode` is set to `highDensity` the maximum number of partitions allowed is `3`.
          * 

--- a/sdk/java/src/main/java/com/pulumi/azure/servicebus/outputs/GetSubscriptionResult.java
+++ b/sdk/java/src/main/java/com/pulumi/azure/servicebus/outputs/GetSubscriptionResult.java
@@ -15,7 +15,7 @@ import javax.annotation.Nullable;
 @CustomType
 public final class GetSubscriptionResult {
     /**
-     * @return The idle interval after which the topic is automatically deleted.
+     * @return The idle interval after which the Subscription is automatically deleted.
      * 
      */
     private String autoDeleteOnIdle;
@@ -95,7 +95,7 @@ public final class GetSubscriptionResult {
 
     private GetSubscriptionResult() {}
     /**
-     * @return The idle interval after which the topic is automatically deleted.
+     * @return The idle interval after which the Subscription is automatically deleted.
      * 
      */
     public String autoDeleteOnIdle() {

--- a/sdk/nodejs/apimanagement/backend.ts
+++ b/sdk/nodejs/apimanagement/backend.ts
@@ -32,7 +32,7 @@ import * as utilities from "../utilities";
  *     resourceGroupName: example.name,
  *     apiManagementName: exampleService.name,
  *     protocol: "http",
- *     url: "https://backend",
+ *     url: "https://backend.com/api",
  * });
  * ```
  *
@@ -117,7 +117,7 @@ export class Backend extends pulumi.CustomResource {
      */
     public readonly tls!: pulumi.Output<outputs.apimanagement.BackendTls | undefined>;
     /**
-     * The URL of the backend host.
+     * The backend host URL should be specified in the format `"https://backend.com/api"`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
      */
     public readonly url!: pulumi.Output<string>;
 
@@ -227,7 +227,7 @@ export interface BackendState {
      */
     tls?: pulumi.Input<inputs.apimanagement.BackendTls>;
     /**
-     * The URL of the backend host.
+     * The backend host URL should be specified in the format `"https://backend.com/api"`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
      */
     url?: pulumi.Input<string>;
 }
@@ -281,7 +281,7 @@ export interface BackendArgs {
      */
     tls?: pulumi.Input<inputs.apimanagement.BackendTls>;
     /**
-     * The URL of the backend host.
+     * The backend host URL should be specified in the format `"https://backend.com/api"`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
      */
     url: pulumi.Input<string>;
 }

--- a/sdk/nodejs/apimanagement/policy.ts
+++ b/sdk/nodejs/apimanagement/policy.ts
@@ -84,7 +84,7 @@ export class Policy extends pulumi.CustomResource {
      */
     public readonly apiManagementId!: pulumi.Output<string>;
     /**
-     * The XML Content for this Policy as a string.
+     * The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
      */
     public readonly xmlContent!: pulumi.Output<string>;
     /**
@@ -131,7 +131,7 @@ export interface PolicyState {
      */
     apiManagementId?: pulumi.Input<string>;
     /**
-     * The XML Content for this Policy as a string.
+     * The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
      */
     xmlContent?: pulumi.Input<string>;
     /**
@@ -149,7 +149,7 @@ export interface PolicyArgs {
      */
     apiManagementId: pulumi.Input<string>;
     /**
-     * The XML Content for this Policy as a string.
+     * The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
      */
     xmlContent?: pulumi.Input<string>;
     /**

--- a/sdk/nodejs/cognitive/deployment.ts
+++ b/sdk/nodejs/cognitive/deployment.ts
@@ -81,6 +81,10 @@ export class Deployment extends pulumi.CustomResource {
      */
     public readonly cognitiveAccountId!: pulumi.Output<string>;
     /**
+     * Whether dynamic throttling is enabled.
+     */
+    public readonly dynamicThrottlingEnabled!: pulumi.Output<boolean | undefined>;
+    /**
      * A `model` block as defined below. Changing this forces a new resource to be created.
      */
     public readonly model!: pulumi.Output<outputs.cognitive.DeploymentModel>;
@@ -115,6 +119,7 @@ export class Deployment extends pulumi.CustomResource {
         if (opts.id) {
             const state = argsOrState as DeploymentState | undefined;
             resourceInputs["cognitiveAccountId"] = state ? state.cognitiveAccountId : undefined;
+            resourceInputs["dynamicThrottlingEnabled"] = state ? state.dynamicThrottlingEnabled : undefined;
             resourceInputs["model"] = state ? state.model : undefined;
             resourceInputs["name"] = state ? state.name : undefined;
             resourceInputs["raiPolicyName"] = state ? state.raiPolicyName : undefined;
@@ -132,6 +137,7 @@ export class Deployment extends pulumi.CustomResource {
                 throw new Error("Missing required property 'sku'");
             }
             resourceInputs["cognitiveAccountId"] = args ? args.cognitiveAccountId : undefined;
+            resourceInputs["dynamicThrottlingEnabled"] = args ? args.dynamicThrottlingEnabled : undefined;
             resourceInputs["model"] = args ? args.model : undefined;
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["raiPolicyName"] = args ? args.raiPolicyName : undefined;
@@ -151,6 +157,10 @@ export interface DeploymentState {
      * The ID of the Cognitive Services Account. Changing this forces a new resource to be created.
      */
     cognitiveAccountId?: pulumi.Input<string>;
+    /**
+     * Whether dynamic throttling is enabled.
+     */
+    dynamicThrottlingEnabled?: pulumi.Input<boolean>;
     /**
      * A `model` block as defined below. Changing this forces a new resource to be created.
      */
@@ -181,6 +191,10 @@ export interface DeploymentArgs {
      * The ID of the Cognitive Services Account. Changing this forces a new resource to be created.
      */
     cognitiveAccountId: pulumi.Input<string>;
+    /**
+     * Whether dynamic throttling is enabled.
+     */
+    dynamicThrottlingEnabled?: pulumi.Input<boolean>;
     /**
      * A `model` block as defined below. Changing this forces a new resource to be created.
      */

--- a/sdk/nodejs/dataprotection/backupInstanceBlogStorage.ts
+++ b/sdk/nodejs/dataprotection/backupInstanceBlogStorage.ts
@@ -7,6 +7,54 @@ import * as utilities from "../utilities";
 /**
  * Manages a Backup Instance Blob Storage.
  *
+ * ## Example Usage
+ *
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as azure from "@pulumi/azure";
+ *
+ * const example = new azure.core.ResourceGroup("example", {
+ *     name: "example-resources",
+ *     location: "West Europe",
+ * });
+ * const exampleAccount = new azure.storage.Account("example", {
+ *     name: "storageaccountname",
+ *     resourceGroupName: example.name,
+ *     location: example.location,
+ *     accountTier: "Standard",
+ *     accountReplicationType: "LRS",
+ * });
+ * const exampleBackupVault = new azure.dataprotection.BackupVault("example", {
+ *     name: "example-backup-vault",
+ *     resourceGroupName: example.name,
+ *     location: example.location,
+ *     datastoreType: "VaultStore",
+ *     redundancy: "LocallyRedundant",
+ *     identity: {
+ *         type: "SystemAssigned",
+ *     },
+ * });
+ * const exampleAssignment = new azure.authorization.Assignment("example", {
+ *     scope: exampleAccount.id,
+ *     roleDefinitionName: "Storage Account Backup Contributor",
+ *     principalId: exampleBackupVault.identity.apply(identity => identity?.principalId),
+ * });
+ * const exampleBackupPolicyBlobStorage = new azure.dataprotection.BackupPolicyBlobStorage("example", {
+ *     name: "example-backup-policy",
+ *     vaultId: exampleBackupVault.id,
+ *     operationalDefaultRetentionDuration: "P30D",
+ * });
+ * const exampleBackupInstanceBlogStorage = new azure.dataprotection.BackupInstanceBlogStorage("example", {
+ *     name: "example-backup-instance",
+ *     vaultId: exampleBackupVault.id,
+ *     location: example.location,
+ *     storageAccountId: exampleAccount.id,
+ *     backupPolicyId: exampleBackupPolicyBlobStorage.id,
+ * }, {
+ *     dependsOn: [exampleAssignment],
+ * });
+ * ```
+ *
  * ## Import
  *
  * Backup Instance Blob Storages can be imported using the `resource id`, e.g.

--- a/sdk/nodejs/keyvault/managedHardwareSecurityModuleKey.ts
+++ b/sdk/nodejs/keyvault/managedHardwareSecurityModuleKey.ts
@@ -58,11 +58,11 @@ export class ManagedHardwareSecurityModuleKey extends pulumi.CustomResource {
      */
     public readonly keyOpts!: pulumi.Output<string[]>;
     /**
-     * Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `keyType` is `RSA-HSM`. Changing this forces a new resource to be created.
+     * Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `keyType` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
      */
     public readonly keySize!: pulumi.Output<number | undefined>;
     /**
-     * Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+     * Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
      */
     public readonly keyType!: pulumi.Output<string>;
     /**
@@ -155,11 +155,11 @@ export interface ManagedHardwareSecurityModuleKeyState {
      */
     keyOpts?: pulumi.Input<pulumi.Input<string>[]>;
     /**
-     * Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `keyType` is `RSA-HSM`. Changing this forces a new resource to be created.
+     * Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `keyType` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
      */
     keySize?: pulumi.Input<number>;
     /**
-     * Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+     * Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
      */
     keyType?: pulumi.Input<string>;
     /**
@@ -203,11 +203,11 @@ export interface ManagedHardwareSecurityModuleKeyArgs {
      */
     keyOpts: pulumi.Input<pulumi.Input<string>[]>;
     /**
-     * Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `keyType` is `RSA-HSM`. Changing this forces a new resource to be created.
+     * Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `keyType` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
      */
     keySize?: pulumi.Input<number>;
     /**
-     * Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+     * Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
      */
     keyType: pulumi.Input<string>;
     /**

--- a/sdk/nodejs/network/natGateway.ts
+++ b/sdk/nodejs/network/natGateway.ts
@@ -18,7 +18,7 @@ import * as utilities from "../utilities";
  *     location: "West Europe",
  * });
  * const exampleNatGateway = new azure.network.NatGateway("example", {
- *     name: "nat-Gateway",
+ *     name: "nat-gateway",
  *     location: example.location,
  *     resourceGroupName: example.name,
  *     skuName: "Standard",

--- a/sdk/nodejs/search/service.ts
+++ b/sdk/nodejs/search/service.ts
@@ -147,7 +147,7 @@ export class Service extends pulumi.CustomResource {
      */
     public readonly name!: pulumi.Output<string>;
     /**
-     * Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+     * Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
      *
      * > **NOTE:** when `hostingMode` is set to `highDensity` the maximum number of partitions allowed is `3`.
      */
@@ -309,7 +309,7 @@ export interface ServiceState {
      */
     name?: pulumi.Input<string>;
     /**
-     * Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+     * Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
      *
      * > **NOTE:** when `hostingMode` is set to `highDensity` the maximum number of partitions allowed is `3`.
      */
@@ -401,7 +401,7 @@ export interface ServiceArgs {
      */
     name?: pulumi.Input<string>;
     /**
-     * Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+     * Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
      *
      * > **NOTE:** when `hostingMode` is set to `highDensity` the maximum number of partitions allowed is `3`.
      */

--- a/sdk/nodejs/servicebus/getSubscription.ts
+++ b/sdk/nodejs/servicebus/getSubscription.ts
@@ -62,7 +62,7 @@ export interface GetSubscriptionArgs {
  */
 export interface GetSubscriptionResult {
     /**
-     * The idle interval after which the topic is automatically deleted.
+     * The idle interval after which the Subscription is automatically deleted.
      */
     readonly autoDeleteOnIdle: string;
     /**

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -16356,6 +16356,8 @@ export namespace cdn {
         protocolType: pulumi.Input<string>;
         /**
          * The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+         *
+         * > **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
          */
         tlsVersion?: pulumi.Input<string>;
     }
@@ -16367,6 +16369,8 @@ export namespace cdn {
         keyVaultSecretId: pulumi.Input<string>;
         /**
          * The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+         *
+         * > **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
          */
         tlsVersion?: pulumi.Input<string>;
     }
@@ -17168,7 +17172,7 @@ export namespace cdn {
 
     export interface FrontdoorOriginGroupHealthProbe {
         /**
-         * Specifies the number of seconds between health probes. Possible values are between `5` and `31536000` seconds (inclusive).
+         * Specifies the number of seconds between health probes. Possible values are between `1` and `255` seconds (inclusive).
          */
         intervalInSeconds: pulumi.Input<number>;
         /**

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -22466,6 +22466,8 @@ export namespace cdn {
         protocolType: string;
         /**
          * The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+         *
+         * > **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
          */
         tlsVersion?: string;
     }
@@ -22477,6 +22479,8 @@ export namespace cdn {
         keyVaultSecretId: string;
         /**
          * The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+         *
+         * > **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
          */
         tlsVersion?: string;
     }
@@ -23278,7 +23282,7 @@ export namespace cdn {
 
     export interface FrontdoorOriginGroupHealthProbe {
         /**
-         * Specifies the number of seconds between health probes. Possible values are between `5` and `31536000` seconds (inclusive).
+         * Specifies the number of seconds between health probes. Possible values are between `1` and `255` seconds (inclusive).
          */
         intervalInSeconds: number;
         /**
@@ -46551,6 +46555,7 @@ export namespace logicapps {
     }
 
     export interface GetStandardIdentity {
+        identityIds: string[];
         /**
          * The Principal ID for the Service Principal associated with the Managed Service Identity of this Logic App Workflow.
          */

--- a/sdk/python/pulumi_azure/apimanagement/backend.py
+++ b/sdk/python/pulumi_azure/apimanagement/backend.py
@@ -38,7 +38,7 @@ class BackendArgs:
         :param pulumi.Input[str] api_management_name: The Name of the API Management Service where this backend should be created. Changing this forces a new resource to be created.
         :param pulumi.Input[str] protocol: The protocol used by the backend host. Possible values are `http` or `soap`.
         :param pulumi.Input[str] resource_group_name: The Name of the Resource Group where the API Management Service exists. Changing this forces a new resource to be created.
-        :param pulumi.Input[str] url: The URL of the backend host.
+        :param pulumi.Input[str] url: The backend host URL should be specified in the format `"https://backend.com/api"`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
         :param pulumi.Input['BackendCredentialsArgs'] credentials: A `credentials` block as documented below.
         :param pulumi.Input[str] description: The description of the backend.
         :param pulumi.Input[str] name: The name of the API Management backend. Changing this forces a new resource to be created.
@@ -109,7 +109,7 @@ class BackendArgs:
     @pulumi.getter
     def url(self) -> pulumi.Input[str]:
         """
-        The URL of the backend host.
+        The backend host URL should be specified in the format `"https://backend.com/api"`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
         """
         return pulumi.get(self, "url")
 
@@ -242,7 +242,7 @@ class _BackendState:
         :param pulumi.Input['BackendServiceFabricClusterArgs'] service_fabric_cluster: A `service_fabric_cluster` block as documented below.
         :param pulumi.Input[str] title: The title of the backend.
         :param pulumi.Input['BackendTlsArgs'] tls: A `tls` block as documented below.
-        :param pulumi.Input[str] url: The URL of the backend host.
+        :param pulumi.Input[str] url: The backend host URL should be specified in the format `"https://backend.com/api"`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
         """
         if api_management_name is not None:
             pulumi.set(__self__, "api_management_name", api_management_name)
@@ -405,7 +405,7 @@ class _BackendState:
     @pulumi.getter
     def url(self) -> Optional[pulumi.Input[str]]:
         """
-        The URL of the backend host.
+        The backend host URL should be specified in the format `"https://backend.com/api"`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
         """
         return pulumi.get(self, "url")
 
@@ -456,7 +456,7 @@ class Backend(pulumi.CustomResource):
             resource_group_name=example.name,
             api_management_name=example_service.name,
             protocol="http",
-            url="https://backend")
+            url="https://backend.com/api")
         ```
 
         ## Import
@@ -480,7 +480,7 @@ class Backend(pulumi.CustomResource):
         :param pulumi.Input[Union['BackendServiceFabricClusterArgs', 'BackendServiceFabricClusterArgsDict']] service_fabric_cluster: A `service_fabric_cluster` block as documented below.
         :param pulumi.Input[str] title: The title of the backend.
         :param pulumi.Input[Union['BackendTlsArgs', 'BackendTlsArgsDict']] tls: A `tls` block as documented below.
-        :param pulumi.Input[str] url: The URL of the backend host.
+        :param pulumi.Input[str] url: The backend host URL should be specified in the format `"https://backend.com/api"`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
         """
         ...
     @overload
@@ -512,7 +512,7 @@ class Backend(pulumi.CustomResource):
             resource_group_name=example.name,
             api_management_name=example_service.name,
             protocol="http",
-            url="https://backend")
+            url="https://backend.com/api")
         ```
 
         ## Import
@@ -619,7 +619,7 @@ class Backend(pulumi.CustomResource):
         :param pulumi.Input[Union['BackendServiceFabricClusterArgs', 'BackendServiceFabricClusterArgsDict']] service_fabric_cluster: A `service_fabric_cluster` block as documented below.
         :param pulumi.Input[str] title: The title of the backend.
         :param pulumi.Input[Union['BackendTlsArgs', 'BackendTlsArgsDict']] tls: A `tls` block as documented below.
-        :param pulumi.Input[str] url: The URL of the backend host.
+        :param pulumi.Input[str] url: The backend host URL should be specified in the format `"https://backend.com/api"`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
@@ -731,7 +731,7 @@ class Backend(pulumi.CustomResource):
     @pulumi.getter
     def url(self) -> pulumi.Output[str]:
         """
-        The URL of the backend host.
+        The backend host URL should be specified in the format `"https://backend.com/api"`, avoiding trailing slashes (/) to minimize misconfiguration risks. Azure API Management instance will append the backend resource name to this URL. This URL typically serves as the `base-url` in the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, enabling seamless transitions from frontend to backend.
         """
         return pulumi.get(self, "url")
 

--- a/sdk/python/pulumi_azure/apimanagement/policy.py
+++ b/sdk/python/pulumi_azure/apimanagement/policy.py
@@ -25,7 +25,7 @@ class PolicyArgs:
         """
         The set of arguments for constructing a Policy resource.
         :param pulumi.Input[str] api_management_id: The ID of the API Management service. Changing this forces a new API Management service Policy to be created.
-        :param pulumi.Input[str] xml_content: The XML Content for this Policy as a string.
+        :param pulumi.Input[str] xml_content: The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
         :param pulumi.Input[str] xml_link: A link to a Policy XML Document, which must be publicly available.
         """
         pulumi.set(__self__, "api_management_id", api_management_id)
@@ -50,7 +50,7 @@ class PolicyArgs:
     @pulumi.getter(name="xmlContent")
     def xml_content(self) -> Optional[pulumi.Input[str]]:
         """
-        The XML Content for this Policy as a string.
+        The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
         """
         return pulumi.get(self, "xml_content")
 
@@ -80,7 +80,7 @@ class _PolicyState:
         """
         Input properties used for looking up and filtering Policy resources.
         :param pulumi.Input[str] api_management_id: The ID of the API Management service. Changing this forces a new API Management service Policy to be created.
-        :param pulumi.Input[str] xml_content: The XML Content for this Policy as a string.
+        :param pulumi.Input[str] xml_content: The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
         :param pulumi.Input[str] xml_link: A link to a Policy XML Document, which must be publicly available.
         """
         if api_management_id is not None:
@@ -106,7 +106,7 @@ class _PolicyState:
     @pulumi.getter(name="xmlContent")
     def xml_content(self) -> Optional[pulumi.Input[str]]:
         """
-        The XML Content for this Policy as a string.
+        The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
         """
         return pulumi.get(self, "xml_content")
 
@@ -180,7 +180,7 @@ class Policy(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_management_id: The ID of the API Management service. Changing this forces a new API Management service Policy to be created.
-        :param pulumi.Input[str] xml_content: The XML Content for this Policy as a string.
+        :param pulumi.Input[str] xml_content: The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
         :param pulumi.Input[str] xml_link: A link to a Policy XML Document, which must be publicly available.
         """
         ...
@@ -283,7 +283,7 @@ class Policy(pulumi.CustomResource):
         :param pulumi.Input[str] id: The unique provider ID of the resource to lookup.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_management_id: The ID of the API Management service. Changing this forces a new API Management service Policy to be created.
-        :param pulumi.Input[str] xml_content: The XML Content for this Policy as a string.
+        :param pulumi.Input[str] xml_content: The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
         :param pulumi.Input[str] xml_link: A link to a Policy XML Document, which must be publicly available.
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
@@ -307,7 +307,7 @@ class Policy(pulumi.CustomResource):
     @pulumi.getter(name="xmlContent")
     def xml_content(self) -> pulumi.Output[str]:
         """
-        The XML Content for this Policy as a string.
+        The XML Content for this Policy as a string. To integrate frontend and backend services in Azure API Management, utilize the [`set-backend-service`](https://learn.microsoft.com/azure/api-management/set-backend-service-policy) policy, specifying the `base-url` value. Typically, this value corresponds to the `url` property defined in the `Backend` resource configuration.
         """
         return pulumi.get(self, "xml_content")
 

--- a/sdk/python/pulumi_azure/cdn/_inputs.py
+++ b/sdk/python/pulumi_azure/cdn/_inputs.py
@@ -186,6 +186,8 @@ if not MYPY:
         tls_version: NotRequired[pulumi.Input[str]]
         """
         The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+
+        > **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
         """
 elif False:
     EndpointCustomDomainCdnManagedHttpsArgsDict: TypeAlias = Mapping[str, Any]
@@ -200,6 +202,8 @@ class EndpointCustomDomainCdnManagedHttpsArgs:
         :param pulumi.Input[str] certificate_type: The type of HTTPS certificate. Possible values are `Shared` and `Dedicated`.
         :param pulumi.Input[str] protocol_type: The type of protocol. Possible values are `ServerNameIndication` and `IPBased`.
         :param pulumi.Input[str] tls_version: The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+               
+               > **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
         """
         pulumi.set(__self__, "certificate_type", certificate_type)
         pulumi.set(__self__, "protocol_type", protocol_type)
@@ -235,6 +239,8 @@ class EndpointCustomDomainCdnManagedHttpsArgs:
     def tls_version(self) -> Optional[pulumi.Input[str]]:
         """
         The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+
+        > **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
         """
         return pulumi.get(self, "tls_version")
 
@@ -252,6 +258,8 @@ if not MYPY:
         tls_version: NotRequired[pulumi.Input[str]]
         """
         The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+
+        > **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
         """
 elif False:
     EndpointCustomDomainUserManagedHttpsArgsDict: TypeAlias = Mapping[str, Any]
@@ -264,6 +272,8 @@ class EndpointCustomDomainUserManagedHttpsArgs:
         """
         :param pulumi.Input[str] key_vault_secret_id: The ID of the Key Vault Secret that contains the HTTPS certificate.
         :param pulumi.Input[str] tls_version: The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+               
+               > **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
         """
         pulumi.set(__self__, "key_vault_secret_id", key_vault_secret_id)
         if tls_version is not None:
@@ -286,6 +296,8 @@ class EndpointCustomDomainUserManagedHttpsArgs:
     def tls_version(self) -> Optional[pulumi.Input[str]]:
         """
         The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+
+        > **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
         """
         return pulumi.get(self, "tls_version")
 
@@ -4057,7 +4069,7 @@ if not MYPY:
     class FrontdoorOriginGroupHealthProbeArgsDict(TypedDict):
         interval_in_seconds: pulumi.Input[int]
         """
-        Specifies the number of seconds between health probes. Possible values are between `5` and `31536000` seconds (inclusive).
+        Specifies the number of seconds between health probes. Possible values are between `1` and `255` seconds (inclusive).
         """
         protocol: pulumi.Input[str]
         """
@@ -4084,7 +4096,7 @@ class FrontdoorOriginGroupHealthProbeArgs:
                  path: Optional[pulumi.Input[str]] = None,
                  request_type: Optional[pulumi.Input[str]] = None):
         """
-        :param pulumi.Input[int] interval_in_seconds: Specifies the number of seconds between health probes. Possible values are between `5` and `31536000` seconds (inclusive).
+        :param pulumi.Input[int] interval_in_seconds: Specifies the number of seconds between health probes. Possible values are between `1` and `255` seconds (inclusive).
         :param pulumi.Input[str] protocol: Specifies the protocol to use for health probe. Possible values are `Http` and `Https`.
         :param pulumi.Input[str] path: Specifies the path relative to the origin that is used to determine the health of the origin. Defaults to `/`.
                
@@ -4102,7 +4114,7 @@ class FrontdoorOriginGroupHealthProbeArgs:
     @pulumi.getter(name="intervalInSeconds")
     def interval_in_seconds(self) -> pulumi.Input[int]:
         """
-        Specifies the number of seconds between health probes. Possible values are between `5` and `31536000` seconds (inclusive).
+        Specifies the number of seconds between health probes. Possible values are between `1` and `255` seconds (inclusive).
         """
         return pulumi.get(self, "interval_in_seconds")
 

--- a/sdk/python/pulumi_azure/cdn/outputs.py
+++ b/sdk/python/pulumi_azure/cdn/outputs.py
@@ -131,6 +131,8 @@ class EndpointCustomDomainCdnManagedHttps(dict):
         :param str certificate_type: The type of HTTPS certificate. Possible values are `Shared` and `Dedicated`.
         :param str protocol_type: The type of protocol. Possible values are `ServerNameIndication` and `IPBased`.
         :param str tls_version: The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+               
+               > **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
         """
         pulumi.set(__self__, "certificate_type", certificate_type)
         pulumi.set(__self__, "protocol_type", protocol_type)
@@ -158,6 +160,8 @@ class EndpointCustomDomainCdnManagedHttps(dict):
     def tls_version(self) -> Optional[str]:
         """
         The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+
+        > **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
         """
         return pulumi.get(self, "tls_version")
 
@@ -189,6 +193,8 @@ class EndpointCustomDomainUserManagedHttps(dict):
         """
         :param str key_vault_secret_id: The ID of the Key Vault Secret that contains the HTTPS certificate.
         :param str tls_version: The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+               
+               > **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
         """
         pulumi.set(__self__, "key_vault_secret_id", key_vault_secret_id)
         if tls_version is not None:
@@ -207,6 +213,8 @@ class EndpointCustomDomainUserManagedHttps(dict):
     def tls_version(self) -> Optional[str]:
         """
         The minimum TLS protocol version that is used for HTTPS. Possible values are `TLS10` (representing TLS 1.0/1.1), `TLS12` (representing TLS 1.2) and `None` (representing no minimums). Defaults to `TLS12`.
+
+        > **Note** Azure Services will require TLS 1.2+ by August 2025, please see this [announcement](https://azure.microsoft.com/en-us/updates/v2/update-retirement-tls1-0-tls1-1-versions-azure-services/) for more.
         """
         return pulumi.get(self, "tls_version")
 
@@ -3076,7 +3084,7 @@ class FrontdoorOriginGroupHealthProbe(dict):
                  path: Optional[str] = None,
                  request_type: Optional[str] = None):
         """
-        :param int interval_in_seconds: Specifies the number of seconds between health probes. Possible values are between `5` and `31536000` seconds (inclusive).
+        :param int interval_in_seconds: Specifies the number of seconds between health probes. Possible values are between `1` and `255` seconds (inclusive).
         :param str protocol: Specifies the protocol to use for health probe. Possible values are `Http` and `Https`.
         :param str path: Specifies the path relative to the origin that is used to determine the health of the origin. Defaults to `/`.
                
@@ -3094,7 +3102,7 @@ class FrontdoorOriginGroupHealthProbe(dict):
     @pulumi.getter(name="intervalInSeconds")
     def interval_in_seconds(self) -> int:
         """
-        Specifies the number of seconds between health probes. Possible values are between `5` and `31536000` seconds (inclusive).
+        Specifies the number of seconds between health probes. Possible values are between `1` and `255` seconds (inclusive).
         """
         return pulumi.get(self, "interval_in_seconds")
 

--- a/sdk/python/pulumi_azure/cognitive/deployment.py
+++ b/sdk/python/pulumi_azure/cognitive/deployment.py
@@ -24,6 +24,7 @@ class DeploymentArgs:
                  cognitive_account_id: pulumi.Input[str],
                  model: pulumi.Input['DeploymentModelArgs'],
                  sku: pulumi.Input['DeploymentSkuArgs'],
+                 dynamic_throttling_enabled: Optional[pulumi.Input[bool]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  rai_policy_name: Optional[pulumi.Input[str]] = None,
                  version_upgrade_option: Optional[pulumi.Input[str]] = None):
@@ -32,6 +33,7 @@ class DeploymentArgs:
         :param pulumi.Input[str] cognitive_account_id: The ID of the Cognitive Services Account. Changing this forces a new resource to be created.
         :param pulumi.Input['DeploymentModelArgs'] model: A `model` block as defined below. Changing this forces a new resource to be created.
         :param pulumi.Input['DeploymentSkuArgs'] sku: A `sku` block as defined below.
+        :param pulumi.Input[bool] dynamic_throttling_enabled: Whether dynamic throttling is enabled.
         :param pulumi.Input[str] name: The name of the Cognitive Services Account Deployment. Changing this forces a new resource to be created.
         :param pulumi.Input[str] rai_policy_name: The name of RAI policy.
         :param pulumi.Input[str] version_upgrade_option: Deployment model version upgrade option. Possible values are `OnceNewDefaultVersionAvailable`, `OnceCurrentVersionExpired`, and `NoAutoUpgrade`. Defaults to `OnceNewDefaultVersionAvailable`.
@@ -39,6 +41,8 @@ class DeploymentArgs:
         pulumi.set(__self__, "cognitive_account_id", cognitive_account_id)
         pulumi.set(__self__, "model", model)
         pulumi.set(__self__, "sku", sku)
+        if dynamic_throttling_enabled is not None:
+            pulumi.set(__self__, "dynamic_throttling_enabled", dynamic_throttling_enabled)
         if name is not None:
             pulumi.set(__self__, "name", name)
         if rai_policy_name is not None:
@@ -83,6 +87,18 @@ class DeploymentArgs:
         pulumi.set(self, "sku", value)
 
     @property
+    @pulumi.getter(name="dynamicThrottlingEnabled")
+    def dynamic_throttling_enabled(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Whether dynamic throttling is enabled.
+        """
+        return pulumi.get(self, "dynamic_throttling_enabled")
+
+    @dynamic_throttling_enabled.setter
+    def dynamic_throttling_enabled(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "dynamic_throttling_enabled", value)
+
+    @property
     @pulumi.getter
     def name(self) -> Optional[pulumi.Input[str]]:
         """
@@ -123,6 +139,7 @@ class DeploymentArgs:
 class _DeploymentState:
     def __init__(__self__, *,
                  cognitive_account_id: Optional[pulumi.Input[str]] = None,
+                 dynamic_throttling_enabled: Optional[pulumi.Input[bool]] = None,
                  model: Optional[pulumi.Input['DeploymentModelArgs']] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  rai_policy_name: Optional[pulumi.Input[str]] = None,
@@ -131,6 +148,7 @@ class _DeploymentState:
         """
         Input properties used for looking up and filtering Deployment resources.
         :param pulumi.Input[str] cognitive_account_id: The ID of the Cognitive Services Account. Changing this forces a new resource to be created.
+        :param pulumi.Input[bool] dynamic_throttling_enabled: Whether dynamic throttling is enabled.
         :param pulumi.Input['DeploymentModelArgs'] model: A `model` block as defined below. Changing this forces a new resource to be created.
         :param pulumi.Input[str] name: The name of the Cognitive Services Account Deployment. Changing this forces a new resource to be created.
         :param pulumi.Input[str] rai_policy_name: The name of RAI policy.
@@ -139,6 +157,8 @@ class _DeploymentState:
         """
         if cognitive_account_id is not None:
             pulumi.set(__self__, "cognitive_account_id", cognitive_account_id)
+        if dynamic_throttling_enabled is not None:
+            pulumi.set(__self__, "dynamic_throttling_enabled", dynamic_throttling_enabled)
         if model is not None:
             pulumi.set(__self__, "model", model)
         if name is not None:
@@ -161,6 +181,18 @@ class _DeploymentState:
     @cognitive_account_id.setter
     def cognitive_account_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "cognitive_account_id", value)
+
+    @property
+    @pulumi.getter(name="dynamicThrottlingEnabled")
+    def dynamic_throttling_enabled(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Whether dynamic throttling is enabled.
+        """
+        return pulumi.get(self, "dynamic_throttling_enabled")
+
+    @dynamic_throttling_enabled.setter
+    def dynamic_throttling_enabled(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "dynamic_throttling_enabled", value)
 
     @property
     @pulumi.getter
@@ -229,6 +261,7 @@ class Deployment(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  cognitive_account_id: Optional[pulumi.Input[str]] = None,
+                 dynamic_throttling_enabled: Optional[pulumi.Input[bool]] = None,
                  model: Optional[pulumi.Input[Union['DeploymentModelArgs', 'DeploymentModelArgsDict']]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  rai_policy_name: Optional[pulumi.Input[str]] = None,
@@ -277,6 +310,7 @@ class Deployment(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] cognitive_account_id: The ID of the Cognitive Services Account. Changing this forces a new resource to be created.
+        :param pulumi.Input[bool] dynamic_throttling_enabled: Whether dynamic throttling is enabled.
         :param pulumi.Input[Union['DeploymentModelArgs', 'DeploymentModelArgsDict']] model: A `model` block as defined below. Changing this forces a new resource to be created.
         :param pulumi.Input[str] name: The name of the Cognitive Services Account Deployment. Changing this forces a new resource to be created.
         :param pulumi.Input[str] rai_policy_name: The name of RAI policy.
@@ -344,6 +378,7 @@ class Deployment(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  cognitive_account_id: Optional[pulumi.Input[str]] = None,
+                 dynamic_throttling_enabled: Optional[pulumi.Input[bool]] = None,
                  model: Optional[pulumi.Input[Union['DeploymentModelArgs', 'DeploymentModelArgsDict']]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  rai_policy_name: Optional[pulumi.Input[str]] = None,
@@ -361,6 +396,7 @@ class Deployment(pulumi.CustomResource):
             if cognitive_account_id is None and not opts.urn:
                 raise TypeError("Missing required property 'cognitive_account_id'")
             __props__.__dict__["cognitive_account_id"] = cognitive_account_id
+            __props__.__dict__["dynamic_throttling_enabled"] = dynamic_throttling_enabled
             if model is None and not opts.urn:
                 raise TypeError("Missing required property 'model'")
             __props__.__dict__["model"] = model
@@ -381,6 +417,7 @@ class Deployment(pulumi.CustomResource):
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
             cognitive_account_id: Optional[pulumi.Input[str]] = None,
+            dynamic_throttling_enabled: Optional[pulumi.Input[bool]] = None,
             model: Optional[pulumi.Input[Union['DeploymentModelArgs', 'DeploymentModelArgsDict']]] = None,
             name: Optional[pulumi.Input[str]] = None,
             rai_policy_name: Optional[pulumi.Input[str]] = None,
@@ -394,6 +431,7 @@ class Deployment(pulumi.CustomResource):
         :param pulumi.Input[str] id: The unique provider ID of the resource to lookup.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] cognitive_account_id: The ID of the Cognitive Services Account. Changing this forces a new resource to be created.
+        :param pulumi.Input[bool] dynamic_throttling_enabled: Whether dynamic throttling is enabled.
         :param pulumi.Input[Union['DeploymentModelArgs', 'DeploymentModelArgsDict']] model: A `model` block as defined below. Changing this forces a new resource to be created.
         :param pulumi.Input[str] name: The name of the Cognitive Services Account Deployment. Changing this forces a new resource to be created.
         :param pulumi.Input[str] rai_policy_name: The name of RAI policy.
@@ -405,6 +443,7 @@ class Deployment(pulumi.CustomResource):
         __props__ = _DeploymentState.__new__(_DeploymentState)
 
         __props__.__dict__["cognitive_account_id"] = cognitive_account_id
+        __props__.__dict__["dynamic_throttling_enabled"] = dynamic_throttling_enabled
         __props__.__dict__["model"] = model
         __props__.__dict__["name"] = name
         __props__.__dict__["rai_policy_name"] = rai_policy_name
@@ -419,6 +458,14 @@ class Deployment(pulumi.CustomResource):
         The ID of the Cognitive Services Account. Changing this forces a new resource to be created.
         """
         return pulumi.get(self, "cognitive_account_id")
+
+    @property
+    @pulumi.getter(name="dynamicThrottlingEnabled")
+    def dynamic_throttling_enabled(self) -> pulumi.Output[Optional[bool]]:
+        """
+        Whether dynamic throttling is enabled.
+        """
+        return pulumi.get(self, "dynamic_throttling_enabled")
 
     @property
     @pulumi.getter

--- a/sdk/python/pulumi_azure/dataprotection/backup_instance_blog_storage.py
+++ b/sdk/python/pulumi_azure/dataprotection/backup_instance_blog_storage.py
@@ -244,6 +244,47 @@ class BackupInstanceBlogStorage(pulumi.CustomResource):
         """
         Manages a Backup Instance Blob Storage.
 
+        ## Example Usage
+
+        ```python
+        import pulumi
+        import pulumi_azure as azure
+
+        example = azure.core.ResourceGroup("example",
+            name="example-resources",
+            location="West Europe")
+        example_account = azure.storage.Account("example",
+            name="storageaccountname",
+            resource_group_name=example.name,
+            location=example.location,
+            account_tier="Standard",
+            account_replication_type="LRS")
+        example_backup_vault = azure.dataprotection.BackupVault("example",
+            name="example-backup-vault",
+            resource_group_name=example.name,
+            location=example.location,
+            datastore_type="VaultStore",
+            redundancy="LocallyRedundant",
+            identity={
+                "type": "SystemAssigned",
+            })
+        example_assignment = azure.authorization.Assignment("example",
+            scope=example_account.id,
+            role_definition_name="Storage Account Backup Contributor",
+            principal_id=example_backup_vault.identity.principal_id)
+        example_backup_policy_blob_storage = azure.dataprotection.BackupPolicyBlobStorage("example",
+            name="example-backup-policy",
+            vault_id=example_backup_vault.id,
+            operational_default_retention_duration="P30D")
+        example_backup_instance_blog_storage = azure.dataprotection.BackupInstanceBlogStorage("example",
+            name="example-backup-instance",
+            vault_id=example_backup_vault.id,
+            location=example.location,
+            storage_account_id=example_account.id,
+            backup_policy_id=example_backup_policy_blob_storage.id,
+            opts = pulumi.ResourceOptions(depends_on=[example_assignment]))
+        ```
+
         ## Import
 
         Backup Instance Blob Storages can be imported using the `resource id`, e.g.
@@ -271,6 +312,47 @@ class BackupInstanceBlogStorage(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Manages a Backup Instance Blob Storage.
+
+        ## Example Usage
+
+        ```python
+        import pulumi
+        import pulumi_azure as azure
+
+        example = azure.core.ResourceGroup("example",
+            name="example-resources",
+            location="West Europe")
+        example_account = azure.storage.Account("example",
+            name="storageaccountname",
+            resource_group_name=example.name,
+            location=example.location,
+            account_tier="Standard",
+            account_replication_type="LRS")
+        example_backup_vault = azure.dataprotection.BackupVault("example",
+            name="example-backup-vault",
+            resource_group_name=example.name,
+            location=example.location,
+            datastore_type="VaultStore",
+            redundancy="LocallyRedundant",
+            identity={
+                "type": "SystemAssigned",
+            })
+        example_assignment = azure.authorization.Assignment("example",
+            scope=example_account.id,
+            role_definition_name="Storage Account Backup Contributor",
+            principal_id=example_backup_vault.identity.principal_id)
+        example_backup_policy_blob_storage = azure.dataprotection.BackupPolicyBlobStorage("example",
+            name="example-backup-policy",
+            vault_id=example_backup_vault.id,
+            operational_default_retention_duration="P30D")
+        example_backup_instance_blog_storage = azure.dataprotection.BackupInstanceBlogStorage("example",
+            name="example-backup-instance",
+            vault_id=example_backup_vault.id,
+            location=example.location,
+            storage_account_id=example_account.id,
+            backup_policy_id=example_backup_policy_blob_storage.id,
+            opts = pulumi.ResourceOptions(depends_on=[example_assignment]))
+        ```
 
         ## Import
 

--- a/sdk/python/pulumi_azure/keyvault/managed_hardware_security_module_key.py
+++ b/sdk/python/pulumi_azure/keyvault/managed_hardware_security_module_key.py
@@ -31,11 +31,11 @@ class ManagedHardwareSecurityModuleKeyArgs:
         """
         The set of arguments for constructing a ManagedHardwareSecurityModuleKey resource.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] key_opts: A list of JSON web key operations. Possible values include: `decrypt`, `encrypt`, `sign`, `unwrapKey`, `verify` and `wrapKey`. Please note these values are case-sensitive.
-        :param pulumi.Input[str] key_type: Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+        :param pulumi.Input[str] key_type: Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
         :param pulumi.Input[str] managed_hsm_id: Specifies the ID of the Key Vault Managed Hardware Security Module that they key will be owned by. Changing this forces a new resource to be created.
         :param pulumi.Input[str] curve: Specifies the curve to use when creating an `EC-HSM` key. Possible values are `P-256`, `P-256K`, `P-384`, and `P-521`. This field is required if `key_type` is `EC-HSM`. Changing this forces a new resource to be created.
         :param pulumi.Input[str] expiration_date: Expiration UTC datetime (Y-m-d'T'H:M:S'Z'). When this parameter gets changed on reruns, if newer date is ahead of current date, an update is performed. If the newer date is before the current date, resource will be force created.
-        :param pulumi.Input[int] key_size: Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM`. Changing this forces a new resource to be created.
+        :param pulumi.Input[int] key_size: Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
         :param pulumi.Input[str] name: Specifies the name of the Key Vault Managed Hardware Security Module Key. Changing this forces a new resource to be created.
         :param pulumi.Input[str] not_before_date: Key not usable before the provided UTC datetime (Y-m-d'T'H:M:S'Z').
                
@@ -74,7 +74,7 @@ class ManagedHardwareSecurityModuleKeyArgs:
     @pulumi.getter(name="keyType")
     def key_type(self) -> pulumi.Input[str]:
         """
-        Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+        Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
         """
         return pulumi.get(self, "key_type")
 
@@ -122,7 +122,7 @@ class ManagedHardwareSecurityModuleKeyArgs:
     @pulumi.getter(name="keySize")
     def key_size(self) -> Optional[pulumi.Input[int]]:
         """
-        Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM`. Changing this forces a new resource to be created.
+        Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
         """
         return pulumi.get(self, "key_size")
 
@@ -187,8 +187,8 @@ class _ManagedHardwareSecurityModuleKeyState:
         :param pulumi.Input[str] curve: Specifies the curve to use when creating an `EC-HSM` key. Possible values are `P-256`, `P-256K`, `P-384`, and `P-521`. This field is required if `key_type` is `EC-HSM`. Changing this forces a new resource to be created.
         :param pulumi.Input[str] expiration_date: Expiration UTC datetime (Y-m-d'T'H:M:S'Z'). When this parameter gets changed on reruns, if newer date is ahead of current date, an update is performed. If the newer date is before the current date, resource will be force created.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] key_opts: A list of JSON web key operations. Possible values include: `decrypt`, `encrypt`, `sign`, `unwrapKey`, `verify` and `wrapKey`. Please note these values are case-sensitive.
-        :param pulumi.Input[int] key_size: Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM`. Changing this forces a new resource to be created.
-        :param pulumi.Input[str] key_type: Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+        :param pulumi.Input[int] key_size: Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
+        :param pulumi.Input[str] key_type: Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
         :param pulumi.Input[str] managed_hsm_id: Specifies the ID of the Key Vault Managed Hardware Security Module that they key will be owned by. Changing this forces a new resource to be created.
         :param pulumi.Input[str] name: Specifies the name of the Key Vault Managed Hardware Security Module Key. Changing this forces a new resource to be created.
         :param pulumi.Input[str] not_before_date: Key not usable before the provided UTC datetime (Y-m-d'T'H:M:S'Z').
@@ -258,7 +258,7 @@ class _ManagedHardwareSecurityModuleKeyState:
     @pulumi.getter(name="keySize")
     def key_size(self) -> Optional[pulumi.Input[int]]:
         """
-        Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM`. Changing this forces a new resource to be created.
+        Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
         """
         return pulumi.get(self, "key_size")
 
@@ -270,7 +270,7 @@ class _ManagedHardwareSecurityModuleKeyState:
     @pulumi.getter(name="keyType")
     def key_type(self) -> Optional[pulumi.Input[str]]:
         """
-        Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+        Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
         """
         return pulumi.get(self, "key_type")
 
@@ -374,8 +374,8 @@ class ManagedHardwareSecurityModuleKey(pulumi.CustomResource):
         :param pulumi.Input[str] curve: Specifies the curve to use when creating an `EC-HSM` key. Possible values are `P-256`, `P-256K`, `P-384`, and `P-521`. This field is required if `key_type` is `EC-HSM`. Changing this forces a new resource to be created.
         :param pulumi.Input[str] expiration_date: Expiration UTC datetime (Y-m-d'T'H:M:S'Z'). When this parameter gets changed on reruns, if newer date is ahead of current date, an update is performed. If the newer date is before the current date, resource will be force created.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] key_opts: A list of JSON web key operations. Possible values include: `decrypt`, `encrypt`, `sign`, `unwrapKey`, `verify` and `wrapKey`. Please note these values are case-sensitive.
-        :param pulumi.Input[int] key_size: Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM`. Changing this forces a new resource to be created.
-        :param pulumi.Input[str] key_type: Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+        :param pulumi.Input[int] key_size: Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
+        :param pulumi.Input[str] key_type: Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
         :param pulumi.Input[str] managed_hsm_id: Specifies the ID of the Key Vault Managed Hardware Security Module that they key will be owned by. Changing this forces a new resource to be created.
         :param pulumi.Input[str] name: Specifies the name of the Key Vault Managed Hardware Security Module Key. Changing this forces a new resource to be created.
         :param pulumi.Input[str] not_before_date: Key not usable before the provided UTC datetime (Y-m-d'T'H:M:S'Z').
@@ -481,8 +481,8 @@ class ManagedHardwareSecurityModuleKey(pulumi.CustomResource):
         :param pulumi.Input[str] curve: Specifies the curve to use when creating an `EC-HSM` key. Possible values are `P-256`, `P-256K`, `P-384`, and `P-521`. This field is required if `key_type` is `EC-HSM`. Changing this forces a new resource to be created.
         :param pulumi.Input[str] expiration_date: Expiration UTC datetime (Y-m-d'T'H:M:S'Z'). When this parameter gets changed on reruns, if newer date is ahead of current date, an update is performed. If the newer date is before the current date, resource will be force created.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] key_opts: A list of JSON web key operations. Possible values include: `decrypt`, `encrypt`, `sign`, `unwrapKey`, `verify` and `wrapKey`. Please note these values are case-sensitive.
-        :param pulumi.Input[int] key_size: Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM`. Changing this forces a new resource to be created.
-        :param pulumi.Input[str] key_type: Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+        :param pulumi.Input[int] key_size: Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
+        :param pulumi.Input[str] key_type: Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
         :param pulumi.Input[str] managed_hsm_id: Specifies the ID of the Key Vault Managed Hardware Security Module that they key will be owned by. Changing this forces a new resource to be created.
         :param pulumi.Input[str] name: Specifies the name of the Key Vault Managed Hardware Security Module Key. Changing this forces a new resource to be created.
         :param pulumi.Input[str] not_before_date: Key not usable before the provided UTC datetime (Y-m-d'T'H:M:S'Z').
@@ -535,7 +535,7 @@ class ManagedHardwareSecurityModuleKey(pulumi.CustomResource):
     @pulumi.getter(name="keySize")
     def key_size(self) -> pulumi.Output[Optional[int]]:
         """
-        Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM`. Changing this forces a new resource to be created.
+        Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA-HSM` or `oct-HSM`. Changing this forces a new resource to be created.
         """
         return pulumi.get(self, "key_size")
 
@@ -543,7 +543,7 @@ class ManagedHardwareSecurityModuleKey(pulumi.CustomResource):
     @pulumi.getter(name="keyType")
     def key_type(self) -> pulumi.Output[str]:
         """
-        Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM` and `RSA-HSM`. Changing this forces a new resource to be created.
+        Specifies the Key Type to use for this Key Vault Managed Hardware Security Module Key. Possible values are `EC-HSM`, `oct-HSM` and `RSA-HSM`. More details see [HSM-protected keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys#hsm-protected-keys). Changing this forces a new resource to be created.
         """
         return pulumi.get(self, "key_type")
 

--- a/sdk/python/pulumi_azure/logicapps/outputs.py
+++ b/sdk/python/pulumi_azure/logicapps/outputs.py
@@ -1921,6 +1921,7 @@ class GetStandardConnectionStringResult(dict):
 @pulumi.output_type
 class GetStandardIdentityResult(dict):
     def __init__(__self__, *,
+                 identity_ids: Sequence[str],
                  principal_id: str,
                  tenant_id: str,
                  type: str):
@@ -1929,9 +1930,15 @@ class GetStandardIdentityResult(dict):
         :param str tenant_id: The Tenant ID for the Service Principal associated with the Managed Service Identity of this Logic App Workflow.
         :param str type: The Type of Managed Identity assigned to this Logic App Workflow.
         """
+        pulumi.set(__self__, "identity_ids", identity_ids)
         pulumi.set(__self__, "principal_id", principal_id)
         pulumi.set(__self__, "tenant_id", tenant_id)
         pulumi.set(__self__, "type", type)
+
+    @property
+    @pulumi.getter(name="identityIds")
+    def identity_ids(self) -> Sequence[str]:
+        return pulumi.get(self, "identity_ids")
 
     @property
     @pulumi.getter(name="principalId")

--- a/sdk/python/pulumi_azure/network/nat_gateway.py
+++ b/sdk/python/pulumi_azure/network/nat_gateway.py
@@ -305,7 +305,7 @@ class NatGateway(pulumi.CustomResource):
             name="nat-gateway-example-rg",
             location="West Europe")
         example_nat_gateway = azure.network.NatGateway("example",
-            name="nat-Gateway",
+            name="nat-gateway",
             location=example.location,
             resource_group_name=example.name,
             sku_name="Standard",
@@ -354,7 +354,7 @@ class NatGateway(pulumi.CustomResource):
             name="nat-gateway-example-rg",
             location="West Europe")
         example_nat_gateway = azure.network.NatGateway("example",
-            name="nat-Gateway",
+            name="nat-gateway",
             location=example.location,
             resource_group_name=example.name,
             sku_name="Standard",

--- a/sdk/python/pulumi_azure/search/service.py
+++ b/sdk/python/pulumi_azure/search/service.py
@@ -58,7 +58,7 @@ class ServiceArgs:
         :param pulumi.Input[bool] local_authentication_enabled: Specifies whether the Search Service allows authenticating using API Keys? Defaults to `true`.
         :param pulumi.Input[str] location: The Azure Region where the Search Service should exist. Changing this forces a new Search Service to be created.
         :param pulumi.Input[str] name: The Name which should be used for this Search Service. Changing this forces a new Search Service to be created.
-        :param pulumi.Input[int] partition_count: Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+        :param pulumi.Input[int] partition_count: Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
                
                > **NOTE:** when `hosting_mode` is set to `highDensity` the maximum number of partitions allowed is `3`.
         :param pulumi.Input[bool] public_network_access_enabled: Specifies whether Public Network Access is allowed for this resource. Defaults to `true`.
@@ -231,7 +231,7 @@ class ServiceArgs:
     @pulumi.getter(name="partitionCount")
     def partition_count(self) -> Optional[pulumi.Input[int]]:
         """
-        Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+        Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
 
         > **NOTE:** when `hosting_mode` is set to `highDensity` the maximum number of partitions allowed is `3`.
         """
@@ -331,7 +331,7 @@ class _ServiceState:
         :param pulumi.Input[bool] local_authentication_enabled: Specifies whether the Search Service allows authenticating using API Keys? Defaults to `true`.
         :param pulumi.Input[str] location: The Azure Region where the Search Service should exist. Changing this forces a new Search Service to be created.
         :param pulumi.Input[str] name: The Name which should be used for this Search Service. Changing this forces a new Search Service to be created.
-        :param pulumi.Input[int] partition_count: Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+        :param pulumi.Input[int] partition_count: Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
                
                > **NOTE:** when `hosting_mode` is set to `highDensity` the maximum number of partitions allowed is `3`.
         :param pulumi.Input[str] primary_key: The Primary Key used for Search Service Administration.
@@ -507,7 +507,7 @@ class _ServiceState:
     @pulumi.getter(name="partitionCount")
     def partition_count(self) -> Optional[pulumi.Input[int]]:
         """
-        Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+        Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
 
         > **NOTE:** when `hosting_mode` is set to `highDensity` the maximum number of partitions allowed is `3`.
         """
@@ -733,7 +733,7 @@ class Service(pulumi.CustomResource):
         :param pulumi.Input[bool] local_authentication_enabled: Specifies whether the Search Service allows authenticating using API Keys? Defaults to `true`.
         :param pulumi.Input[str] location: The Azure Region where the Search Service should exist. Changing this forces a new Search Service to be created.
         :param pulumi.Input[str] name: The Name which should be used for this Search Service. Changing this forces a new Search Service to be created.
-        :param pulumi.Input[int] partition_count: Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+        :param pulumi.Input[int] partition_count: Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
                
                > **NOTE:** when `hosting_mode` is set to `highDensity` the maximum number of partitions allowed is `3`.
         :param pulumi.Input[bool] public_network_access_enabled: Specifies whether Public Network Access is allowed for this resource. Defaults to `true`.
@@ -934,7 +934,7 @@ class Service(pulumi.CustomResource):
         :param pulumi.Input[bool] local_authentication_enabled: Specifies whether the Search Service allows authenticating using API Keys? Defaults to `true`.
         :param pulumi.Input[str] location: The Azure Region where the Search Service should exist. Changing this forces a new Search Service to be created.
         :param pulumi.Input[str] name: The Name which should be used for this Search Service. Changing this forces a new Search Service to be created.
-        :param pulumi.Input[int] partition_count: Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+        :param pulumi.Input[int] partition_count: Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
                
                > **NOTE:** when `hosting_mode` is set to `highDensity` the maximum number of partitions allowed is `3`.
         :param pulumi.Input[str] primary_key: The Primary Key used for Search Service Administration.
@@ -1060,7 +1060,7 @@ class Service(pulumi.CustomResource):
     @pulumi.getter(name="partitionCount")
     def partition_count(self) -> pulumi.Output[Optional[int]]:
         """
-        Specifies the number of partitions which should be created. This field cannot be set when using a `free` or `basic` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
+        Specifies the number of partitions which should be created. This field cannot be set when using a `free` sku ([see the Microsoft documentation](https://learn.microsoft.com/azure/search/search-sku-tier)). Possible values include `1`, `2`, `3`, `4`, `6`, or `12`. Defaults to `1`.
 
         > **NOTE:** when `hosting_mode` is set to `highDensity` the maximum number of partitions allowed is `3`.
         """

--- a/sdk/python/pulumi_azure/servicebus/get_subscription.py
+++ b/sdk/python/pulumi_azure/servicebus/get_subscription.py
@@ -80,7 +80,7 @@ class GetSubscriptionResult:
     @pulumi.getter(name="autoDeleteOnIdle")
     def auto_delete_on_idle(self) -> str:
         """
-        The idle interval after which the topic is automatically deleted.
+        The idle interval after which the Subscription is automatically deleted.
         """
         return pulumi.get(self, "auto_delete_on_idle")
 


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider pulumi/pulumi-azure --kind=all --target-bridge-version=latest`.

---

- Upgrading terraform-provider-azurerm from 4.12.0  to 4.13.0.
	Fixes #2745
