### PR TITLE
Disallow missing resource docs on upgrades

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -50,5 +50,6 @@ releaseVerification:
   # python: examples/eventhub-py
   dotnet: examples/appservice-cs
   go: examples/network-go
+allowMissingDocs: false
 integrationTestProvider: true
 autoMergeProviderUpgrades: false


### PR DESCRIPTION
Sets the `allowMissingDocs` ci-mgmt config to false to error on missing resource docs. This maintains the current behaviour.

Part of https://github.com/pulumi/upgrade-provider/issues/303