### PR TITLE
Enable RawStateDelta

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -3417,6 +3417,7 @@ func Provider() tfbridge.ProviderInfo {
 		},
 		EnableZeroDefaultSchemaVersion: true,
 		EnableAccurateBridgePreview:    true,
+		EnableRawStateDelta:            true,
 	}
 
 	// New Authorization Mod - this combines the old MSI and Role Modules


### PR DESCRIPTION
An bridge feature for preserving Terraform raw state is rolled out to this provider. See also:

- https://github.com/pulumi/pulumi-terraform-bridge/issues/1667
- https://github.com/pulumi/pulumi-terraform-bridge/issues/3003