### PR TITLE
Don't auto-merge upstream upgrades

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -51,3 +51,4 @@ releaseVerification:
   dotnet: examples/appservice-cs
   go: examples/network-go
 integrationTestProvider: true
+autoMergeProviderUpgrades: false

--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -50,6 +50,5 @@ releaseVerification:
   # python: examples/eventhub-py
   dotnet: examples/appservice-cs
   go: examples/network-go
-allowMissingDocs: false
 integrationTestProvider: true
 autoMergeProviderUpgrades: false

--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -50,5 +50,6 @@ releaseVerification:
   # python: examples/eventhub-py
   dotnet: examples/appservice-cs
   go: examples/network-go
+allowMissingDocs: false
 integrationTestProvider: true
 autoMergeProviderUpgrades: false


### PR DESCRIPTION
Sets the `AutoMergeProviderUpgrades` ci-mgmt config to false to avoid auto-merging upstream upgrades. This maintains the current behaviour.

Part of https://github.com/pulumi/ci-mgmt/issues/1344