### PR TITLE
Remove `preTest` action as unit tests are run by default

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -43,11 +43,6 @@ plugins:
     kind: converter
     version: "1.0.16"
 goBuildParallelism: 2
-actions:
-  preTest:
-    - name: Run provider tests
-      run: |
-        cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
 pulumiConvert: 1
 releaseVerification:
   nodejs: examples/topic
@@ -55,3 +50,4 @@ releaseVerification:
   # python: examples/eventhub-py
   dotnet: examples/appservice-cs
   go: examples/network-go
+integrationTestProvider: true

--- a/.github/workflows/prerequisites.yml
+++ b/.github/workflows/prerequisites.yml
@@ -97,7 +97,7 @@ jobs:
           schema-tools compare -r github://api.github.com/pulumi -p azure -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-azure/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
-    - if: inputs.is_pr && inputs.is_automated == false
+    - if: inputs.is_pr && inputs.is_automated == false && github.actor != 'dependabot[bot]'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,8 +92,9 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         version: v2.5.0
     - name: Run provider tests
-      run: |
-        cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      if: matrix.testTarget == 'local'
+      working-directory: provider
+      run: go test -v -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
     - name: Run tests
       if: matrix.testTarget == 'local'
       run: cd examples && go test -v -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -skip TestPulumiExamples -parallel 4 .


### PR DESCRIPTION
The `actions.preTest` modifier is no longer necessary since `ci-mgmt` now runs unit tests in the `prerequisites` step. This change removes the redundancy caused by previously using `actions.preTest` to work around the lack of default unit test execution.

This is necessary now because ci-mgmt recently started running `actions.preTest` as part of release verification, and that job is not able to run `actions.preTest` step (missing `gotestfmt`).

Related to #2895