### PR TITLE
Add state transformation on ResourceGroupTemplateDeployment v5 --> v6

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -17,6 +17,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1021,8 +1022,9 @@ func Provider() tfbridge.ProviderInfo {
 			"azurerm_resource_deployment_script_azure_cli":         {Tok: azureResource(azureCore, "ResourceDeploymentScriptAzureCli")},
 			"azurerm_resource_deployment_script_azure_power_shell": {Tok: azureResource(azureCore, "ResourceDeploymentScriptPowerShell")},
 			"azurerm_resource_group_template_deployment": {
-				Tok:     azureResource(azureCore, "ResourceGroupTemplateDeployment"),
-				Aliases: []tfbridge.AliasInfo{{Type: ref("azure:core/templateDeployment:TemplateDeployment")}},
+				Tok:                azureResource(azureCore, "ResourceGroupTemplateDeployment"),
+				Aliases:            []tfbridge.AliasInfo{{Type: ref("azure:core/templateDeployment:TemplateDeployment")}},
+				TransformFromState: clearMetaSchemaVersion,
 			},
 			"azurerm_resource_group_policy_assignment": {Tok: azureResource(azureCore, "ResourceGroupPolicyAssignment")},
 			"azurerm_resource_group_policy_exemption": {
@@ -3785,6 +3787,31 @@ func fixEnumCase(pm resource.PropertyMap, fieldName string, allowedValues ...str
 
 func fixHdInsightTier(_ context.Context, pm resource.PropertyMap) (resource.PropertyMap, error) {
 	fixEnumCase(pm, "tier", "Standard", "Premium")
+	return pm, nil
+}
+
+// clearMetaSchemaVersion strips schema_version from the __meta blob so v5 state with a
+// higher upstream schema version doesn't trip the bridge's state-version-greater-than-schema
+// check. The state then flows through normal upgrade as if it were at schema version 0.
+func clearMetaSchemaVersion(_ context.Context, pm resource.PropertyMap) (resource.PropertyMap, error) {
+	const metaKey = resource.PropertyKey("__meta")
+	metaVal, ok := pm[metaKey]
+	if !ok || !metaVal.IsString() {
+		return pm, nil
+	}
+	var meta map[string]any
+	if err := json.Unmarshal([]byte(metaVal.StringValue()), &meta); err != nil {
+		return pm, nil
+	}
+	if _, hasVersion := meta["schema_version"]; !hasVersion {
+		return pm, nil
+	}
+	delete(meta, "schema_version")
+	encoded, err := json.Marshal(meta)
+	if err != nil {
+		return pm, nil
+	}
+	pm[metaKey] = resource.NewStringProperty(string(encoded))
 	return pm, nil
 }
 

--- a/provider/state_migration_test.go
+++ b/provider/state_migration_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026, Pulumi Corporation.
+
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+func TestClearMetaSchemaVersion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		meta    map[string]any
+		wantHas bool
+		wantKey string
+	}{
+		{
+			name:    "v5 state strips schema_version, preserves other keys",
+			meta:    map[string]any{"schema_version": "1", "timeouts": map[string]any{"create": 600000000000.0}},
+			wantHas: false,
+			wantKey: "timeouts",
+		},
+		{
+			name:    "no schema_version is a no-op",
+			meta:    map[string]any{"timeouts": map[string]any{"create": 600000000000.0}},
+			wantHas: false,
+			wantKey: "timeouts",
+		},
+		{
+			name:    "schema_version 0 is also stripped (any-version strip)",
+			meta:    map[string]any{"schema_version": "0"},
+			wantHas: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			raw, err := json.Marshal(tc.meta)
+			require.NoError(t, err)
+			pm := resource.PropertyMap{
+				"__meta": resource.NewStringProperty(string(raw)),
+			}
+
+			got, err := clearMetaSchemaVersion(context.Background(), pm)
+			require.NoError(t, err)
+
+			var parsed map[string]any
+			require.NoError(t, json.Unmarshal([]byte(got["__meta"].StringValue()), &parsed))
+			_, hasVer := parsed["schema_version"]
+			require.Equal(t, tc.wantHas, hasVer, "schema_version presence")
+			if tc.wantKey != "" {
+				require.Contains(t, parsed, tc.wantKey, "other meta keys preserved")
+			}
+		})
+	}
+}
+
+func TestClearMetaSchemaVersion_NoMeta(t *testing.T) {
+	t.Parallel()
+
+	pm := resource.PropertyMap{
+		"otherField": resource.NewStringProperty("unchanged"),
+	}
+	got, err := clearMetaSchemaVersion(context.Background(), pm)
+	require.NoError(t, err)
+	require.Equal(t, pm, got)
+}
+
+func TestClearMetaSchemaVersion_NonStringMeta(t *testing.T) {
+	t.Parallel()
+
+	pm := resource.PropertyMap{
+		"__meta": resource.NewNumberProperty(42),
+	}
+	got, err := clearMetaSchemaVersion(context.Background(), pm)
+	require.NoError(t, err)
+	require.Equal(t, pm, got)
+}
+
+func TestClearMetaSchemaVersion_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	pm := resource.PropertyMap{
+		"__meta": resource.NewStringProperty("not valid json"),
+	}
+	got, err := clearMetaSchemaVersion(context.Background(), pm)
+	require.NoError(t, err)
+	require.Equal(t, pm, got)
+}


### PR DESCRIPTION
The legacy upstream `azurerm_template_deployment` was at `SchemaVersion: 1`; the v6 replacement `azurerm_resource_group_template_deployment` (aliased from the v5 Pulumi token `azure:core/templateDeployment:TemplateDeployment`) has no `SchemaVersion` set, so it defaults to 0. The bridge's state-version-greater-than-schema check rejects v5 state with:

```
State version 1 is greater than schema version 0 for resource azurerm_resource_group_template_deployment. Please upgrade the provider to work with this resource.
```

Adds a `TransformFromState` that strips `schema_version` from the `__meta` blob so upgrade flow proceeds as if state were at schema version 0.

Fixes #3292.

I've verified this fixes v5 -> v6 upgrades with a local repro.