### PR TITLE
Enable accurate bridge previews by default

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -3358,6 +3358,7 @@ func Provider() tfbridge.ProviderInfo {
 			Namespaces: namespaceMap,
 		},
 		EnableZeroDefaultSchemaVersion: true,
+		EnableAccurateBridgePreview:    true,
 	}
 
 	// New Authorization Mod - this combines the old MSI and Role Modules


### PR DESCRIPTION
This enables the Accurate Previews bridge feature for the provider.

part of pulumi/pulumi-terraform-bridge#2598