### PR TITLE
Fix stale Go codegen pattern in getFrontdoorBatchRuleSet.go

### DIFF
--- a/sdk/go/azure/cdn/getFrontdoorBatchRuleSet.go
+++ b/sdk/go/azure/cdn/getFrontdoorBatchRuleSet.go
@@ -84,12 +84,8 @@ type LookupFrontdoorBatchRuleSetResult struct {
 }
 
 func LookupFrontdoorBatchRuleSetOutput(ctx *pulumi.Context, args LookupFrontdoorBatchRuleSetOutputArgs, opts ...pulumi.InvokeOption) LookupFrontdoorBatchRuleSetResultOutput {
-	return pulumi.ToOutputWithContext(ctx.Context(), args).
-		ApplyT(func(v interface{}) (LookupFrontdoorBatchRuleSetResultOutput, error) {
-			args := v.(LookupFrontdoorBatchRuleSetArgs)
-			options := pulumi.InvokeOutputOptions{InvokeOptions: internal.PkgInvokeDefaultOpts(opts)}
-			return ctx.InvokeOutput("azure:cdn/getFrontdoorBatchRuleSet:getFrontdoorBatchRuleSet", args, LookupFrontdoorBatchRuleSetResultOutput{}, options).(LookupFrontdoorBatchRuleSetResultOutput), nil
-		}).(LookupFrontdoorBatchRuleSetResultOutput)
+	options := pulumi.InvokeOutputOptions{InvokeOptions: internal.PkgInvokeDefaultOpts(opts)}
+	return ctx.InvokeOutput("azure:cdn/getFrontdoorBatchRuleSet:getFrontdoorBatchRuleSet", args, LookupFrontdoorBatchRuleSetResultOutput{}, options).(LookupFrontdoorBatchRuleSetResultOutput)
 }
 
 // A collection of arguments for invoking getFrontdoorBatchRuleSet.


### PR DESCRIPTION
## Summary
- Fixes the `build_sdk (go)` CI failure on master: https://github.com/pulumi/pulumi-azure/actions/runs/33179321848/job/98893626852
- `sdk/go/azure/cdn/getFrontdoorBatchRuleSet.go` (added in #3627) was generated with an older Go SDK codegen pattern (`pulumi.ToOutputWithContext(args).ApplyT(...)` wrapping an `InvokeOutput` call) that predates [pulumi/pulumi#24060](https://github.com/pulumi/pulumi/pull/24060), which changed output-form invokes to call `ctx.InvokeOutput` directly.
- The rest of the SDK was already generated with the new pattern, so a fresh `make build_go` (using the pinned `pulumi/pulumi v3.259.0` in `provider/go.mod`) only touches this one file — confirmed by rebuilding `bin/pulumi-tfgen-azure` from a clean state and diffing against master, which reproduces the exact CI diff.

## Test plan
- [x] Rebuilt `bin/pulumi-tfgen-azure` from `provider/go.mod` (pulumi/pulumi v3.259.0) and regenerated `sdk/go/` — the only diff produced is this file, matching CI's reported diff exactly.
- [ ] CI (`build_sdk` / `Check worktree clean`)