### PR TITLE
Fix build issues

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -6,6 +6,7 @@ generate-nightly-test-workflow: true
 providerVersion: github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion
 freeDiskSpaceBeforeTest: true
 freeDiskSpaceBeforeBuild: true
+freeDiskSpaceBeforeSdkBuild: true
 esc:
   enabled: true
 env:

--- a/.github/workflows/build_sdk.yml
+++ b/.github/workflows/build_sdk.yml
@@ -38,6 +38,13 @@ jobs:
       contents: write # For Renovate SDKs.
       id-token: write # For ESC secrets.
     steps:
+      # Run as first step so we don't delete things that have just been installed
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          swap-storage: false
+          dotnet: false
       - name: Checkout Repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:

--- a/examples/durable-functions/index.ts
+++ b/examples/durable-functions/index.ts
@@ -7,6 +7,7 @@ const resourceGroup = new azure.core.ResourceGroup("durable-example");
 
 var app = new azure.appservice.MultiCallbackFunctionApp("durable", {
     resourceGroup,
+    nodeVersion: "~22",
     functions: [
         new azure.appservice.DurableActivityFunction("SayHello", {
             activityInputName: "name",

--- a/examples/eventhub/index.ts
+++ b/examples/eventhub/index.ts
@@ -17,7 +17,10 @@ const eventHub = new eventhub.EventHub("test", {
     messageRetention: 7,
 });
 
-eventHub.onEvent("test", async (context, arg) => {
-    console.log("ctx: " + JSON.stringify(context, null, 4));
-    console.log("arg: " + JSON.stringify(arg, null, 4));
+eventHub.onEvent("test", {
+    nodeVersion: "~22",
+    callback: async (context, arg) => {
+        console.log("ctx: " + JSON.stringify(context, null, 4));
+        console.log("arg: " + JSON.stringify(arg, null, 4));
+    },
 });

--- a/examples/http-external/index.ts
+++ b/examples/http-external/index.ts
@@ -6,6 +6,7 @@ const resourceGroup = new azure.core.ResourceGroup('example');
 // Create a Function App implemented in PowerShell with source code from 'funcapp' folder
 const app = new azure.appservice.ArchiveFunctionApp("http-ps", {
     resourceGroupName: resourceGroup.name,
+    nodeVersion: "~22",
     archive: new pulumi.asset.FileArchive("./funcapp"),
     appSettings: {
       "runtime": "powershell",

--- a/examples/http-multi/index.ts
+++ b/examples/http-multi/index.ts
@@ -20,6 +20,7 @@ const warmer = new azure.appservice.TimerFunction("Warmer", {
 // Create a Function App containing multiple functions
 const app = new azure.appservice.MultiCallbackFunctionApp("http-multi", {
     resourceGroupName: resourceGroup.name,
+    nodeVersion: "~22",
     functions: [ ...http, warmer],
 });
 

--- a/examples/http/index.ts
+++ b/examples/http/index.ts
@@ -4,6 +4,7 @@ const resourceGroup = new azure.core.ResourceGroup('example');
 
 const greeting = new azure.appservice.HttpEventSubscription('greeting', {
   resourceGroup,
+  nodeVersion: "~22",
   callback: async (context, args) => {
     return {
       status: 200,

--- a/examples/iot/index.ts
+++ b/examples/iot/index.ts
@@ -19,7 +19,10 @@ const iotHub = new iot.IoTHub("test", {
     },
 });
 
-iotHub.onEvent("test", async (context, message) => {
-    console.log("ctx: " + JSON.stringify(context, null, 4));
-    console.log("arg: " + message);
+iotHub.onEvent("test", {
+    nodeVersion: "~22",
+    callback: async (context, message) => {
+        console.log("ctx: " + JSON.stringify(context, null, 4));
+        console.log("arg: " + message);
+    },
 });

--- a/examples/linux-virtual-machine/index.ts
+++ b/examples/linux-virtual-machine/index.ts
@@ -25,7 +25,7 @@ const exampleNetworkInterface = new azure.network.NetworkInterface("exampleNetwo
 const exampleLinuxVirtualMachine = new azure.compute.LinuxVirtualMachine("exampleLinuxVirtualMachine", {
     resourceGroupName: exampleResourceGroup.name,
     location: exampleResourceGroup.location,
-    size: "Standard_B2ts_v2",
+    size: "Standard_DS1_v2",
     adminUsername: "adminuser",
     networkInterfaceIds: [exampleNetworkInterface.id],
     adminSshKeys: [{

--- a/examples/linux-virtual-machine/index.ts
+++ b/examples/linux-virtual-machine/index.ts
@@ -25,7 +25,7 @@ const exampleNetworkInterface = new azure.network.NetworkInterface("exampleNetwo
 const exampleLinuxVirtualMachine = new azure.compute.LinuxVirtualMachine("exampleLinuxVirtualMachine", {
     resourceGroupName: exampleResourceGroup.name,
     location: exampleResourceGroup.location,
-    size: "Standard_F2",
+    size: "Standard_A1_v2",
     adminUsername: "adminuser",
     networkInterfaceIds: [exampleNetworkInterface.id],
     adminSshKeys: [{

--- a/examples/linux-virtual-machine/index.ts
+++ b/examples/linux-virtual-machine/index.ts
@@ -38,8 +38,8 @@ const exampleLinuxVirtualMachine = new azure.compute.LinuxVirtualMachine("exampl
     },
     sourceImageReference: {
         publisher: "Canonical",
-        offer: "ubuntu",
-        sku: "24_04-lts",
-        version: "minimal:latest",
+        offer: "ubuntu-24_04-lts",
+        sku: "minimal",
+        version: "latest",
     },
 });

--- a/examples/linux-virtual-machine/index.ts
+++ b/examples/linux-virtual-machine/index.ts
@@ -25,7 +25,7 @@ const exampleNetworkInterface = new azure.network.NetworkInterface("exampleNetwo
 const exampleLinuxVirtualMachine = new azure.compute.LinuxVirtualMachine("exampleLinuxVirtualMachine", {
     resourceGroupName: exampleResourceGroup.name,
     location: exampleResourceGroup.location,
-    size: "Standard_A1_v2",
+    size: "Standard_B2ts_v2",
     adminUsername: "adminuser",
     networkInterfaceIds: [exampleNetworkInterface.id],
     adminSshKeys: [{

--- a/examples/linux-virtual-machine/index.ts
+++ b/examples/linux-virtual-machine/index.ts
@@ -38,8 +38,8 @@ const exampleLinuxVirtualMachine = new azure.compute.LinuxVirtualMachine("exampl
     },
     sourceImageReference: {
         publisher: "Canonical",
-        offer: "UbuntuServer",
-        sku: "16.04-LTS",
-        version: "latest",
+        offer: "ubuntu",
+        sku: "24_04-lts",
+        version: "minimal:latest",
     },
 });

--- a/examples/queue/index.ts
+++ b/examples/queue/index.ts
@@ -24,6 +24,7 @@ const queue2 = new azure.storage.Queue("queue2", {
 // HTTP Function will send a message to the first queue on each request
 const greeting = new azure.appservice.HttpEventSubscription("greeting", {
     resourceGroup,
+    nodeVersion: "~22",
     route: "{name}",
     outputs: [
         queue1.output("queueOut"),
@@ -42,6 +43,7 @@ const greeting = new azure.appservice.HttpEventSubscription("greeting", {
 
 // When a new message is added, fire an event and forward the message to the output queue
 queue1.onEvent("NewMessage",  {
+    nodeVersion: "~22",
     outputs: [queue2.output("queueOut")],
     callback: async (context, person) => {
         return {
@@ -52,6 +54,7 @@ queue1.onEvent("NewMessage",  {
 
 // When a message is forwarded, fire another event
 queue2.onEvent("ForwardedMessage",  {
+    nodeVersion: "~22",
     callback: async (context, msg) => {
         console.log(msg);
     },

--- a/examples/secretcapture/index.ts
+++ b/examples/secretcapture/index.ts
@@ -7,6 +7,7 @@ const secret = pulumi.secret("s3cr3t");
 
 const greeting = new azure.appservice.HttpEventSubscription('greeting', {
   resourceGroup,
+  nodeVersion: "~22",
   callback: async (context, args) => {
     console.log(secret.get());
     return {

--- a/examples/servicebus-migration-test/index.ts
+++ b/examples/servicebus-migration-test/index.ts
@@ -24,10 +24,7 @@ const serviceBusQueue = new azure.eventhub.Queue("example", {
     namespaceId: exampleNamespace.id,
 });
 
-serviceBusQueue.onEvent("Test", {
-    nodeVersion: "~22",
-    calback: async (context, arg) => {
-        console.log("ctx: " + JSON.stringify(context, null, 4));
-        console.log("arg: " + JSON.stringify(arg, null, 4));
-    },
+serviceBusQueue.onEvent("Test", async (context, arg) => {
+    console.log("ctx: " + JSON.stringify(context, null, 4));
+    console.log("arg: " + JSON.stringify(arg, null, 4));
 });

--- a/examples/servicebus-migration-test/index.ts
+++ b/examples/servicebus-migration-test/index.ts
@@ -24,7 +24,10 @@ const serviceBusQueue = new azure.eventhub.Queue("example", {
     namespaceId: exampleNamespace.id,
 });
 
-serviceBusQueue.onEvent("Test", async (context, arg) => {
-    console.log("ctx: " + JSON.stringify(context, null, 4));
-    console.log("arg: " + JSON.stringify(arg, null, 4));
+serviceBusQueue.onEvent("Test", {
+    nodeVersion: "~22",
+    callback: async (context, arg) => {
+        console.log("ctx: " + JSON.stringify(context, null, 4));
+        console.log("arg: " + JSON.stringify(arg, null, 4));
+    },
 });

--- a/examples/servicebus-migration-test/index.ts
+++ b/examples/servicebus-migration-test/index.ts
@@ -24,7 +24,10 @@ const serviceBusQueue = new azure.eventhub.Queue("example", {
     namespaceId: exampleNamespace.id,
 });
 
-serviceBusQueue.onEvent("Test", async (context, arg) => {
-    console.log("ctx: " + JSON.stringify(context, null, 4));
-    console.log("arg: " + JSON.stringify(arg, null, 4));
+serviceBusQueue.onEvent("Test", {
+    nodeVersion: "~22",
+    calback: async (context, arg) => {
+        console.log("ctx: " + JSON.stringify(context, null, 4));
+        console.log("arg: " + JSON.stringify(arg, null, 4));
+    },
 });

--- a/examples/servicebus-migration-test/step2/index.ts
+++ b/examples/servicebus-migration-test/step2/index.ts
@@ -17,7 +17,10 @@ const serviceBusQueue = new azure.servicebus.Queue("example", {
     namespaceId: exampleNamespace.id,
 });
 
-serviceBusQueue.onEvent("Test", async (context, arg) => {
-    console.log("ctx: " + JSON.stringify(context, null, 4));
-    console.log("arg: " + JSON.stringify(arg, null, 4));
+serviceBusQueue.onEvent("Test", {
+    nodeVersion: "~22",
+    callback: async (context, arg) => {
+        console.log("ctx: " + JSON.stringify(context, null, 4));
+        console.log("arg: " + JSON.stringify(arg, null, 4));
+    },
 });

--- a/examples/table/index.ts
+++ b/examples/table/index.ts
@@ -19,6 +19,7 @@ const values = new azure.storage.Table("values", {
 // HTTP Function gets the value from the store
 const getFunc = new azure.appservice.HttpEventSubscription('get-value', {
     resourceGroup,
+    nodeVersion: "~22",
     route: "{key}",
     inputs: [
         values.input("entry", { partitionKey: "test", rowKey: "{key}" }),
@@ -34,6 +35,7 @@ const getFunc = new azure.appservice.HttpEventSubscription('get-value', {
 // HTTP Function adds the value to the store
 const addFunc = new azure.appservice.HttpEventSubscription('add-value', {
     resourceGroup,
+    nodeVersion: "~22",
     methods: ["POST"],
     outputs: [
         values.output("entry"),

--- a/examples/timer/index.ts
+++ b/examples/timer/index.ts
@@ -4,6 +4,7 @@ const resourceGroup = new azure.core.ResourceGroup('example');
 
 new azure.appservice.TimerSubscription('everyminute', {
     resourceGroup,
+    nodeVersion: "~22",
     schedule: { second: 0 },
     callback: async (context, args) => {
         console.log(`Timer due at ${args.ScheduleStatus.Last}`);

--- a/examples/webserver-py-old/__main__.py
+++ b/examples/webserver-py-old/__main__.py
@@ -45,7 +45,7 @@ vm = compute.VirtualMachine(
     },
     storage_image_reference={
         "publisher": "Canonical",
-        "offer": "ubuntu",
-        "sku": "24_04-lts",
-        "version": "minimal:latest",
+        "offer": "ubuntu-24_04-lts",
+        "sku": "minimal",
+        "version": "latest",
     })

--- a/examples/webserver-py-old/__main__.py
+++ b/examples/webserver-py-old/__main__.py
@@ -44,8 +44,8 @@ vm = compute.VirtualMachine(
         "name": "myosdisk1",
     },
     storage_image_reference={
-        "publisher": "canonical",
-        "offer": "UbuntuServer",
-        "sku": "16.04-LTS",
-        "version": "latest",
+        "publisher": "Canonical",
+        "offer": "ubuntu",
+        "sku": "24_04-lts",
+        "version": "minimal:latest",
     })

--- a/examples/webserver-py/__main__.py
+++ b/examples/webserver-py/__main__.py
@@ -45,7 +45,7 @@ vm = compute.VirtualMachine(
     ),
     storage_image_reference=compute.VirtualMachineStorageImageReferenceArgs(
         publisher="Canonical",
-        offer="ubuntu",
-        sku="24_04-lts",
-        version="minimal:latest",
+        offer="ubuntu-24_04-lts",
+        sku="minimal",
+        version="latest",
     ))

--- a/examples/webserver-py/__main__.py
+++ b/examples/webserver-py/__main__.py
@@ -44,8 +44,8 @@ vm = compute.VirtualMachine(
         name="myosdisk1",
     ),
     storage_image_reference=compute.VirtualMachineStorageImageReferenceArgs(
-        publisher="canonical",
-        offer="UbuntuServer",
-        sku="16.04-LTS",
-        version="latest",
+        publisher="Canonical",
+        offer="ubuntu",
+        sku="24_04-lts",
+        version="minimal:latest",
     ))

--- a/examples/webserver/index.ts
+++ b/examples/webserver/index.ts
@@ -27,7 +27,7 @@ let networkInterface = new azure.network.NetworkInterface(name, {
 let vm = new azure.compute.VirtualMachine("webservervm", {
     resourceGroupName: resourceGroup.name,
     networkInterfaceIds: [networkInterface.id],
-    vmSize: "Standard_A0",
+    vmSize: "Standard_A1_v2",
     deleteDataDisksOnTermination: true,
     deleteOsDiskOnTermination: true,
     osProfile: {

--- a/examples/webserver/index.ts
+++ b/examples/webserver/index.ts
@@ -44,8 +44,8 @@ let vm = new azure.compute.VirtualMachine("webservervm", {
     },
     storageImageReference: {
         publisher: "Canonical",
-        offer: "ubuntu",
-        sku: "24_04-lts",
-        version: "minimal:latest",
+        offer: "ubuntu-24_04-lts",
+        sku: "minimal",
+        version: "latest",
     },
 });

--- a/examples/webserver/index.ts
+++ b/examples/webserver/index.ts
@@ -43,9 +43,9 @@ let vm = new azure.compute.VirtualMachine("webservervm", {
         name: "myosdisk1",
     },
     storageImageReference: {
-        publisher: "canonical",
-        offer: "UbuntuServer",
-        sku: "16.04-LTS",
-        version: "latest",
+        publisher: "Canonical",
+        offer: "ubuntu",
+        sku: "24_04-lts",
+        version: "minimal:latest",
     },
 });

--- a/examples/webserver/index.ts
+++ b/examples/webserver/index.ts
@@ -27,7 +27,7 @@ let networkInterface = new azure.network.NetworkInterface(name, {
 let vm = new azure.compute.VirtualMachine("webservervm", {
     resourceGroupName: resourceGroup.name,
     networkInterfaceIds: [networkInterface.id],
-    vmSize: "Standard_B2ts_v2",
+    vmSize: "Standard_DS1_v2",
     deleteDataDisksOnTermination: true,
     deleteOsDiskOnTermination: true,
     osProfile: {

--- a/examples/webserver/index.ts
+++ b/examples/webserver/index.ts
@@ -27,7 +27,7 @@ let networkInterface = new azure.network.NetworkInterface(name, {
 let vm = new azure.compute.VirtualMachine("webservervm", {
     resourceGroupName: resourceGroup.name,
     networkInterfaceIds: [networkInterface.id],
-    vmSize: "Standard_A1_v2",
+    vmSize: "Standard_B2ts_v2",
     deleteDataDisksOnTermination: true,
     deleteOsDiskOnTermination: true,
     osProfile: {


### PR DESCRIPTION
The 6.27 release failed because it ran out of disk space while building the Go SDK.

Also updates some image references from Ubuntu 16 (no longer available) to 24 LTS.

Also updates the node runtime on some examples since Azure pulled v14.

Fixes #3289.
Fixes #3287.
Fixes #3286.