### PR TITLE
Disallow missing resource docs on upgrades

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -50,4 +50,5 @@ releaseVerification:
   # python: examples/eventhub-py
   dotnet: examples/appservice-cs
   go: examples/network-go
+allowMissingDocs: false
 integrationTestProvider: true


### PR DESCRIPTION
Standing this up again as I accidentally merged https://github.com/pulumi/pulumi-azure/pull/3003 into the other branch.

Sets the `allowMissingDocs` ci-mgmt config to false to error on missing resource docs. This maintains the current behaviour.

Part of https://github.com/pulumi/upgrade-provider/issues/303